### PR TITLE
Korrigiere Echo-Overlay: Bistatische Ellipsen-Geometrie

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import math
 from types import SimpleNamespace
 
+import pytest
+
 from transceiver.measurement_mission import MeasurementPoint
-from transceiver.mission_workflow_ui import MissionWorkflowWindow
+from transceiver.mission_workflow_ui import MissionWorkflowWindow, _compute_bistatic_echo_ellipse_axes
 
 
 def test_format_echo_distances_for_table_returns_only_meter_values_for_first_five_echoes() -> None:
@@ -207,6 +210,46 @@ def test_build_waypoint_arrow_polygon_points_up_for_ninety_degree_yaw() -> None:
     assert round(left_y, 3) == 54.0
     assert round(right_x, 3) == 96.0
     assert round(right_y, 3) == 54.0
+
+
+def test_compute_bistatic_echo_ellipse_axes_uses_sum_path_geometry() -> None:
+    axes = _compute_bistatic_echo_ellipse_axes(distance_rx_to_point=10.0, echo_distance_m=6.0)
+
+    assert axes is not None
+    c, a, b = axes
+    assert c == 5.0
+    assert a == 8.0
+    assert b == pytest.approx(math.sqrt(39.0))
+
+
+def test_compute_bistatic_echo_ellipse_points_satisfy_focus_distance_sum() -> None:
+    axes = _compute_bistatic_echo_ellipse_axes(distance_rx_to_point=10.0, echo_distance_m=6.0)
+
+    assert axes is not None
+    c, a, b = axes
+    d = 10.0
+    delta = 6.0
+    for step in range(0, 65):
+        t = (2.0 * math.pi * step) / 64.0
+        x = a * math.cos(t)
+        y = b * math.sin(t)
+        distance_to_focus_1 = math.hypot(x + c, y)
+        distance_to_focus_2 = math.hypot(x - c, y)
+        assert distance_to_focus_1 + distance_to_focus_2 == pytest.approx(d + delta, abs=1e-9)
+
+
+def test_compute_bistatic_echo_ellipse_axes_handles_zero_delta_without_crash() -> None:
+    axes = _compute_bistatic_echo_ellipse_axes(distance_rx_to_point=10.0, echo_distance_m=0.0)
+
+    assert axes is not None
+    c, a, b = axes
+    assert c == 5.0
+    assert a == 5.0
+    assert b == 0.0
+
+
+def test_compute_bistatic_echo_ellipse_axes_rejects_negative_delta() -> None:
+    assert _compute_bistatic_echo_ellipse_axes(distance_rx_to_point=10.0, echo_distance_m=-0.1) is None
 
 
 class _FakeAdapter:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -89,6 +89,30 @@ def _operator_error_code(event_type: str, detail: str) -> str:
         return "navigation_failed.aborted"
     return f"navigation_failed.{event_type}"
 
+
+def _compute_bistatic_echo_ellipse_axes(
+    *,
+    distance_rx_to_point: float,
+    echo_distance_m: float,
+) -> tuple[float, float, float] | None:
+    if (
+        not math.isfinite(distance_rx_to_point)
+        or not math.isfinite(echo_distance_m)
+        or distance_rx_to_point < 0.0
+        or echo_distance_m < 0.0
+    ):
+        return None
+    semi_focal_distance = distance_rx_to_point / 2.0
+    semi_major_axis = (distance_rx_to_point + echo_distance_m) / 2.0
+    semi_minor_squared = semi_major_axis * semi_major_axis - semi_focal_distance * semi_focal_distance
+    if semi_minor_squared < 0.0 and abs(semi_minor_squared) < 1e-12:
+        semi_minor_squared = 0.0
+    if semi_minor_squared < 0.0:
+        return None
+    semi_minor_axis = math.sqrt(semi_minor_squared)
+    return (semi_focal_distance, semi_major_axis, semi_minor_axis)
+
+
 class _UiNavigator:
     def __init__(self, *, adapter: NavigationAdapter, on_status, on_operator_message) -> None:
         self._adapter = adapter
@@ -1216,16 +1240,25 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not math.isfinite(resolution) or resolution <= 0.0:
             return
         rx_x, rx_y = rx_position
-        distance_rx_to_point = math.hypot(point.x - rx_x, point.y - rx_y)
-        if not math.isfinite(distance_rx_to_point):
+        if (
+            not math.isfinite(rx_x)
+            or not math.isfinite(rx_y)
+            or not math.isfinite(point.x)
+            or not math.isfinite(point.y)
+            or not math.isfinite(echo_distance_m)
+            or echo_distance_m < 0.0
+        ):
             return
