### PR TITLE
Ergebnis-Tabelle: 'Pos.' Spalte mit x,y-Koordinaten hinzufügen

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -113,6 +113,26 @@ def test_format_distance_to_rx_for_table_returns_dash_without_rx_position() -> N
     assert distance == "-"
 
 
+def test_format_position_for_table_uses_one_decimal_for_x_and_y() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission_points = [
+        MeasurementPoint(id="p0", name="P0", x=3.24, y=-1.01, yaw=0.0),
+    ]
+
+    position = window._format_position_for_table({"point_index": 0})
+
+    assert position == "3.2,-1.0"
+
+
+def test_format_position_for_table_returns_dash_without_known_point() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission_points = []
+
+    position = window._format_position_for_table({"point_index": 0})
+
+    assert position == "-"
+
+
 def test_parse_lidar_scan_text_for_overlay_supports_inline_ranges() -> None:
     parsed = MissionWorkflowWindow._parse_lidar_scan_text_for_overlay(
         "angle_min: -1.57\nangle_increment: 0.1\nranges: [1.0, 2.5, inf, nan]\n"

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -494,6 +494,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         columns = (
             "measurement_idx",
             "idx",
+            "position",
             "distance_to_rx_m",
             "echo_1_m",
             "echo_2_m",
@@ -507,6 +508,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         headings = {
             "measurement_idx": "Messung",
             "idx": "Punktindex",
+            "position": "Pos.",
             "distance_to_rx_m": "Abstand",
             "echo_1_m": f"{ECHO_HEADING_MARKERS[0]} E1",
             "echo_2_m": f"{ECHO_HEADING_MARKERS[1]} E2",
@@ -519,6 +521,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self.results_table.heading(key, text=title)
             self.results_table.column(key, stretch=True, width=110)
         self.results_table.column("measurement_idx", width=80)
+        self.results_table.column("position", width=100)
         self.results_table.column("distance_to_rx_m", width=90)
         self.results_table.column("echo_1_m", width=80)
         self.results_table.column("echo_2_m", width=80)
@@ -2530,6 +2533,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             error_text = f"{error_text}: {review_detail}" if error_text else review_detail
         combined_status = self._compose_table_outcome(payload, error_text)
         echo_distances = self._format_echo_distances_for_table(result.get("echo_delays"))
+        position_text = self._format_position_for_table(payload)
         distance_to_rx = self._format_distance_to_rx_for_table(payload)
         self.results_table.insert(
             "",
@@ -2537,6 +2541,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             values=(
                 self._format_one_based_index(payload.get("global_index")),
                 self._format_one_based_index(payload.get("point_index")),
+                position_text,
                 distance_to_rx,
                 *echo_distances,
                 combined_status,
@@ -2624,6 +2629,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not math.isfinite(distance_m):
             return "-"
         return f"{distance_m:.2f}".rstrip("0").rstrip(".")
+
+    def _format_position_for_table(self, payload: dict[str, Any]) -> str:
+        point = self._selected_record_point(payload)
+        if point is None:
+            return "-"
+        return f"{point.x:.1f},{point.y:.1f}"
 
     def _on_run_finished(self, state: str) -> None:
         self._stop_live_label_ticker()


### PR DESCRIPTION
### Motivation
- Die Ergebnistabelle im Mission-Workflow soll die Messpunkt-Koordinaten direkt anzeigen, damit Bediener schnell die Position der jeweiligen Messung sehen können.
- Positionswerte sollen als kommagetrennte `x,y`-Paar mit einer Dezimalstelle dargestellt werden (z. B. `3.2,-1.0`).

### Description
- Fügt die neue Spalte `position` mit Überschrift `Pos.` zur `Treeview`-Definition in `transceiver/mission_workflow_ui.py` hinzu und konfiguriert deren Breite (`self.results_table.column("position", width=100)`).
- Ergänzt beim Einfügen von Ergebniszeilen den eingefügten Wert um `position_text`, das vor `distance_to_rx` eingefügt wird (`self.results_table.insert(..., values=(..., position_text, distance_to_rx, ...))`).
- Implementiert die Hilfsfunktion `def _format_position_for_table(self, payload: dict[str, Any]) -> str` in `transceiver/mission_workflow_ui.py`, die `-` zurückgibt, wenn kein Punkt bekannt ist, oder `f"{point.x:.1f},{point.y:.1f}"` otherwise.
- Fügt zwei Unit-Tests in `tests/test_mission_workflow_ui.py` hinzu: `test_format_position_for_table_uses_one_decimal_for_x_and_y` und `test_format_position_for_table_returns_dash_without_known_point`.

### Testing
- Running `pytest -q tests/test_mission_workflow_ui.py -k "position_for_table or distance_to_rx_for_table"` ohne `PYTHONPATH` schlug fehl in dieser Umgebung mit `ModuleNotFoundError: No module named 'transceiver'` (Umgebungsabhängigkeit). 
- Mit korrektem Importpfad wurde `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "position_for_table or distance_to_rx_for_table"` ausgeführt und alle relevanten Tests bestanden (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfad1cfdb48321a535b49dcc7d107c)