### PR TITLE
Add 'Abstand' column to mission workflow results table

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -89,6 +89,30 @@ def test_compose_table_outcome_includes_navigation_and_measurement_for_failures(
     )
 
 
+def test_format_distance_to_rx_for_table_uses_measurement_point_coordinates() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._rx_antenna_global_position = (1.0, 2.0)
+    window._mission_points = [
+        MeasurementPoint(id="p0", name="P0", x=4.0, y=6.0, yaw=0.0),
+    ]
+
+    distance = window._format_distance_to_rx_for_table({"point_index": 0})
+
+    assert distance == "5"
+
+
+def test_format_distance_to_rx_for_table_returns_dash_without_rx_position() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._rx_antenna_global_position = None
+    window._mission_points = [
+        MeasurementPoint(id="p0", name="P0", x=4.0, y=6.0, yaw=0.0),
+    ]
+
+    distance = window._format_distance_to_rx_for_table({"point_index": 0})
+
+    assert distance == "-"
+
+
 def test_parse_lidar_scan_text_for_overlay_supports_inline_ranges() -> None:
     parsed = MissionWorkflowWindow._parse_lidar_scan_text_for_overlay(
         "angle_min: -1.57\nangle_increment: 0.1\nranges: [1.0, 2.5, inf, nan]\n"

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -487,6 +487,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         columns = (
             "measurement_idx",
             "idx",
+            "distance_to_rx_m",
             "echo_1_m",
             "echo_2_m",
             "echo_3_m",
@@ -499,6 +500,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         headings = {
             "measurement_idx": "Messung",
             "idx": "Punktindex",
+            "distance_to_rx_m": "Abstand",
             "echo_1_m": f"{ECHO_HEADING_MARKERS[0]} E1",
             "echo_2_m": f"{ECHO_HEADING_MARKERS[1]} E2",
             "echo_3_m": f"{ECHO_HEADING_MARKERS[2]} E3",
@@ -510,6 +512,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self.results_table.heading(key, text=title)
             self.results_table.column(key, stretch=True, width=110)
         self.results_table.column("measurement_idx", width=80)
+        self.results_table.column("distance_to_rx_m", width=90)
         self.results_table.column("echo_1_m", width=80)
         self.results_table.column("echo_2_m", width=80)
         self.results_table.column("echo_3_m", width=80)
@@ -2502,12 +2505,14 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             error_text = f"{error_text}: {review_detail}" if error_text else review_detail
         combined_status = self._compose_table_outcome(payload, error_text)
         echo_distances = self._format_echo_distances_for_table(result.get("echo_delays"))
+        distance_to_rx = self._format_distance_to_rx_for_table(payload)
         self.results_table.insert(
             "",
             "end",
             values=(
                 self._format_one_based_index(payload.get("global_index")),
                 self._format_one_based_index(payload.get("point_index")),
+                distance_to_rx,
                 *echo_distances,
                 combined_status,
             ),
@@ -2582,6 +2587,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if len(formatted) < limit:
             formatted.extend("-" for _ in range(limit - len(formatted)))
         return tuple(formatted)
+
+    def _format_distance_to_rx_for_table(self, payload: dict[str, Any]) -> str:
+        rx_position = self._rx_antenna_global_position
+        if rx_position is None:
+            return "-"
+        point = self._selected_record_point(payload)
+        if point is None:
+            return "-"
+        distance_m = math.hypot(point.x - rx_position[0], point.y - rx_position[1])
+        if not math.isfinite(distance_m):
+            return "-"
+        return f"{distance_m:.2f}".rstrip("0").rstrip(".")
 
     def _on_run_finished(self, state: str) -> None:
         self._stop_live_label_ticker()


### PR DESCRIPTION
### Motivation
- Provide a visible distance value in the mission results table showing how far each measurement point is from the configured RX antenna position to aid validation and debugging.

### Description
- Add a new `distance_to_rx_m` column (header `Abstand`) to the results `Treeview` and set a reasonable column width using the existing headings pattern.
- Compute and format the distance using a new helper ` _format_distance_to_rx_for_table` that uses `math.hypot` on the measurement point and `self._rx_antenna_global_position` and returns `"-"` when the RX position or point is unavailable or invalid.
- Insert the computed distance into each row during `_on_record` before the echo distance columns so the table values align as `measurement_idx`, `idx`, `distance_to_rx_m`, `echo_1_m`, ... .
- Add unit tests in `tests/test_mission_workflow_ui.py` to verify the numeric formatting and the fallback `"-"` when no RX position is set.

### Testing
- Running `pytest -q tests/test_mission_workflow_ui.py` without `PYTHONPATH` failed during import due to module resolution (expected in some CI setups). 
- Running `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` succeeded with all tests passing (`28 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d662663f948321a3fdb1c377fffd59)