### PR TITLE
Fix RX stats label visibility

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -909,7 +909,7 @@ class TransceiverUI(tk.Tk):
                 justify='left',
                 anchor='w'
             )
-            self.gen_stats_label.grid(row=len(modes), column=0, sticky='ew', pady=2)
+        self.gen_stats_label.grid(row=len(modes), column=0, sticky='ew', pady=2)
         self.gen_stats_label.configure(text=text)
 
     def _display_rx_plots(self, data: np.ndarray, fs: float) -> None:
@@ -953,7 +953,7 @@ class TransceiverUI(tk.Tk):
                 justify='left',
                 anchor='w'
             )
-            self.rx_stats_label.grid(row=len(modes), column=0, sticky='ew', pady=2)
+        self.rx_stats_label.grid(row=len(modes), column=0, sticky='ew', pady=2)
         self.rx_stats_label.configure(text=text)
 
         # ----- Trim button -----


### PR DESCRIPTION
## Summary
- keep grid() call outside conditional for TX/RX stat labels so they reappear after refresh

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686536cd762c832b8cb9265d6edf8916