### PR TITLE
Enable dragging for multiple Echo markers on cross-correlation plots

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1477,7 +1477,7 @@ def _add_draggable_markers(
     lags: np.ndarray,
     magnitudes: np.ndarray,
     los_idx: int | None,
-    echo_idx: int | None,
+    echo_indices: list[int] | tuple[int, ...] | None,
     on_los_drag=None,
     on_echo_drag=None,
     on_los_drag_end=None,
@@ -1487,8 +1487,8 @@ def _add_draggable_markers(
     los_magnitudes: np.ndarray | None = None,
     echo_lags: np.ndarray | None = None,
     echo_magnitudes: np.ndarray | None = None,
-) -> tuple[DraggableLagMarker | None, DraggableLagMarker | None]:
-    """Attach draggable LOS/echo markers to a plot."""
+) -> tuple[DraggableLagMarker | None, list[DraggableLagMarker]]:
+    """Attach draggable LOS and Echo 1..N markers to a plot."""
     view_box = plot.getViewBox()
     los_lags = np.asarray(los_lags) if los_lags is not None else np.asarray(lags)
     echo_lags = np.asarray(echo_lags) if echo_lags is not None else np.asarray(lags)
@@ -1503,7 +1503,12 @@ def _add_draggable_markers(
         else np.asarray(magnitudes)
     )
     los_marker = None
-    echo_marker = None
+    echo_markers: list[DraggableLagMarker] = []
+    echo_indices_list = [
+        int(idx)
+        for idx in (echo_indices or [])
+        if idx is not None
+    ]
     if los_idx is not None:
         los_marker = DraggableLagMarker(
             view_box,
@@ -1515,18 +1520,21 @@ def _add_draggable_markers(
             on_drag_end=on_los_drag_end,
         )
         plot.addItem(los_marker)
-    if echo_idx is not None:
+    echo_palette = [PLOT_COLORS["echo"], *XCORR_EXTRA_PEAK_COLORS]
+    for marker_idx, echo_idx in enumerate(echo_indices_list):
+        marker_color = echo_palette[marker_idx % len(echo_palette)]
         echo_marker = DraggableLagMarker(
             view_box,
             echo_lags,
             echo_magnitudes,
             echo_idx,
-            "g",
+            marker_color,
             on_drag=on_echo_drag,
             on_drag_end=on_echo_drag_end,
         )
         plot.addItem(echo_marker)
-    return los_marker, echo_marker
+        echo_markers.append(echo_marker)
+    return los_marker, echo_markers
 
 
 def _crosscorr_peak_labels(group_indices: list[int]) -> dict[int, str]:
@@ -3011,12 +3019,12 @@ def _plot_on_pg(
         echo_drag_callback = _wrap_drag(on_echo_drag)
         los_end_callback = _wrap_drag(on_los_drag_end)
         echo_end_callback = _wrap_drag(on_echo_drag_end)
-        los_marker, echo_marker = _add_draggable_markers(
+        los_marker, echo_markers = _add_draggable_markers(
             plot,
             lags,
             mag,
             los_idx,
-            echo_idx,
+            filtered_echo_indices,
             on_los_drag=los_drag_callback,
             on_echo_drag=echo_drag_callback,
             on_los_drag_end=los_end_callback,
@@ -3048,7 +3056,7 @@ def _plot_on_pg(
                     idx = int(np.abs(lags - pos.x()).argmin())
                     lag_value = float(lags[idx])
                     manual_lags["echo"] = int(round(lag_value))
-                    if echo_marker is not None:
+                    for echo_marker in echo_markers:
                         echo_marker.set_index(idx)
                     callback = echo_drag_callback or echo_end_callback
                     if callback is not None:


### PR DESCRIPTION
### Motivation
- Improve UX by allowing users to click and drag not only the LOS marker and a single echo, but all visible echo peaks (Echo 1..N) on cross-correlation plots so they can adjust echo lags the same way they already do for LOS/Echo.
- Keep existing LOS interaction unchanged while providing distinct colors for multiple echo markers to make simultaneous manipulation clear.

### Description
- Changed `_add_draggable_markers` signature to accept `echo_indices: list[int] | tuple[int, ...] | None` and return `(los_marker, echo_markers)` where `echo_markers` is a list of `DraggableLagMarker` instances instead of a single echo marker.
- Create one `DraggableLagMarker` per echo index and assign colors from `PLOT_COLORS["echo"]` and `XCORR_EXTRA_PEAK_COLORS` so multiple echos are visually distinct.
- Updated cross-correlation plot integration to pass `filtered_echo_indices` into `_add_draggable_markers` and to set the index on all echo markers when an Alt-click manual echo lag is selected.
- Kept LOS marker creation and callbacks unchanged and wrapped drag callbacks with existing `_wrap_drag` logic.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` and it passed (`9 passed`).
- Ran `PYTHONPATH=. pytest -q tests/test_continuous_processing_correlation.py` and it passed (`5 passed`).
- Note: running `pytest` without `PYTHONPATH=.` initially failed during collection due to module import path, but tests passed when invoked with `PYTHONPATH=.` as used above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfac9cfde0832198eb5ba2305e7834)