### PR TITLE
Add 'Testlauf (ohne Messung)' test-run mode to mission workflow

### DIFF
--- a/tests/test_measurement_run_executor.py
+++ b/tests/test_measurement_run_executor.py
@@ -79,6 +79,34 @@ def test_executes_points_strictly_in_order_and_persists_context() -> None:
     assert persisted[1]["point"]["id"] == "p2"
 
 
+
+
+def test_test_run_mode_navigates_without_measurements() -> None:
+    nav = FakeNavigator(["succeeded", "succeeded"])
+    measured: list[str] = []
+    persisted: list[dict] = []
+
+    def trigger(point: MeasurementPoint) -> dict:
+        measured.append(point.id or "")
+        return {"value": point.x + point.y}
+
+    executor = MeasurementRunExecutor(
+        mission=_mission(),
+        navigator=nav,
+        trigger_measurement=trigger,
+        persist_result=persisted.append,
+        config=MeasurementRunExecutorConfig(enable_measurements=False),
+    )
+
+    final_state = executor.start()
+
+    assert final_state == "completed"
+    assert measured == []
+    assert len(persisted) == 2
+    assert persisted[0]["measurement"]["status"] == "skipped"
+    assert persisted[0]["measurement"]["result"] == {"mode": "test_run"}
+    assert all(rec.status == "succeeded" for rec in executor.records)
+
 def test_navigation_failure_retries_then_continue() -> None:
     nav = FakeNavigator(["timeout", "aborted", "succeeded"])
     persisted: list[dict] = []

--- a/transceiver/measurement_run_executor.py
+++ b/transceiver/measurement_run_executor.py
@@ -131,6 +131,7 @@ class MeasurementRunExecutorConfig:
     on_point_error: OnPointError = "continue"
     start_point_index: int = 0
     reverse_point_order: bool = False
+    enable_measurements: bool = True
 
 
 @dataclass(frozen=True)
@@ -453,6 +454,31 @@ class MeasurementRunExecutor:
                 navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
             )
             return record
+
+        if not self.config.enable_measurements:
+            self._persist_point_log(
+                point=point,
+                point_index=point_index,
+                cycle=cycle,
+                global_index=global_index,
+                navigation_state=nav_state,
+                navigation_attempts=attempt,
+                point_started_at=point_started_at,
+                measurement_result={"mode": "test_run"},
+                measurement_status="skipped",
+                error=None,
+                navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
+            )
+            return PointExecutionRecord(
+                index=global_index,
+                point_id=point.id,
+                point_name=point.name,
+                status="succeeded",
+                navigation_state=nav_state,
+                navigation_attempts=attempt,
+                measurement_result={"mode": "test_run"},
+                error=None,
+            )
 
         try:
             measurement_result = self.measurement_service.trigger(

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -220,6 +220,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._live_label_ticker_active = False
         self.lidar_reference_enabled_var = tk.BooleanVar(value=True)
         self.manual_review_enabled_var = tk.BooleanVar(value=True)
+        self.test_run_enabled_var = tk.BooleanVar(value=False)
         self.live_pose_stream_enabled_var = tk.BooleanVar(value=False)
         self._live_pose_stream_active = False
 
@@ -467,12 +468,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             variable=self.manual_review_enabled_var,
             command=self._on_manual_review_toggle_changed,
         ).grid(row=3, column=2, padx=(8, 3), pady=(0, 4), sticky="w")
+        ctk.CTkCheckBox(
+            controls,
+            text="Testlauf (ohne Messung)",
+            variable=self.test_run_enabled_var,
+            command=self._on_test_run_toggle_changed,
+        ).grid(row=3, column=3, padx=(8, 3), pady=(0, 4), sticky="w")
         ctk.CTkSwitch(
             controls,
             text="Live-Position aktivieren",
             variable=self.live_pose_stream_enabled_var,
             command=self._on_live_pose_stream_switch_changed,
-        ).grid(row=3, column=3, columnspan=2, padx=(8, 8), pady=(0, 4), sticky="w")
+        ).grid(row=3, column=4, columnspan=1, padx=(8, 8), pady=(0, 4), sticky="w")
 
         self.live_var = tk.StringVar(value="Punkt: - | Navigation: idle | Messung: idle | Verbleibend: - | Live-Status: Karte nicht geladen")
         ctk.CTkLabel(controls, textvariable=self.live_var, anchor="w", justify="left").grid(
@@ -1821,6 +1828,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "rx_antenna_global_position": self._serialize_rx_antenna_global_position(),
             "lidar_reference_enabled": bool(self.lidar_reference_enabled_var.get()),
             "manual_review_enabled": bool(self.manual_review_enabled_var.get()),
+            "test_run_enabled": bool(self.test_run_enabled_var.get()),
             "reverse_point_order": bool(self.reverse_point_order_var.get()),
             "live_pose_stream_enabled": bool(self.live_pose_stream_enabled_var.get()),
         }
