### PR TITLE
Persist live-position toggle and auto-manage pose stream on workflow open/close

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -366,3 +366,15 @@ def test_check_run_prerequisites_skips_review_requirements_when_manual_review_di
 
     assert ok is True
     assert reasons == []
+
+
+def test_on_live_pose_stream_switch_changed_persists_and_syncs() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    calls: list[str] = []
+    window._persist_workflow_state = lambda: calls.append("persist")
+    window._sync_live_pose_stream_state = lambda: calls.append("sync")
+    window._update_live_label = lambda: calls.append("label")
+
+    window._on_live_pose_stream_switch_changed()
+
+    assert calls == ["persist", "sync", "label"]

--- a/tests/test_mission_workflow_ui_state.py
+++ b/tests/test_mission_workflow_ui_state.py
@@ -130,3 +130,19 @@ def test_save_and_load_json_dict_preserves_manual_review_enabled_flag(tmp_path) 
     loaded = _load_json_dict(state_file)
 
     assert loaded["manual_review_enabled"] is False
+
+
+def test_save_and_load_json_dict_preserves_live_pose_stream_enabled_flag(tmp_path) -> None:
+    state_file = tmp_path / "mission-workflow-state.json"
+    payload = {
+        "name": "scan-live-pose-toggle",
+        "repeat": 1,
+        "start_point_index": 0,
+        "live_pose_stream_enabled": True,
+        "points": [{"id": "p001", "x": 0.0, "y": 0.0, "z": 0.0, "yaw": 0.0, "enabled": True}],
+    }
+
+    _save_json_dict(state_file, payload)
+    loaded = _load_json_dict(state_file)
+
+    assert loaded["live_pose_stream_enabled"] is True

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -224,6 +224,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
         self._build_ui()
         self._restore_workflow_state()
+        self._sync_live_pose_stream_state()
         self.after_idle(self._stabilize_initial_geometry)
         self.after_idle(self._open_maximized)
 
@@ -1811,6 +1812,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "lidar_reference_enabled": bool(self.lidar_reference_enabled_var.get()),
             "manual_review_enabled": bool(self.manual_review_enabled_var.get()),
             "reverse_point_order": bool(self.reverse_point_order_var.get()),
+            "live_pose_stream_enabled": bool(self.live_pose_stream_enabled_var.get()),
         }
 
     def _serialize_rx_antenna_global_position(self) -> dict[str, float] | None:
@@ -1890,6 +1892,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self.lidar_reference_enabled_var.set(bool(payload.get("lidar_reference_enabled", True)))
             self.manual_review_enabled_var.set(bool(payload.get("manual_review_enabled", True)))
             self.reverse_point_order_var.set(bool(payload.get("reverse_point_order", False)))
+            self.live_pose_stream_enabled_var.set(bool(payload.get("live_pose_stream_enabled", False)))
             self._refresh_points_table()
             self._refresh_map_section()
             persisted_start_point = payload.get("start_point_index")
@@ -2273,6 +2276,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._refresh_review_ready_indicator()
 
     def _on_live_pose_stream_switch_changed(self) -> None:
+        self._persist_workflow_state()
         self._sync_live_pose_stream_state()
         self._update_live_label()
 


### PR DESCRIPTION
### Motivation
- Keep the `Live-Position aktivieren` setting across application restarts so the mission workflow resumes the same streaming preference. 
- Start position streaming automatically when the mission workflow window is opened if the persisted setting is enabled and stop streaming again when the window is closed. 

### Description
- Persist the live-position switch in the workflow state payload under `live_pose_stream_enabled` by extending `_build_workflow_state_payload` and restoring it in `_restore_workflow_state`. 
- Immediately sync/start the pose stream after restoring state by calling `_sync_live_pose_stream_state()` during window initialization. 
- Ensure toggling the live-position switch now calls `_persist_workflow_state()` before `_sync_live_pose_stream_state()` in `_on_live_pose_stream_switch_changed()` so changes are persisted right away. 
- Added unit tests: `test_save_and_load_json_dict_preserves_live_pose_stream_enabled_flag` and `test_on_live_pose_stream_switch_changed_persists_and_syncs` to validate persistence and callback ordering. 

### Testing
- Ran targeted tests with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui_state.py -k live_pose_stream_enabled_flag tests/test_mission_workflow_ui.py -k on_live_pose_stream_switch_changed_persists_and_syncs` and they passed. 
- Ran the broader suite with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui_state.py tests/test_mission_workflow_ui.py` and observed one pre-existing, unrelated failure in `test_draw_lidar_scan_overlay_adapts_stride_for_large_scan` (expected `<=700` lines, observed `719`), while the new tests still passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d65ffc763083218ca55e00cdea4545)