-        echo_radius = abs(distance_rx_to_point - echo_distance_m)
-        semi_focal_distance = distance_rx_to_point / 2.0
-        semi_major_axis = semi_focal_distance + echo_radius
-        if semi_major_axis <= semi_focal_distance:
-            semi_major_axis = semi_focal_distance + 0.05
-        semi_minor_squared = max(0.0, semi_major_axis * semi_major_axis - semi_focal_distance * semi_focal_distance)
-        semi_minor_axis = max(0.05, math.sqrt(semi_minor_squared))
+        distance_rx_to_point = math.hypot(point.x - rx_x, point.y - rx_y)
+        ellipse_axes = _compute_bistatic_echo_ellipse_axes(
+            distance_rx_to_point=distance_rx_to_point,
+            echo_distance_m=echo_distance_m,
+        )
+        if ellipse_axes is None:
+            return
+        semi_focal_distance, semi_major_axis, semi_minor_axis = ellipse_axes
+        if semi_minor_axis <= 0.0:
+            return
         center_x = (rx_x + point.x) / 2.0
         center_y = (rx_y + point.y) / 2.0
         angle = math.atan2(point.y - rx_y, point.x - rx_x)
@@ -1249,10 +1282,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                     map_pixel[0] * scale_x + offset_x,
                     map_pixel[1] * scale_y + offset_y,
                 )
-            )
+        )
         if len(preview_points) < 6:
             return
-        line_width = max(1, int(round((echo_radius / resolution) * self._map_preview_scale[0] * 0.03)))
+        line_width = max(1, int(round((echo_distance_m / resolution) * self._map_preview_scale[0] * 0.03)))
         self.map_preview_canvas.create_line(
             *preview_points,
             fill=color,


### PR DESCRIPTION
### Motivation
- Die bisherige Ellipsen-Formel im Mission-Overlay verwendete fälschlich eine `abs(d - echo_distance_m)`-Logik und modellierte damit nicht die physikalische Bedingung eines bistatischen Echos; die Korrektur gehört in die UI-/Overlay-Geometrie.
- Ziel ist die korrekte Umsetzung der Bedingung `|RP| + |PM| = d + Δ` bei gleichzeitiger Robustheit gegen ungültige Werte und numerische Rundungsfehler.

### Description
- Neue Hilfsfunktion ` _compute_bistatic_echo_ellipse_axes` eingeführt, die aus `distance_rx_to_point` und `echo_distance_m` die Parameter `c`, `a`, `b` (semi-focal, semi-major, semi-minor) gemäß `c=d/2`, `a=(d+Δ)/2`, `b=sqrt(a*a-c*c)` berechnet und bei ungültigen Eingaben `None` zurückgibt.
- Die alte `abs(d - echo_distance_m)`-Logik wurde entfernt und durch Aufruf des neuen Helpers in `_draw_echo_ellipse_for_overlay` ersetzt; Mittelpunkt, Rotation entlang `RX->Messpunkt`, parametrisierte Punkt-Erzeugung und Zeichenstil bleiben unverändert.
- Guards ergänzt für fehlende/`NaN`/`inf`-Werte, `echo_distance_m < 0`, degenerierten Fall `Δ == 0` (führt zu `b == 0`) und numerische Stabilität (`a*a - c*c` sehr klein negativ durch Rundung wird auf `0` gesetzt).
- Dateien geändert: `transceiver/mission_workflow_ui.py` (Helper + Anpassung Zeichnen) und `tests/test_mission_workflow_ui.py` (Unit-Tests für neue Geometrie).

### Testing
- Neue Unit-Tests hinzugefügt: `test_compute_bistatic_echo_ellipse_axes_uses_sum_path_geometry`, `test_compute_bistatic_echo_ellipse_points_satisfy_focus_distance_sum`, `test_compute_bistatic_echo_ellipse_axes_handles_zero_delta_without_crash`, `test_compute_bistatic_echo_ellipse_axes_rejects_negative_delta` in `tests/test_mission_workflow_ui.py`.
- Automatischer Testlauf `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py tests/test_mission_measurement_service.py` wurde ausgeführt und war erfolgreich: `40 passed`.
- Bestehende Measurement-Service-Tests blieben unverändert und grün, womit sichergestellt ist, dass die Messdaten-Herleitung (`distance_m` aus `delta_lag`) nicht verändert wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfacb2aa808321b0ab7666ea8d70bb)