### PR TITLE
Fix initialization order in UI

### DIFF
--- a/transceiver_ui.py
+++ b/transceiver_ui.py
@@ -476,7 +476,6 @@ class TransceiverUI(tk.Tk):
         self.latest_data = None
         self.latest_fs = 0.0
 
-        self.update_waveform_fields()
 
         # ----- Presets -----
         preset_frame = ttk.LabelFrame(self, text="Presets")
@@ -595,6 +594,7 @@ class TransceiverUI(tk.Tk):
         )
         rx_frame.rowconfigure(9, weight=1)
         self.rx_canvases = []
+        self.update_waveform_fields()
         self.auto_update_tx_filename()
         self.auto_update_rx_filename()
 


### PR DESCRIPTION
## Summary
- ensure waveform fields are updated after all widgets exist

## Testing
- `python -m py_compile transceiver_ui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7821da50832bbf8658e0fed04fd2