### PR TITLE
Fix oversampling output length for Zadoff-Chu

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -2005,11 +2005,23 @@ class TransceiverUI(tk.Tk):
                 q = int(self.q_entry.get()) if self.q_entry.get() else 1
                 beta = float(self.rrc_beta_entry.get()) if self.rrc_beta_entry.get() else 0.25
                 span = int(self.rrc_span_entry.get()) if self.rrc_span_entry.get() else 6
+
+                if oversampling > 1:
+                    if samples % oversampling != 0:
+                        messagebox.showerror(
+                            "Generate error",
+                            "Samples muss durch Oversampling teilbar sein",
+                        )
+                        return
+                    base_samples = samples // oversampling
+                else:
+                    base_samples = samples
+
                 data = generate_waveform(
                     waveform,
                     fs,
                     0.0,
-                    samples,
+                    base_samples,
                     q=q,
                     rrc_beta=beta,
                     rrc_span=span,

--- a/transceiver/helpers/tx_generator.py
+++ b/transceiver/helpers/tx_generator.py
@@ -305,15 +305,21 @@ def main() -> None:
         args.f1 = args.fs / 2 - 1  # Maximal fast bis Nyquist
 
     N_waveform = args.samples
-    N_output = N_waveform * args.oversampling
+    N_output = N_waveform
 
     # Blockgröße ggf. an Primzahl anpassen (nur ZC)
     if args.waveform == "zadoffchu":
-        prime = find_prime_near(N_waveform, search_up=True)
-        if prime != N_waveform:
-            print(f"Info: samples={N_waveform} angepasst auf Primzahl {prime} für ZC.")
-            N_waveform = prime
-        N_output = N_waveform * args.oversampling
+        if args.oversampling > 1:
+            if args.samples % args.oversampling != 0:
+                raise ValueError("samples muss ein Vielfaches von oversampling sein")
+            N_waveform = args.samples // args.oversampling
+            N_output = args.samples
+        else:
+            prime = find_prime_near(N_waveform, search_up=True)
+            if prime != N_waveform:
+                print(f"Info: samples={N_waveform} angepasst auf Primzahl {prime} für ZC.")
+                N_waveform = prime
+            N_output = N_waveform
 
     append_zeros = not args.no_zeros
 


### PR DESCRIPTION
## Summary
- keep requested sample count when oversampling Zadoff-Chu signals
- adjust GUI generator accordingly

## Testing
- `python -m py_compile transceiver/helpers/tx_generator.py transceiver/__main__.py`

------
https://chatgpt.com/codex/tasks/task_e_687a4de78820832b90de6f2b015a5116