### PR TITLE
Implement RX-side oversampling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ The GUI shows basic signal statistics (minimum/maximum frequency, maximum
 amplitude and 3\ dB bandwidth) for both the generated and the received
 signals.
 
+The receive view now also offers optional oversampling which can be applied
+after capturing the data.  This improves the accuracy of the channel impulse
+response when using the built‑in cross‑correlation tools.
+


### PR DESCRIPTION
## Summary
- add post-processing oversampling option to improve cross‑correlation
- expose oversampling controls in the RX panel
- regenerate RX filenames when oversampling is active
- mention new feature in README

## Testing
- `python -m py_compile transceiver/__main__.py`
- `black transceiver/__main__.py`

------
https://chatgpt.com/codex/tasks/task_e_688a2eb67db8832ba5dc0a44c6f97731