### PR TITLE
Reduce dense lidar-scan overlay clutter in Mission Workflow map

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -108,6 +108,48 @@ def test_extract_lidar_ranges_from_scan_text_supports_list_style() -> None:
     assert values[2] == 3.4
 
 
+def test_draw_lidar_scan_overlay_deduplicates_dense_endpoints() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._map_image_original = SimpleNamespace(width=lambda: 200, height=lambda: 120)
+    window._map_preview_scale = (1.0, 1.0)
+    window._map_preview_offset = (0.0, 0.0)
+    window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
+    window._is_pixel_inside_map = lambda *_args, **_kwargs: True
+    line_calls: list[tuple[float, float, float, float]] = []
+    window.map_preview_canvas = SimpleNamespace(
+        create_oval=lambda *_args, **_kwargs: None,
+        create_line=lambda sx, sy, ex, ey, **_kwargs: line_calls.append((sx, sy, ex, ey)),
+    )
+
+    window._draw_lidar_scan_overlay_for_point(
+        point=MeasurementPoint(id="p1", name="P1", x=10.0, y=20.0, yaw=0.0),
+        scan={"angle_min": 0.0, "angle_increment": 0.0, "ranges": [2.0] * 1800},
+    )
+
+    assert len(line_calls) == 1
+
+
+def test_draw_lidar_scan_overlay_adapts_stride_for_large_scan() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._map_image_original = SimpleNamespace(width=lambda: 3000, height=lambda: 3000)
+    window._map_preview_scale = (1.0, 1.0)
+    window._map_preview_offset = (0.0, 0.0)
+    window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
+    window._is_pixel_inside_map = lambda *_args, **_kwargs: True
+    line_calls: list[tuple[float, float, float, float]] = []
+    window.map_preview_canvas = SimpleNamespace(
+        create_oval=lambda *_args, **_kwargs: None,
+        create_line=lambda sx, sy, ex, ey, **_kwargs: line_calls.append((sx, sy, ex, ey)),
+    )
+
+    window._draw_lidar_scan_overlay_for_point(
+        point=MeasurementPoint(id="p2", name="P2", x=0.0, y=0.0, yaw=0.0),
+        scan={"angle_min": 0.0, "angle_increment": 0.01, "ranges": [500.0] * 2000},
+    )
+
+    assert len(line_calls) <= 700
+
+
 def test_build_waypoint_arrow_polygon_points_to_positive_x_for_zero_yaw() -> None:
     points = MissionWorkflowWindow._build_waypoint_arrow_polygon(
         center_x=100.0,

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -44,6 +44,8 @@ LIVE_LABEL_TICKER_INTERVAL_MS = 250
 AUTO_STOP_CONTINUOUS_BEFORE_RUN = True
 ECHO_OVERLAY_COLORS = ("#ef5350", "#42a5f5", "#66bb6a", "#ffca28", "#ab47bc")
 ECHO_HEADING_MARKERS = ("🟥", "🟦", "🟩", "🟨", "🟪")
+LIDAR_OVERLAY_MAX_DRAWN_BEAMS = 700
+LIDAR_OVERLAY_CELL_SIZE_PX = 3.0
 
 
 def _load_json_dict(path: Path) -> dict[str, Any]:
@@ -1360,10 +1362,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         angle_min = float(scan["angle_min"])
         angle_increment = float(scan["angle_increment"])
         ranges = scan["ranges"]
+        beam_stride = max(1, len(ranges) // LIDAR_OVERLAY_MAX_DRAWN_BEAMS)
+        drawn_beam_cells: set[tuple[int, int]] = set()
         for idx, distance in enumerate(ranges):
             if not math.isfinite(distance) or distance <= 0.0:
                 continue
-            if idx % 4 != 0:
+            if idx % beam_stride != 0:
                 continue
             beam_angle = point.yaw + angle_min + idx * angle_increment
             end_world_x = point.x + math.cos(beam_angle) * distance
@@ -1373,6 +1377,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 continue
             end_x = end_map_pixel[0] * scale_x + offset_x
             end_y = end_map_pixel[1] * scale_y + offset_y
+            beam_cell = (
+                int((end_x - start_x) / LIDAR_OVERLAY_CELL_SIZE_PX),
+                int((end_y - start_y) / LIDAR_OVERLAY_CELL_SIZE_PX),
+            )
+            if beam_cell in drawn_beam_cells:
+                continue
+            drawn_beam_cells.add(beam_cell)
             self.map_preview_canvas.create_line(
                 start_x,
                 start_y,


### PR DESCRIPTION
## Summary
- make lidar overlay sampling adaptive to scan size instead of fixed every 4th beam
- cap rendered lidar beams to ~700 by deriving a dynamic stride from the range count
- add screen-space deduplication so beams ending in the same small pixel cell are rendered only once
- keep point marker rendering intact while reducing overdraw in high-density areas

## Tests
- added unit test to verify dense same-endpoint scans are deduplicated to a single line
- added unit test to verify large scans are downsampled to at most the configured beam cap

## Notes
- Changes are static and focused on map-overlay rendering behavior in `MissionWorkflowWindow`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d65e99c0cc8321bf107bdf16cc8f39)