@@ -1901,6 +1909,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 self._set_rx_antenna_position(x=rx_position[0], y=rx_position[1], persist=False)
             self.lidar_reference_enabled_var.set(bool(payload.get("lidar_reference_enabled", True)))
             self.manual_review_enabled_var.set(bool(payload.get("manual_review_enabled", True)))
+            self.test_run_enabled_var.set(bool(payload.get("test_run_enabled", False)))
             self.reverse_point_order_var.set(bool(payload.get("reverse_point_order", False)))
             self.live_pose_stream_enabled_var.set(bool(payload.get("live_pose_stream_enabled", False)))
             self._refresh_points_table()
@@ -2003,8 +2012,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             )
             self._append_validation("❌ Run-Start blockiert: " + " | ".join(reasons))
             return
-        if not self._ensure_transmitter_before_run():
+        test_run_enabled = self._is_test_run_enabled()
+        if not test_run_enabled and not self._ensure_transmitter_before_run():
             return
+        if test_run_enabled:
+            self._append_validation("ℹ️ Testlauf aktiv: Wegpunkte werden ohne Messung angefahren.")
         start_point_index = self._selected_start_point_index()
 
         self.results_table.delete(*self.results_table.get_children())
@@ -2051,6 +2063,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 navigation_retry_attempts=self._runtime_config.navigation_retry_attempts,
                 start_point_index=start_point_index,
                 reverse_point_order=bool(self.reverse_point_order_var.get()),
+                enable_measurements=not test_run_enabled,
             ),
         )
 
@@ -2259,7 +2272,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not any(point.enabled for point in self._mission_points):
             reasons.append("Keine aktiven Wegpunkte vorhanden. Bitte mindestens einen Punkt aktivieren.")
         reasons.extend(self._runtime_guard_reasons())
-        if bool(self.manual_review_enabled_var.get()):
+        if not self._is_test_run_enabled() and bool(self.manual_review_enabled_var.get()):
             review_fn = getattr(self.master, "review_measurement_for_mission", None)
             if not callable(review_fn):
                 reasons.append(
@@ -2301,6 +2314,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._persist_workflow_state()
         self._refresh_review_ready_indicator()
 
+    def _on_test_run_toggle_changed(self) -> None:
+        self._persist_workflow_state()
+        self._refresh_review_ready_indicator()
+
     def _on_live_pose_stream_switch_changed(self) -> None:
         self._persist_workflow_state()
         self._sync_live_pose_stream_state()
@@ -2325,6 +2342,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         cont_thread = getattr(self.master, "_cont_thread", None)
         return bool(cont_thread is not None and cont_thread.is_alive())
 
+    def _is_test_run_enabled(self) -> bool:
+        var = getattr(self, "test_run_enabled_var", None)
+        getter = getattr(var, "get", None)
+        return bool(getter()) if callable(getter) else False
+
     def _runtime_guard_reasons(self) -> list[str]:
         reasons: list[str] = []
         if self._is_continuous_active():
@@ -2340,6 +2362,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
     def _refresh_review_ready_indicator(self, prerequisites_ok: bool | None = None) -> None:
         if prerequisites_ok is None:
             prerequisites_ok, _ = self._check_run_prerequisites()
+        if self._is_test_run_enabled():
+            self.review_ready_var.set("Review: Testlauf ✅")
+            return
         if not bool(self.manual_review_enabled_var.get()):
             self.review_ready_var.set("Review: automatisch ✅")
             return


### PR DESCRIPTION
### Motivation
- Provide a navigation-only test mode so operators can drive the robot through all mission points without performing or requiring measurements or transmitter checks.

### Description
- Add a `Testlauf (ohne Messung)` checkbox (`test_run_enabled_var`) to the mission workflow UI and persist/restore the `test_run_enabled` flag in the workflow state.
- When a test run is active the run-start logic skips the transmitter activation guard and logs an informational operator message, and the executor is started with `enable_measurements=False`.
- Extend `MeasurementRunExecutorConfig` with `enable_measurements` and implement a fast-path in `_execute_point` that records a skipped measurement payload `{"mode": "test_run"}` and does not call the measurement trigger while still navigating points sequentially.
- Add unit coverage `test_test_run_mode_navigates_without_measurements` to confirm navigation still occurs but no measurement triggers are invoked and per-point logs are written.

### Testing
- Running `pytest -q tests/test_measurement_run_executor.py tests/test_mission_workflow_ui.py tests/test_mission_workflow_ui_state.py` without `PYTHONPATH` failed during collection due to `ModuleNotFoundError: transceiver` (environment issue).
- Running `PYTHONPATH=. pytest -q tests/test_measurement_run_executor.py tests/test_mission_workflow_ui.py tests/test_mission_workflow_ui_state.py` succeeded with `59 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df7ae5afc48321a12c8d81e8c99652)