### PR TITLE
Show RX signal stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ The helper modules can also be executed individually, e.g.
 python -m transceiver.helpers.rx_to_file --help
 ```
 
+The GUI shows basic signal statistics (minimum/maximum frequency, maximum
+amplitude and 3\ dB bandwidth) for both the generated and the received
+signals.
+

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -315,6 +315,16 @@ def _calc_stats(data: np.ndarray, fs: float) -> dict:
     return stats
 
 
+def _format_stats_text(stats: dict) -> str:
+    """Return a formatted multi-line string for signal statistics."""
+    return (
+        f"fmin: {_format_hz(stats['f_low'])}\n"
+        f"fmax: {_format_hz(stats['f_high'])}\n"
+        f"max Amp: {stats['amp']:.1f}\n"
+        f"BW (3dB): {_format_hz(stats['bw'])}"
+    )
+
+
 def visualize(data: np.ndarray, fs: float, mode: str, title: str, ref_data: np.ndarray | None = None) -> None:
     """Visualize *data* using PyQtGraph."""
     if data.size == 0:
@@ -892,12 +902,7 @@ class TransceiverUI(tk.Tk):
             self.gen_canvases.append(canvas)
 
         stats = _calc_stats(data, fs)
-        text = (
-            f"fmin: {_format_hz(stats['f_low'])}\n"
-            f"fmax: {_format_hz(stats['f_high'])}\n"
-            f"max Amp: {stats['amp']:.1f}\n"
-            f"BW (3dB): {_format_hz(stats['bw'])}"
-        )
+        text = _format_stats_text(stats)
         if not hasattr(self, 'gen_stats_label'):
             self.gen_stats_label = ttk.Label(
                 self.gen_plots_frame,
@@ -941,12 +946,7 @@ class TransceiverUI(tk.Tk):
             self.rx_canvases.append(canvas)
 
         stats = _calc_stats(data, fs)
-        text = (
-            f"fmin: {_format_hz(stats['f_low'])}\n"
-            f"fmax: {_format_hz(stats['f_high'])}\n"
-            f"max Amp: {stats['amp']:.1f}\n"
-            f"BW (3dB): {_format_hz(stats['bw'])}"
-        )
+        text = _format_stats_text(stats)
         if not hasattr(self, 'rx_stats_label'):
             self.rx_stats_label = ttk.Label(
                 self.rx_plots_frame,


### PR DESCRIPTION
## Summary
- extract common stats display code into `_format_stats_text`
- use it for both generation and receive plots
- document that the GUI now shows stats for RX signals

## Testing
- `python -m py_compile transceiver/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_68653429bf68832b9d2c82a0703ca410