### PR TITLE
Echo-Werte im Missions-Review-Dialog durch Interpolationsfaktor normalisieren

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1566,6 +1566,7 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
         magnitudes: np.ndarray,
         los_idx: int | None,
         echo_indices: list[int],
+        interpolation_factor: float = 1.0,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Mission Measurement Review")
@@ -1578,6 +1579,11 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
         self._selected_los_idx = int(los_idx) if los_idx is not None else None
         self._base_echo_indices = [int(idx) for idx in echo_indices]
         self._selected_echo_indices = [int(idx) for idx in echo_indices]
+        try:
+            interpolation_factor_value = float(interpolation_factor)
+        except (TypeError, ValueError):
+            interpolation_factor_value = 1.0
+        self._interpolation_factor = interpolation_factor_value if interpolation_factor_value > 0 else 1.0
 
         layout = QtWidgets.QVBoxLayout(self)
         header = QtWidgets.QLabel(
@@ -1765,7 +1771,13 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             return
         rows = []
         for i, delay in enumerate(self.echo_delays, start=1):
-            rows.append(f"Echo {i}: {delay} samp ({delay * 1.5:.1f} m)")
+            adjusted_delay = float(delay) / self._interpolation_factor
+            adjusted_delay_text = (
+                str(int(adjusted_delay))
+                if adjusted_delay.is_integer()
+                else f"{adjusted_delay:.2f}".rstrip("0").rstrip(".")
+            )
+            rows.append(f"Echo {i}: {adjusted_delay_text} samp ({adjusted_delay * 1.5:.1f} m)")
         self._stats_label.setText("LOS-Echos:\n" + "\n".join(rows) if rows else "LOS-Echos: --")
 
     def _connect_click_handler(self) -> None:
@@ -6865,6 +6877,9 @@ class TransceiverUI(ctk.CTk):
                     magnitudes=mag,
                     los_idx=int(los_idx),
                     echo_indices=echo_indices,
+                    interpolation_factor=self._rx_effective_interpolation_factor()
+                    if self.rx_interpolation_enable.get()
+                    else 1.0,
                 )
                 dialog.raise_()
                 dialog.activateWindow()


### PR DESCRIPTION
### Motivation
- Die im Fenster zur manuellen Bestätigung angezeigten LOS→Echo-Sample-Werte mussten wie die Ergebnis-Payload durch den Interpolationsfaktor normalisiert (geteilt) werden, damit Anzeige und gespeicherte Daten konsistent sind.

### Description
- Übergibt den effektiven Interpolationsfaktor an den `MissionMeasurementReviewDialog` beim Öffnen aus der RX-Konfiguration (nur wenn Interpolation aktiviert, sonst `1.0`) in `transceiver/__main__.py`.
- Speichert im Dialog einen robusten `self._interpolation_factor`, der ungültige oder nicht-positive Eingaben auf `1.0` zurücksetzt.
- Skaliert die in der Dialog-Statustextansicht gezeigten Echo-Delay-Werte, indem die Sample-Abstände durch `self._interpolation_factor` geteilt werden und die Meter-Angabe entsprechend angepasst wird.

### Testing
- Ausgewählte Unit-Tests wurden ausgeführt mit `PYTHONPATH=. pytest -q tests/test_receive_for_mission_threading.py::test_review_measurement_for_mission_applies_same_interpolation_as_single_receive tests/test_mission_measurement_service.py::test_trigger_scales_review_echo_delays_by_interpolation_factor`.
- Beide Tests liefen erfolgreich und bestanden (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d658fb05bc83219a2a1c33848f8165)