### PR TITLE
Fix oversampled filename lengths

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -812,7 +812,10 @@ def _gen_tx_filename(app) -> str:
         parts.append(f"{_pretty(f0)}_{_pretty(f1)}")
 
     parts.append(f"fs{_pretty(fs)}")
-    parts.append(f"N{samples * oversampling}")
+    # ``samples`` already represents the number of output samples. Using
+    # ``samples * oversampling`` would misrepresent the actual length when
+    # oversampling is enabled.
+    parts.append(f"N{samples}")
     stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     name = "_".join(parts) + f"_{stamp}.bin"
     return str(Path("signals/tx") / name)

--- a/transceiver/helpers/tx_generator.py
+++ b/transceiver/helpers/tx_generator.py
@@ -89,7 +89,9 @@ def generate_filename(args) -> Path:
             parts.append(f"os{args.oversampling}")
     elif args.waveform == "chirp":
         parts.append(f"{_pretty(args.f0)}_{_pretty(args.f1)}")
-    parts.append(f"N{args.samples * getattr(args, 'oversampling', 1)}")
+    # The filename should reflect the actual output length which equals
+    # ``args.samples`` even when oversampling is enabled.
+    parts.append(f"N{args.samples}")
     stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     name = "_".join(parts) + f"_{stamp}.bin"
     return Path(args.output_dir) / name


### PR DESCRIPTION
## Summary
- adjust filename generation to reflect real sample count when oversampling

## Testing
- `python -m py_compile transceiver/helpers/tx_generator.py transceiver/__main__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a524903dc832bb391bc64d347714b