### PR TITLE
Fix default channel list for RX script

### DIFF
--- a/rx_to_file.py
+++ b/rx_to_file.py
@@ -36,7 +36,7 @@ def parse_args():
     parser.add_argument("-f", "--freq", type=float, required=True)
     parser.add_argument("-r", "--rate", default=1e6, type=float)
     parser.add_argument("-d", "--duration", default=5.0, type=float)
-    parser.add_argument("-c", "--channels", default=0, nargs="+", type=int)
+    parser.add_argument("-c", "--channels", default=[0], nargs="+", type=int)
     parser.add_argument("-g", "--gain", type=int, default=10)
     parser.add_argument(
         "-n",


### PR DESCRIPTION
## Summary
- ensure `--channels` defaults to `[0]` in `rx_to_file.py` so it is iterable

## Testing
- `python3 -m py_compile rx_to_file.py transceiver_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_684c713695a8832ba500395038e196bb