### PR TITLE
Set default generation frequency to 25e3

### DIFF
--- a/transceiver_ui.py
+++ b/transceiver_ui.py
@@ -414,7 +414,7 @@ class TransceiverUI(tk.Tk):
         self.f_label = ttk.Label(gen_frame, text="f")
         self.f_label.grid(row=2, column=0, sticky="w")
         self.f_entry = SuggestEntry(gen_frame, "f_entry")
-        self.f_entry.insert(0, "1e6")
+        self.f_entry.insert(0, "25e3")
         self.f_entry.grid(row=2, column=1, sticky="ew")
         self.f_entry.entry.bind("<FocusOut>", lambda _e: self.auto_update_tx_filename())
 


### PR DESCRIPTION
## Summary
- change the frequency entry's initial value in the GUI to `25e3`

## Testing
- `python3 -m py_compile transceiver_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_684c79a0d6ac832b99a3294455124f2f