### PR TITLE
Persistente "Manuelle Prüfung" Checkbox im Mission-Workflow

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -281,3 +281,27 @@ def test_on_map_canvas_release_creates_waypoint_and_disables_pick_mode() -> None
 
     assert add_calls == [(4.0, -3.0, 1.2)]
     assert mode_calls == [False]
+
+
+def test_review_measurement_auto_approves_when_manual_review_disabled() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.manual_review_enabled_var = SimpleNamespace(get=lambda: False)
+
+    review_result = window._review_measurement(
+        point_context=SimpleNamespace(point=SimpleNamespace(id="p1", name=""), global_index=1),
+        output_file="dummy.bin",
+    )
+
+    assert review_result == {"approved": True, "reason": "", "detail": ""}
+
+
+def test_check_run_prerequisites_skips_review_requirements_when_manual_review_disabled() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.manual_review_enabled_var = SimpleNamespace(get=lambda: False)
+    window._mission_points = [MeasurementPoint(id="p1", name="", x=0.0, y=0.0, yaw=0.0, enabled=True)]
+    window._runtime_guard_reasons = lambda: []
+
+    ok, reasons = window._check_run_prerequisites()
+
+    assert ok is True
+    assert reasons == []

--- a/tests/test_mission_workflow_ui_state.py
+++ b/tests/test_mission_workflow_ui_state.py
@@ -114,3 +114,19 @@ def test_save_and_load_json_dict_preserves_lidar_reference_enabled_flag(tmp_path
     loaded = _load_json_dict(state_file)
 
     assert loaded["lidar_reference_enabled"] is False
+
+
+def test_save_and_load_json_dict_preserves_manual_review_enabled_flag(tmp_path) -> None:
+    state_file = tmp_path / "mission-workflow-state.json"
+    payload = {
+        "name": "scan-manual-review-toggle",
+        "repeat": 1,
+        "start_point_index": 0,
+        "manual_review_enabled": False,
+        "points": [{"id": "p001", "x": 0.0, "y": 0.0, "z": 0.0, "yaw": 0.0, "enabled": True}],
+    }
+
+    _save_json_dict(state_file, payload)
+    loaded = _load_json_dict(state_file)
+
+    assert loaded["manual_review_enabled"] is False

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -214,6 +214,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._live_label_ticker_job: str | None = None
         self._live_label_ticker_active = False
         self.lidar_reference_enabled_var = tk.BooleanVar(value=True)
+        self.manual_review_enabled_var = tk.BooleanVar(value=True)
         self.live_pose_stream_enabled_var = tk.BooleanVar(value=False)
         self._live_pose_stream_active = False
 
@@ -454,12 +455,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             variable=self.lidar_reference_enabled_var,
             command=self._persist_workflow_state,
         ).grid(row=3, column=0, columnspan=2, padx=(8, 3), pady=(0, 4), sticky="w")
+        ctk.CTkCheckBox(
+            controls,
+            text="Manuelle Prüfung",
+            variable=self.manual_review_enabled_var,
+            command=self._on_manual_review_toggle_changed,
+        ).grid(row=3, column=2, padx=(8, 3), pady=(0, 4), sticky="w")
         ctk.CTkSwitch(
             controls,
             text="Live-Position aktivieren",
             variable=self.live_pose_stream_enabled_var,
             command=self._on_live_pose_stream_switch_changed,
-        ).grid(row=3, column=2, columnspan=3, padx=(8, 8), pady=(0, 4), sticky="w")
+        ).grid(row=3, column=3, columnspan=2, padx=(8, 8), pady=(0, 4), sticky="w")
 
         self.live_var = tk.StringVar(value="Punkt: - | Navigation: idle | Messung: idle | Verbleibend: - | Live-Status: Karte nicht geladen")
         ctk.CTkLabel(controls, textvariable=self.live_var, anchor="w", justify="left").grid(
@@ -1679,6 +1686,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "map_config_file": self._selected_map_config_file,
             "rx_antenna_global_position": self._serialize_rx_antenna_global_position(),
             "lidar_reference_enabled": bool(self.lidar_reference_enabled_var.get()),
+            "manual_review_enabled": bool(self.manual_review_enabled_var.get()),
             "reverse_point_order": bool(self.reverse_point_order_var.get()),
         }
 
@@ -1757,6 +1765,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             else:
                 self._set_rx_antenna_position(x=rx_position[0], y=rx_position[1], persist=False)
             self.lidar_reference_enabled_var.set(bool(payload.get("lidar_reference_enabled", True)))
+            self.manual_review_enabled_var.set(bool(payload.get("manual_review_enabled", True)))
             self.reverse_point_order_var.set(bool(payload.get("reverse_point_order", False)))
             self._refresh_points_table()
             self._refresh_map_section()
