### PR TITLE
Fix equal column width in UI

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1075,9 +1075,9 @@ class TransceiverUI(tk.Tk):
 
     def create_widgets(self):
         self.rowconfigure(0, weight=1)
-        self.columnconfigure(0, weight=1)
-        self.columnconfigure(1, weight=1)
-        self.columnconfigure(2, weight=1)
+        self.columnconfigure(0, weight=1, uniform="cols")
+        self.columnconfigure(1, weight=1, uniform="cols")
+        self.columnconfigure(2, weight=1, uniform="cols")
 
         # ----- Column 1: Generation -----
         gen_frame = ttk.LabelFrame(self, text="Signal Generation")


### PR DESCRIPTION
## Summary
- ensure the three main columns in `transceiver` grid layout have the same width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a5167249c832b8a54f5bc68244f0f