### PR TITLE
Fix retransmit failure by waiting for process termination

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1487,6 +1487,8 @@ class TransceiverUI(tk.Tk):
         if self._proc:
             try:
                 self._proc.terminate()
+                self._proc.wait(timeout=5)
+                self._proc = None
             except Exception:
                 pass
         self._stop_requested = True
@@ -1509,6 +1511,8 @@ class TransceiverUI(tk.Tk):
         if self._proc:
             try:
                 self._proc.terminate()
+                self._proc.wait(timeout=5)
+                self._proc = None
             except Exception:
                 pass
         if hasattr(self, "rx_stop"):


### PR DESCRIPTION
## Summary
- ensure stopped RFNoC helper processes are fully terminated before starting new runs

## Testing
- `python -m py_compile transceiver/__main__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653c8fc860832ba63b995b1028c9c2