### PR TITLE
Fix oversample bug in waveform generator

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1318,7 +1318,7 @@ class TransceiverUI(tk.Tk):
                     0.0,
                     samples,
                     q=q,
-                    oversample=osf,
+                    oversample_factor=osf,
                     oversample_method=method,
                 )
             else:  # chirp

--- a/transceiver/helpers/tx_generator.py
+++ b/transceiver/helpers/tx_generator.py
@@ -148,12 +148,12 @@ def generate_waveform(
     q: int = 1,
     f0: Optional[float] = None,
     f1: Optional[float] = None,
-    oversample: int = 1,
+    oversample_factor: int = 1,
     oversample_method: str = "fft",
 ) -> np.ndarray:
     """Erzeugt komplexe Samples einer der unterstützten Wellenformen.
 
-    Mit ``oversample`` kann eine Überabtastung angegeben werden. ``oversample``
+    Mit ``oversample_factor`` kann eine Überabtastung angegeben werden. ``oversample_factor``
     muss dabei ein ganzzahliger Faktor sein. Die Methode ``oversample_method``
     bestimmt, ob per FFT-Zero‑Padding (``"fft"``) oder mittels Sinc‑Filter
     (``"filter"``) interpoliert wird.
@@ -194,7 +194,7 @@ def generate_waveform(
         raise ValueError(f"Unbekannte Wellenform: {waveform}")
 
     signal = signal.astype(np.complex64)
-    return oversample(signal, oversample, oversample_method)
+    return oversample(signal, oversample_factor, oversample_method)
 
 
 # ---------- Hauptprogramm ----------------------------------------------------
@@ -343,7 +343,7 @@ def main() -> None:
         args.q,
         f0=args.f0,
         f1=args.f1,
-        oversample=args.oversample,
+        oversample_factor=args.oversample,
         oversample_method=args.method,
     )
 


### PR DESCRIPTION
## Summary
- rename the oversample parameter in `generate_waveform` to avoid name clash
- update UI and CLI code accordingly

## Testing
- `python -m transceiver.helpers.tx_generator signals/test.bin --waveform sinus --fs 1e6 --f 1e3 --samples 1000 --no-zeros`
- `pytest` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_685ea7e3f910832b9933e7aefe64429e