### PR TITLE
Show waypoint arrows with heading in mission workflow map

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -89,6 +89,41 @@ def test_extract_lidar_ranges_from_scan_text_supports_list_style() -> None:
     assert values[2] == 3.4
 
 
+def test_build_waypoint_arrow_polygon_points_to_positive_x_for_zero_yaw() -> None:
+    points = MissionWorkflowWindow._build_waypoint_arrow_polygon(
+        center_x=100.0,
+        center_y=50.0,
+        yaw_radians=0.0,
+        arrow_length=10.0,
+        tail_length=4.0,
+        tail_width=8.0,
+    )
+
+    tip_x, tip_y, left_x, left_y, right_x, right_y = points
+    assert (tip_x, tip_y) == (110.0, 50.0)
+    assert (left_x, left_y) == (96.0, 54.0)
+    assert (right_x, right_y) == (96.0, 46.0)
+
+
+def test_build_waypoint_arrow_polygon_points_up_for_ninety_degree_yaw() -> None:
+    points = MissionWorkflowWindow._build_waypoint_arrow_polygon(
+        center_x=100.0,
+        center_y=50.0,
+        yaw_radians=1.5707963267948966,
+        arrow_length=10.0,
+        tail_length=4.0,
+        tail_width=8.0,
+    )
+
+    tip_x, tip_y, left_x, left_y, right_x, right_y = points
+    assert round(tip_x, 3) == 100.0
+    assert round(tip_y, 3) == 40.0
+    assert round(left_x, 3) == 104.0
+    assert round(left_y, 3) == 54.0
+    assert round(right_x, 3) == 96.0
+    assert round(right_y, 3) == 54.0
+
+
 class _FakeAdapter:
     def __init__(self, events):
         self.config = object()

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -828,11 +828,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             px, py = pixel_coordinates
             px += offset_x
             py += offset_y
-            marker_id = self.map_preview_canvas.create_oval(
-                px - 4,
-                py - 4,
-                px + 4,
-                py + 4,
+            marker_points = self._build_waypoint_arrow_polygon(
+                center_x=px,
+                center_y=py,
+                yaw_radians=float(point.yaw),
+                arrow_length=10.0,
+                tail_length=4.0,
+                tail_width=8.0,
+            )
+            marker_id = self.map_preview_canvas.create_polygon(
+                marker_points,
                 fill="#00d26a",
                 outline="#0d1016",
                 width=1,
@@ -840,6 +845,32 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._map_marker_ids.append(marker_id)
             if index == self._selected_point_index:
                 self._highlight_marker(marker_id)
+
+    @staticmethod
+    def _build_waypoint_arrow_polygon(
+        *,
+        center_x: float,
+        center_y: float,
+        yaw_radians: float,
+        arrow_length: float,
+        tail_length: float,
+        tail_width: float,
+    ) -> tuple[float, float, float, float, float, float]:
+        heading_x = math.cos(yaw_radians)
+        heading_y = -math.sin(yaw_radians)
+        perpendicular_x = math.sin(yaw_radians)
+        perpendicular_y = math.cos(yaw_radians)
+
+        tip_x = center_x + heading_x * arrow_length
+        tip_y = center_y + heading_y * arrow_length
+        tail_center_x = center_x - heading_x * tail_length
+        tail_center_y = center_y - heading_y * tail_length
+        half_width = tail_width / 2.0
+        left_x = tail_center_x + perpendicular_x * half_width
+        left_y = tail_center_y + perpendicular_y * half_width
+        right_x = tail_center_x - perpendicular_x * half_width
+        right_y = tail_center_y - perpendicular_y * half_width
+        return (tip_x, tip_y, left_x, left_y, right_x, right_y)
 
     def _world_to_preview_pixel(
         self,


### PR DESCRIPTION
### Motivation

- Wegpunkte im Mission-Workflow sollen statt als Punkte als kleine Pfeile dargestellt werden, damit neben der Position auch die Ausrichtung (Yaw) sichtbar ist.
- Die bestehende Farbcodierung und das Selektions-Highlight der Wegpunkte sollen unverändert bleiben.

### Description

- Replaced circular waypoint markers in `transceiver/mission_workflow_ui.py` with small directional arrow polygons computed per-point and drawn via `Canvas.create_polygon` to indicate heading. 
- Added a helper `_build_waypoint_arrow_polygon(...)` that computes arrow tip and tail corner coordinates from `center_x`, `center_y` and `yaw_radians`. 
- Preserved existing color scheme and selection highlighting by reusing the same fill/outline values and `_highlight_marker` behavior. 
- Added unit tests in `tests/test_mission_workflow_ui.py` validating the arrow geometry for 0° and 90° yaw orientations.

### Testing

- Ran `pytest -q tests/test_mission_workflow_ui.py` which initially failed due to module import path (`ModuleNotFoundError`), as expected without `PYTHONPATH` set. 
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` which succeeded with `16 passed`.
- No other automated test failures were observed for the modified test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6513caae08321845d2eb664cbc9c3)