### PR TITLE
Fix missing mission results when manual review is disabled

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -305,13 +305,30 @@ def test_on_map_canvas_release_creates_waypoint_and_disables_pick_mode() -> None
 def test_review_measurement_auto_approves_when_manual_review_disabled() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window.manual_review_enabled_var = SimpleNamespace(get=lambda: False)
+    observed: dict[str, object] = {}
+    window.master = SimpleNamespace(
+        review_measurement_for_mission=lambda **kwargs: observed.update(kwargs) or {
+            "approved": False,
+            "echo_delays": [12],
+            "echo_lags": [8],
+            "los_lag": -4,
+        }
+    )
 
     review_result = window._review_measurement(
         point_context=SimpleNamespace(point=SimpleNamespace(id="p1", name=""), global_index=1),
         output_file="dummy.bin",
     )
 
-    assert review_result == {"approved": True, "reason": "", "detail": ""}
+    assert observed["auto_approve"] is True
+    assert review_result == {
+        "approved": True,
+        "reason": "",
+        "detail": "",
+        "echo_delays": [12],
+        "echo_lags": [8],
+        "los_lag": -4,
+    }
 
 
 def test_check_run_prerequisites_skips_review_requirements_when_manual_review_disabled() -> None:

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -6809,6 +6809,7 @@ class TransceiverUI(ctk.CTk):
         *,
         point_label: str,
         output_file: str,
+        auto_approve: bool = False,
     ) -> dict[str, object]:
         """Open a blocking cross-correlation review dialog for one mission point."""
         outcome: dict[str, object] = {
@@ -6860,6 +6861,30 @@ class TransceiverUI(ctk.CTk):
                     outcome["approved"] = False
                     outcome["reason"] = REVIEW_REASON_NO_DETECTABLE_LOS
                     outcome["detail"] = detail
+                    return
+                if auto_approve:
+                    interpolation_enabled = bool(self.rx_interpolation_enable.get())
+                    interpolation_factor = self._rx_effective_interpolation_factor()
+                    los_idx_final = int(los_idx)
+                    echo_indices_final = [int(idx) for idx in echo_indices]
+                    los_lag = int(round(float(lags[los_idx_final])))
+                    outcome["approved"] = True
+                    outcome["reason"] = ""
+                    outcome["detail"] = ""
+                    outcome["manual_lags"] = {"los": None, "echo": None}
+                    outcome["interpolation_enabled"] = interpolation_enabled
+                    outcome["interpolation_factor"] = interpolation_factor
+                    outcome["los_idx"] = los_idx_final
+                    outcome["echo_indices"] = echo_indices_final
+                    outcome["echo_delays"] = [
+                        int(abs(int(round(float(lags[int(idx)]))) - los_lag))
+                        for idx in echo_indices_final
+                    ]
+                    outcome["los_lag"] = los_lag
+                    outcome["echo_lags"] = [
+                        int(round(float(lags[int(idx)])))
+                        for idx in echo_indices_final
+                    ]
                     return
 
                 parent_window = qapp.activeWindow()

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2110,15 +2110,31 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._live_label_ticker_job = None
 
     def _review_measurement(self, *, point_context, output_file: str) -> dict[str, object]:  # type: ignore[no-untyped-def]
-        if not bool(self.manual_review_enabled_var.get()):
-            return {
-                "approved": True,
-                "reason": "",
-                "detail": ""
-            }
+        manual_review_enabled = bool(self.manual_review_enabled_var.get())
         point_id = point_context.point.id or point_context.point.name or f"point-{point_context.global_index}"
         point_label = f"Punkt {point_context.global_index} ({point_id})"
         review_fn = getattr(self.master, "review_measurement_for_mission", None)
+        if not manual_review_enabled and callable(review_fn):
+            try:
+                review_result = review_fn(
+                    point_label=point_label,
+                    output_file=output_file,
+                    auto_approve=True,
+                )
+            except TypeError:
+                review_result = review_fn(point_label=point_label, output_file=output_file)
+            except Exception:
+                review_result = {"approved": True, "reason": "", "detail": ""}
+            if isinstance(review_result, dict):
+                result_payload = dict(review_result)
+                result_payload["approved"] = True
+                result_payload["reason"] = ""
+                detail = result_payload.get("detail")
+                result_payload["detail"] = detail.strip() if isinstance(detail, str) else ""
+                return result_payload
+            return {"approved": True, "reason": "", "detail": ""}
+        if not manual_review_enabled:
+            return {"approved": True, "reason": "", "detail": ""}
         if not callable(review_fn):
             detail = "Mission-Review nicht verfügbar; Messung wird verworfen."
             self._append_validation(f"⚠️ {detail}")


### PR DESCRIPTION
### Motivation
- When manual review was disabled the mission workflow returned a plain approved result without any LOS/echo metadata, causing missing measurement details.
- The intent is to keep the automatically suggested cross-correlation results even when no dialog is shown so mission payloads contain the same fields as an explicit review.

### Description
- Call `review_measurement_for_mission(..., auto_approve=True)` from the mission workflow when manual review is disabled so suggested LOS/echo fields are generated and propagated instead of returning a bare approved value.
- Add an `auto_approve` parameter to `TransceiverUI.review_measurement_for_mission` that computes and returns the same suggested `los_lag`, `echo_lags`, `echo_delays`, `los_idx`, and `echo_indices` without opening the dialog.
- Make the auto-approve invocation resilient by falling back to a minimal approved result when the review function signature does not accept `auto_approve` or an error occurs.
- Update `tests/test_mission_workflow_ui.py` to assert the `auto_approve` invocation and that suggested echo fields are returned and included in the approved payload.

### Testing
- Ran targeted unit tests with module path set: `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py::test_review_measurement_auto_approves_when_manual_review_disabled tests/test_mission_measurement_service.py::test_trigger_promotes_review_los_echo_fields_to_measurement_result`, and both tests passed (`2 passed`).
- Running `pytest -q tests/test_mission_workflow_ui.py tests/test_mission_measurement_service.py` without `PYTHONPATH=. ` failed during collection due to `ModuleNotFoundError: No module named 'transceiver'` in the test environment, which is an environment configuration issue and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d65f94cb488321bd58d2b05e8bb2f3)