### PR TITLE
Show combined navigation+measurement outcome in results table and add outcome composer

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -70,6 +70,25 @@ def test_compose_table_status_uses_status_when_error_missing() -> None:
     assert MissionWorkflowWindow._compose_table_status("succeeded", "") == "succeeded"
 
 
+def test_compose_table_outcome_returns_succeeded_for_clean_success() -> None:
+    payload = {
+        "navigation": {"state": "succeeded"},
+        "measurement": {"status": "succeeded"},
+    }
+    assert MissionWorkflowWindow._compose_table_outcome(payload, "") == "succeeded"
+
+
+def test_compose_table_outcome_includes_navigation_and_measurement_for_failures() -> None:
+    payload = {
+        "navigation": {"state": "aborted"},
+        "measurement": {"status": "skipped"},
+    }
+    assert (
+        MissionWorkflowWindow._compose_table_outcome(payload, "navigation_failed.aborted")
+        == "navigation aborted, measurement skipped: navigation_failed.aborted"
+    )
+
+
 def test_parse_lidar_scan_text_for_overlay_supports_inline_ranges() -> None:
     parsed = MissionWorkflowWindow._parse_lidar_scan_text_for_overlay(
         "angle_min: -1.57\nangle_increment: 0.1\nranges: [1.0, 2.5, inf, nan]\n"

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -474,7 +474,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         columns = (
             "measurement_idx",
             "idx",
-            "nav",
             "echo_1_m",
             "echo_2_m",
             "echo_3_m",
@@ -487,7 +486,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         headings = {
             "measurement_idx": "Messung",
             "idx": "Punktindex",
-            "nav": "Navigation",
             "echo_1_m": "E1",
             "echo_2_m": "E2",
             "echo_3_m": "E3",
@@ -2316,7 +2314,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _on_record(self, payload: dict[str, Any]) -> None:
         self._records.append(payload)
-        nav = payload.get("navigation", {})
         meas = payload.get("measurement", {})
         result = meas.get("result", {}) if isinstance(meas.get("result"), dict) else {}
         review = result.get("review", {}) if isinstance(result.get("review"), dict) else {}
@@ -2327,7 +2324,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             error_text = f"{error_text} [{review_reason}]" if error_text else review_reason
         if review_detail:
             error_text = f"{error_text}: {review_detail}" if error_text else review_detail
-        combined_status = self._compose_table_status(self._derive_table_status(payload), error_text)
+        combined_status = self._compose_table_outcome(payload, error_text)
         echo_distances = self._format_echo_distances_for_table(result.get("echo_delays"))
         self.results_table.insert(
             "",
@@ -2335,12 +2332,32 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             values=(
                 self._format_one_based_index(payload.get("global_index")),
                 self._format_one_based_index(payload.get("point_index")),
-                nav.get("state", "-"),
                 *echo_distances,
                 combined_status,
             ),
         )
         self._update_live_label()
+
+    @staticmethod
+    def _compose_table_outcome(payload: dict[str, Any], error_text: str) -> str:
+        nav = payload.get("navigation")
+        nav_state = nav.get("state") if isinstance(nav, dict) else None
+        nav_status = str(nav_state) if isinstance(nav_state, str) and nav_state.strip() else "-"
+        measurement = payload.get("measurement")
+        measurement_state = measurement.get("status") if isinstance(measurement, dict) else None
+        measurement_status = (
+            str(measurement_state)
+            if isinstance(measurement_state, str) and measurement_state.strip()
+            else "-"
+        )
+        if nav_status == "succeeded" and measurement_status == "succeeded" and not error_text.strip():
+            return "succeeded"
+
+        base = f"navigation {nav_status}, measurement {measurement_status}"
+        details = error_text.strip()
+        if details:
+            return f"{base}: {details}"
+        return base
 
     @staticmethod
     def _derive_table_status(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
### Motivation

- Improve how table rows convey both navigation and measurement results by synthesizing a single, human-readable outcome instead of a separate navigation column.

### Description

- Remove the `nav` column from the results `Treeview` and stop inserting a separate navigation state into the table row values.
- Add `MissionWorkflowWindow._compose_table_outcome(payload, error_text)` to combine navigation state, measurement status, and optional error/review details into a single outcome string that returns `succeeded` for a clean success or `navigation <state>, measurement <status>[: <details>]` for other cases.
- Update `_on_record` to use ` _compose_table_outcome` when computing the `combined_status` for table insertion.
- Add unit tests `test_compose_table_outcome_returns_succeeded_for_clean_success` and `test_compose_table_outcome_includes_navigation_and_measurement_for_failures` to validate the new behavior.

### Testing

- Ran the updated unit tests in `tests/test_mission_workflow_ui.py`, including the two new `test_compose_table_outcome_*` tests, and they passed.
- Ran the test file's existing tests to ensure no regressions in table formatting and parsing utilities, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d656e468808321a28866da68e56ea3)