### PR TITLE
Rotate heading by 180° when reverse mission order is enabled

### DIFF
--- a/tests/test_measurement_run_executor.py
+++ b/tests/test_measurement_run_executor.py
@@ -567,6 +567,8 @@ def test_reverse_point_order_executes_active_points_backwards() -> None:
 
     assert final_state == "completed"
     assert measured == ["p3", "p1"]
+    assert nav.calls[0][2] == pytest.approx(1.0)
+    assert nav.calls[1][2] == pytest.approx(1.0)
     assert summaries[0]["reverse_point_order"] is True
 
 
@@ -586,6 +588,41 @@ def test_reverse_point_order_applies_to_start_point_index() -> None:
 
     assert final_state == "completed"
     assert measured == ["p1"]
+    assert nav.calls[0][2] == pytest.approx(1.0)
+
+
+def test_reverse_point_order_rotates_quaternion_heading_by_180_deg() -> None:
+    nav = FakeNavigator(["succeeded"])
+    mission = MeasurementMission(
+        name="reverse-order-quaternion",
+        points=[
+            MeasurementPoint(
+                id="p1",
+                name="Q",
+                x=1.0,
+                y=2.0,
+                qx=0.0,
+                qy=0.0,
+                qz=0.0,
+                qw=1.0,
+                enabled=True,
+            ),
+        ],
+        repeat=1,
+    )
+
+    executor = MeasurementRunExecutor(
+        mission=mission,
+        navigator=nav,
+        trigger_measurement=lambda _point: {"ok": True},
+        persist_result=lambda _payload: None,
+        config=MeasurementRunExecutorConfig(reverse_point_order=True),
+    )
+
+    final_state = executor.start()
+
+    assert final_state == "completed"
+    assert nav.calls[0][2] == pytest.approx(1.0)
 
 
 def test_start_fails_when_mission_has_no_active_points() -> None:

--- a/transceiver/measurement_run_executor.py
+++ b/transceiver/measurement_run_executor.py
@@ -382,7 +382,9 @@ class MeasurementRunExecutor:
 
         for attempt in range(1, attempts + 1):
             nav_state = self.navigator.navigate_to_point(
-                self._to_navigation_point(point),
+                self._to_navigation_point(
+                    point, rotate_heading_by_pi=self.config.reverse_point_order
+                ),
                 timeout_s=self.config.goal_reached_timeout_s,
                 on_navigation_event=_emit_navigation_event,
             )
@@ -685,26 +687,42 @@ class MeasurementRunExecutor:
         return active_points
 
     @staticmethod
-    def _to_navigation_point(point: MeasurementPoint) -> NavigationPoint:
+    def _to_navigation_point(
+        point: MeasurementPoint, *, rotate_heading_by_pi: bool = False
+    ) -> NavigationPoint:
+        yaw_offset = math.pi if rotate_heading_by_pi else 0.0
         if point.yaw is not None:
+            yaw = point.yaw + yaw_offset
             return NavigationPoint(
                 x=point.x,
                 y=point.y,
                 z=point.z,
                 qx=0.0,
                 qy=0.0,
-                qz=math.sin(point.yaw / 2.0),
-                qw=math.cos(point.yaw / 2.0),
+                qz=math.sin(yaw / 2.0),
+                qw=math.cos(yaw / 2.0),
             )
+        qx = point.qx if point.qx is not None else 0.0
+        qy = point.qy if point.qy is not None else 0.0
+        qz = point.qz if point.qz is not None else 0.0
+        qw = point.qw if point.qw is not None else 1.0
+        if rotate_heading_by_pi:
+            qx, qy, qz, qw = _rotate_quaternion_z_by_pi(qx, qy, qz, qw)
         return NavigationPoint(
             x=point.x,
             y=point.y,
             z=point.z,
-            qx=point.qx if point.qx is not None else 0.0,
-            qy=point.qy if point.qy is not None else 0.0,
-            qz=point.qz if point.qz is not None else 0.0,
-            qw=point.qw if point.qw is not None else 1.0,
+            qx=qx,
+            qy=qy,
+            qz=qz,
+            qw=qw,
         )
+
+
+def _rotate_quaternion_z_by_pi(
+    qx: float, qy: float, qz: float, qw: float
+) -> tuple[float, float, float, float]:
+    return (-qy, qx, qw, -qz)
 
 
 def _extract_measurement_id(measurement_result: dict[str, Any] | None) -> Any:


### PR DESCRIPTION
### Motivation
- When the mission UI option to "Reihenfolge umdrehen" (reverse point order) is active, the navigator should approach each point with its heading rotated by 180° so the robot faces the opposite direction when points are executed in reversed order.

### Description
- The call to `_to_navigation_point` now receives `rotate_heading_by_pi=self.config.reverse_point_order` so the navigation target orientation can be adjusted when order is reversed.
- `_to_navigation_point` accepts `rotate_heading_by_pi: bool` and applies a `yaw_offset = π` for yaw-based points before converting to a quaternion.
- For quaternion-based points the helper `_rotate_quaternion_z_by_pi` was added and applied to rotate the quaternion by 180° around Z when requested.
- Tests in `tests/test_measurement_run_executor.py` were updated and extended to assert that the `qz` field passed to the navigator equals `~1.0` when reverse order is enabled for both yaw and quaternion inputs.

### Testing
- Ran `pytest -q tests/test_measurement_run_executor.py` which initially failed during collection due to import path issues (ModuleNotFoundError). 
- Ran `PYTHONPATH=. pytest -q tests/test_measurement_run_executor.py` which succeeded with `23 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df89c4f4388321bfa841ec7a8b7ae0)