### PR TITLE
Fix compare window behavior

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -333,6 +333,7 @@ class SignalColumn(ttk.Frame):
             title="Open Signal",
             filetypes=[("Binary files", "*.bin"), ("All files", "*.*")],
             initialdir="signals/rx",
+            parent=self,
         )
         if not filename:
             return
@@ -352,6 +353,7 @@ class SignalColumn(ttk.Frame):
                     "Sample Rate",
                     "Sample rate [Hz]",
                     initialvalue=self.main_parent.rx_rate.get(),
+                    parent=self,
                 )
             )
         except Exception:
@@ -403,6 +405,13 @@ class CompareWindow(tk.Toplevel):
         super().__init__(parent)
         self.parent = parent
         self.title("Compare Signals")
+        try:
+            self.state("zoomed")
+        except Exception:
+            try:
+                self.attributes("-zoomed", True)
+            except Exception:
+                pass
         for i in range(4):
             self.columnconfigure(i, weight=1)
         self.rowconfigure(0, weight=1)


### PR DESCRIPTION
## Summary
- maximize the compare window when opening
- open dialogs over the compare window

## Testing
- `python -m py_compile transceiver/__main__.py`

------
https://chatgpt.com/codex/tasks/task_e_6877b4e93088832bbdb53d971774f84a