### PR TITLE
Fix oversampling sample count

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -10,6 +10,7 @@ import time
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
 import json
+import math
 from pathlib import Path
 from datetime import datetime
 
@@ -1327,15 +1328,18 @@ class TransceiverUI(tk.Tk):
                 q = int(self.q_entry.get()) if self.q_entry.get() else 1
                 osf = int(self.os_entry.get()) if self.os_entry.get() else 1
                 method = self.os_method.get()
+                base_samples = math.ceil(samples / osf) if osf > 1 else samples
                 data = generate_waveform(
                     waveform,
                     fs,
                     0.0,
-                    samples,
+                    base_samples,
                     q=q,
                     oversample_factor=osf,
                     oversample_method=method,
                 )
+                if osf > 1:
+                    data = data[:samples]
             else:  # chirp
                 f0 = float(eval(self.f_entry.get())) if self.f_entry.get() else 0.0
                 f1 = float(eval(self.f1_entry.get())) if self.f1_entry.get() else None

--- a/transceiver/helpers/tx_generator.py
+++ b/transceiver/helpers/tx_generator.py
@@ -250,7 +250,7 @@ def main() -> None:
         "--oversample",
         type=int,
         default=1,
-        help="Überabtastungsfaktor für Zadoff‑Chu (Standard: 1)",
+        help="Überabtastungsfaktor für Zadoff‑Chu; Ausgabe behält Länge --samples (Standard: 1)",
     )
     parser.add_argument(
         "--method",
@@ -308,7 +308,8 @@ def main() -> None:
     if args.waveform == "chirp" and args.f1 is None:
         args.f1 = args.fs / 2 - 1  # Maximal fast bis Nyquist
 
-    N_waveform = args.samples
+    N_output = args.samples
+    N_waveform = math.ceil(N_output / args.oversample)
 
     # Blockgröße ggf. an Primzahl anpassen (nur ZC)
     if args.waveform == "zadoffchu":
@@ -322,12 +323,12 @@ def main() -> None:
     # ------------------------------------------------------------------
     if append_zeros:
         print(
-            f"Erzeuge {N_waveform} Samples {args.waveform} + {N_waveform} Null‑Samples "
+            f"Erzeuge {N_output} Samples {args.waveform} + {N_output} Null-Samples "
             f"(Oversample {args.oversample}×)."
         )
     else:
         print(
-            f"Erzeuge {N_waveform} Samples {args.waveform} (ohne Null‑Samples, "
+            f"Erzeuge {N_output} Samples {args.waveform} (ohne Null-Samples, "
             f"Oversample {args.oversample}×)."
         )
 
@@ -346,6 +347,9 @@ def main() -> None:
         oversample_factor=args.oversample,
         oversample_method=args.method,
     )
+
+    if args.oversample > 1:
+        waveform_signal = waveform_signal[:N_output]
 
     oversampled_len = len(waveform_signal)
     if append_zeros:


### PR DESCRIPTION
## Summary
- keep total number of samples constant when oversampling
- update CLI help text

## Testing
- `python3 -m transceiver.helpers.tx_generator --help | head -n 20`
- `python3 -m transceiver.helpers.tx_generator --waveform zadoffchu --samples 1000 --oversample 4 test.bin --no-zeros | tail -n 4`

------
https://chatgpt.com/codex/tasks/task_e_685eab0341fc832ba2520bdeb70913c3