### PR TITLE
Add autocorrelation preview for generated signals

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -949,7 +949,7 @@ class TransceiverUI(tk.Tk):
             c.get_tk_widget().destroy()
         self.gen_canvases.clear()
 
-        modes = ["Signal", "Freq", "InstantFreq"]
+        modes = ["Signal", "Freq", "InstantFreq", "Autocorr"]
         for idx, mode in enumerate(modes):
             fig = Figure(figsize=(5, 2), dpi=100)
             ax = fig.add_subplot(111)


### PR DESCRIPTION
## Summary
- show an Autocorr preview plot in the generation column

## Testing
- `python -m py_compile transceiver/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_686548491958832b966dbe34e5980dc0