### PR TITLE
Resize open signal dialog and sort newest first

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -424,6 +424,10 @@ class OpenSignalDialog(tk.Toplevel):
         ttk.Button(btn_frame, text="Cancel", command=self.destroy).pack(side="left", padx=5)
 
         self._populate()
+        self._sort("mtime", True)
+        self.update_idletasks()
+        w, h = self.winfo_width(), self.winfo_height()
+        self.geometry(f"{w * 2}x{h * 2}")
         self.tree.bind("<Double-1>", lambda _e: self._on_open())
         self.grab_set()
         self.transient(parent)


### PR DESCRIPTION
## Summary
- enlarge the Open Signal dialog window to double its size when opened
- default to sorting by most recently modified signal files

## Testing
- `python -m pytest`
- `python -m py_compile transceiver/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7b271e6e8832bb015f5d20f18f778