### PR TITLE
Fix FFT bandwidth scaling

### DIFF
--- a/transceiver/helpers/rx_freq_visualizer.py
+++ b/transceiver/helpers/rx_freq_visualizer.py
@@ -30,6 +30,7 @@ def main():
         rx = rx[:args.samples]
 
     # Zu große Datenmengen reduzieren (mehr als 1 MB)
+    step = 1
     if rx.nbytes > 1_000_000:
         step = int(np.ceil(rx.nbytes / 1_000_000))
         rx = rx[::step]
@@ -42,7 +43,7 @@ def main():
 
     # Frequenzachse
     if args.rate:
-        fs = args.rate
+        fs = args.rate / step
         freqs = np.fft.fftshift(np.fft.fftfreq(N, d=1/fs))
         xlabel = "Frequenz (Hz)"
     else:


### PR DESCRIPTION
## Summary
- fix scaling of frequency axis after data reduction
- adjust visualizer helper to account for decimation factor

## Testing
- `python -m py_compile transceiver/__main__.py transceiver/helpers/rx_freq_visualizer.py`

------
https://chatgpt.com/codex/tasks/task_e_685e9cdcec00832ba797fcb6692a12bc