### PR TITLE
Fix RX conversion scaling

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1186,14 +1186,16 @@ class TransceiverUI(tk.Tk):
                         "transceiver.helpers.rx_convert",
                         out_file,
                         "--to",
-                        "fc32",
+                        "sc16",
                     ],
                     check=True,
                 )
                 conv_file = out_file.replace(".bin", "_conv.bin")
-                data = np.fromfile(conv_file, dtype=np.complex64)
-                amp = float(eval(self.amp_entry.get())) if self.amp_entry.get() else 10000.0
-                data *= amp
+                raw = np.fromfile(conv_file, dtype=np.int16)
+                if raw.size % 2:
+                    raw = raw[:-1]
+                raw = raw.reshape(-1, 2).astype(np.float32)
+                data = raw[:, 0] + 1j * raw[:, 1]
                 self._display_rx_plots(data, float(eval(self.rx_rate.get())))
             except Exception as exc:
                 self._out_queue.put(f"Error: {exc}\n")


### PR DESCRIPTION
## Summary
- convert RX samples to SC16 instead of FC32 when processing in the UI
- load SC16 data properly without extra amplitude scaling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68653d12d4c4832bae3699c9a6254ef7