### PR TITLE
Switch visualizers to PyQtGraph

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,5 @@ Werkzeug
 xlrd
 zeep
 zipp
+pyqtgraph
 

--- a/rx_freq_visualizer.py
+++ b/rx_freq_visualizer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import numpy as np
-import matplotlib.pyplot as plt
+from pyqtgraph.Qt import QtCore
+import pyqtgraph as pg
 import argparse
 
 def main():
@@ -28,6 +29,11 @@ def main():
     if args.samples is not None:
         rx = rx[:args.samples]
 
+    # Zu große Datenmengen reduzieren (mehr als 1 MB)
+    if rx.nbytes > 1_000_000:
+        step = int(np.ceil(rx.nbytes / 1_000_000))
+        rx = rx[::step]
+
     N = rx.size
 
     # FFT und zentrieren
@@ -43,15 +49,18 @@ def main():
         freqs = np.fft.fftshift(np.fft.fftfreq(N))
         xlabel = "Normierte Frequenz"
 
-    # Plot
-    plt.figure()
-    plt.plot(freqs,mag)
-    plt.title(f"Frequenzspektrum: {args.filename}")
-    plt.xlabel(xlabel)
-    plt.ylabel("Magnitude (dB)")
-    plt.grid(True)
-    plt.tight_layout()
-    plt.show()
+    # Plot mit PyQtGraph
+    pg.setConfigOption('background', 'w')
+    pg.setConfigOption('foreground', 'k')
+
+    app = pg.mkQApp()
+    win = pg.plot(freqs, mag, pen='b', title=f"Frequenzspektrum: {args.filename}")
+    win.setWindowTitle(args.filename)
+    win.showGrid(x=True, y=True)
+    win.setLabel('bottom', xlabel)
+    win.setLabel('left', 'Magnitude (dB)')
+
+    pg.exec()
 
 if __name__ == "__main__":
     main()

--- a/rx_multi_visualizer.py
+++ b/rx_multi_visualizer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import numpy as np
-import matplotlib.pyplot as plt
+from pyqtgraph.Qt import QtCore
+import pyqtgraph as pg
 import argparse
 import itertools
 
@@ -29,6 +30,11 @@ def main():
     if args.samples is not None:
         data = data[:args.samples, :]
 
+    # Zu große Datenmengen reduzieren (mehr als 1 MB)
+    if data.nbytes > 1_000_000:
+        step = int(np.ceil(data.nbytes / 1_000_000))
+        data = data[::step, :]
+
     # --- Komplexe Arrays je Kanal bilden ------------------------------------
     sigs = []
     for k in range(ch):
@@ -36,26 +42,28 @@ def main():
         Q = data[:, 2*k + 1]
         sigs.append(I + 1j*Q)
 
-    # --- Plot ---------------------------------------------------------------
-    fig, axes = plt.subplots(ch, 1, sharex=True,
-                             figsize=(10, 2.5*ch), squeeze=False)
-    fig.canvas.manager.set_window_title(args.filename)
+    # --- Plot mit PyQtGraph -------------------------------------------------
+    pg.setConfigOption('background', 'w')
+    pg.setConfigOption('foreground', 'k')
 
-    colours = itertools.cycle(("tab:blue", "tab:orange",
-                               "tab:green", "tab:red"))
+    app = pg.mkQApp()
+    win = pg.GraphicsLayoutWidget(title="RX Waveforms (komplex)")
+    win.setWindowTitle(args.filename)
 
-    for idx, (ax, sig, color) in enumerate(zip(axes.flat, sigs, colours)):
-        ax.plot(np.real(sig), label=f"Ch {idx} I", color=color, lw=0.7)
-        ax.plot(np.imag(sig), label=f"Ch {idx} Q",
-                color=color, ls="--", lw=0.7)
-        ax.set_ylabel("Amplitude")
-        ax.grid(True)
-        ax.legend(loc="upper right")
+    colours = itertools.cycle(('b', 'r', 'g', 'm'))
 
-    axes[-1, 0].set_xlabel("Sample Index")
-    fig.suptitle("RX Waveforms (komplex)")
-    plt.tight_layout()
-    plt.show()
+    for idx, (sig, color) in enumerate(zip(sigs, colours)):
+        p = win.addPlot(row=idx, col=0)
+        p.showGrid(x=True, y=True)
+        p.addLegend()
+        p.plot(np.real(sig), pen=pg.mkPen(color), name=f"Ch {idx} I")
+        p.plot(np.imag(sig), pen=pg.mkPen(color, style=QtCore.Qt.DashLine),
+               name=f"Ch {idx} Q")
+        p.setLabel('left', 'Amplitude')
+        if idx == ch - 1:
+            p.setLabel('bottom', 'Sample Index')
+
+    pg.exec()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- migrate visualizer scripts from matplotlib to pyqtgraph
- ensure signals larger than 1MB are downsampled before plotting
- keep white background and allow interactive zooming
- update requirements

## Testing
- `python3 -m py_compile rx_visualizer.py rx_freq_visualizer.py rx_multi_visualizer.py`

------
https://chatgpt.com/codex/tasks/task_e_684c68007534832b8d6556b892b33dee