@@ -1989,6 +1998,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._live_label_ticker_job = None
 
     def _review_measurement(self, *, point_context, output_file: str) -> dict[str, object]:  # type: ignore[no-untyped-def]
+        if not bool(self.manual_review_enabled_var.get()):
+            return {
+                "approved": True,
+                "reason": "",
+                "detail": ""
+            }
         point_id = point_context.point.id or point_context.point.name or f"point-{point_context.global_index}"
         point_label = f"Punkt {point_context.global_index} ({point_id})"
         review_fn = getattr(self.master, "review_measurement_for_mission", None)
@@ -2092,16 +2107,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not any(point.enabled for point in self._mission_points):
             reasons.append("Keine aktiven Wegpunkte vorhanden. Bitte mindestens einen Punkt aktivieren.")
         reasons.extend(self._runtime_guard_reasons())
-        review_fn = getattr(self.master, "review_measurement_for_mission", None)
-        if not callable(review_fn):
-            reasons.append(
-                "Review-Funktion ist nicht verfügbar (self.master.review_measurement_for_mission ist nicht callable)."
-            )
-        reference_data = self._get_crosscorr_reference_for_mission()
-        if not self._has_crosscorr_reference_data(reference_data):
-            reasons.append(
-                "TX-Referenzdaten für Crosscorrelation fehlen. Bitte TX laden (gleiche Quelle wie _get_crosscorr_reference)."
-            )
+        if bool(self.manual_review_enabled_var.get()):
+            review_fn = getattr(self.master, "review_measurement_for_mission", None)
+            if not callable(review_fn):
+                reasons.append(
+                    "Review-Funktion ist nicht verfügbar (self.master.review_measurement_for_mission ist nicht callable)."
+                )
+            reference_data = self._get_crosscorr_reference_for_mission()
+            if not self._has_crosscorr_reference_data(reference_data):
+                reasons.append(
+                    "TX-Referenzdaten für Crosscorrelation fehlen. Bitte TX laden (gleiche Quelle wie _get_crosscorr_reference)."
+                )
         return len(reasons) == 0, reasons
 
     def _create_navigation_adapter(self) -> NavigationAdapter:
@@ -2127,6 +2143,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 on_operator_message=self._append_validation,
             )
         return self._navigator
+
+
+    def _on_manual_review_toggle_changed(self) -> None:
+        self._persist_workflow_state()
+        self._refresh_review_ready_indicator()
 
     def _on_live_pose_stream_switch_changed(self) -> None:
         self._sync_live_pose_stream_state()
@@ -2166,6 +2187,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
     def _refresh_review_ready_indicator(self, prerequisites_ok: bool | None = None) -> None:
         if prerequisites_ok is None:
             prerequisites_ok, _ = self._check_run_prerequisites()
+        if not bool(self.manual_review_enabled_var.get()):
+            self.review_ready_var.set("Review: automatisch ✅")
+            return
         if prerequisites_ok:
             self.review_ready_var.set("Review: bereit ✅")
         else:


### PR DESCRIPTION
### Motivation
- Ermöglichen, dass beim Start einer Mission die manuelle Review optional ausgeschaltet werden kann, wobei das bisherige Verhalten (manuelle Prüfung aktiv) erhalten bleibt.
- Wenn die Checkbox deaktiviert ist, sollen Messungen automatisch bestätigt werden ohne das Crosscorr-Review-Popup.
- Der Zustand der Checkbox soll zwischen Sitzungen erhalten bleiben (Persistenz).

### Description
- Neue GUI-Variable `manual_review_enabled_var` (default `True`) und eine neue Checkbox „Manuelle Prüfung“ in der Laufsteuerung mit Handler `_on_manual_review_toggle_changed` hinzugefügt.
- Die Flagge `manual_review_enabled` wird in das Workflow-State-JSON (via `_build_workflow_state_payload` / `_persist_workflow_state`) geschrieben und beim Laden wiederhergestellt (`_restore_workflow_state`).
- Wenn `manual_review_enabled` deaktiviert ist, gibt `_review_measurement` sofort `{"approved": True, "reason": "", "detail": ""}` zurück, und `_check_run_prerequisites` überspringt review-spezifische Prüfungen (Review-Callback + TX-Referenzdaten).
- Die Review-Anzeige wurde angepasst, um bei deaktivierter manueller Prüfung „Review: automatisch ✅" anzuzeigen.

### Testing
- `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py tests/test_mission_workflow_ui_state.py` wurde ausgeführt und alle Tests bestanden (`29 passed`).
- Neue Tests prüfen (1) Auto-Approve bei deaktivierter manueller Prüfung, (2) Überspringen der Review-Voraussetzungen bei deaktivierter manueller Prüfung und (3) Persistenz des `manual_review_enabled`-Flags, und diese Tests liefen erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d658aae3948321a207093a9474b20f)