### PR TITLE
Improve USRP reconnect handling

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1137,6 +1137,25 @@ class TransceiverUI(tk.Tk):
         except Exception:
             pass
 
+    def _ping_device(self, arg_str: str) -> None:
+        """Send a single ping to the configured device address."""
+        addr = None
+        for part in arg_str.split(','):
+            if part.strip().startswith('addr='):
+                addr = part.split('=', 1)[1].strip()
+                break
+        if not addr:
+            return
+        try:
+            subprocess.run(
+                ["ping", "-c", "1", addr],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=2,
+            )
+        except Exception:
+            pass
+
     def _run_cmd(
         self,
         cmd: list[str],
@@ -1156,7 +1175,9 @@ class TransceiverUI(tk.Tk):
                         bufsize=1,
                     )
                     self._proc = proc
+                    output_lines = []
                     for line in proc.stdout:
+                        output_lines.append(line)
                         self._out_queue.put(line)
                     proc.wait()
                     self._out_queue.put(
@@ -1165,8 +1186,13 @@ class TransceiverUI(tk.Tk):
                 except Exception as exc:
                     self._out_queue.put(f"Error: {exc}\n")
                     proc = None
+                    output_lines = []
                 finally:
                     self._proc = None
+
+                # If the device was not found, try pinging the target once
+                if output_lines and any("No devices found" in l for l in output_lines):
+                    self._ping_device(self.tx_args.get())
 
                 if self._stop_requested or (
                     proc is not None and proc.returncode == 0


### PR DESCRIPTION
## Summary
- ping USRP IP if `rfnoc_replay_samples_from_file` cannot find a device

## Testing
- `python -m py_compile transceiver/__main__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654c15db48832b8105dfa9fb33d408