### PR TITLE
Ensure crosscorr drag updates manual_lags so LOS-Echo stats refresh

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -2919,8 +2919,10 @@ def _plot_on_pg(
                     echo_text.setText("LOS-Echos: --")
             _position_echo_text()
 
-        def _wrap_drag(callback):
+        def _wrap_drag(kind: str, callback):
             def _handler(idx, lag):
+                if manual_lags is not None and kind in ("los", "echo"):
+                    manual_lags[kind] = int(round(lag))
                 if callback is not None:
                     callback(idx, lag)
                 _update_echo_text()
@@ -3015,10 +3017,10 @@ def _plot_on_pg(
             los_label_item.setPos(float(los_lags[los_idx]), float(los_mag[los_idx]))
             plot.addItem(los_label_item)
 
-        los_drag_callback = _wrap_drag(on_los_drag)
-        echo_drag_callback = _wrap_drag(on_echo_drag)
-        los_end_callback = _wrap_drag(on_los_drag_end)
-        echo_end_callback = _wrap_drag(on_echo_drag_end)
+        los_drag_callback = _wrap_drag("los", on_los_drag)
+        echo_drag_callback = _wrap_drag("echo", on_echo_drag)
+        los_end_callback = _wrap_drag("los", on_los_drag_end)
+        echo_end_callback = _wrap_drag("echo", on_echo_drag_end)
         los_marker, echo_markers = _add_draggable_markers(
             plot,
             lags,


### PR DESCRIPTION
### Motivation
- Fix a bug where dragging LOS/Echo markers did not persist the new lag into `manual_lags`, so the "LOS-Echos" distance text in the lower-left stats block did not update.

### Description
- Change `_wrap_drag` in `transceiver/__main__.py` to accept a `kind` (`"los"` / `"echo"`) and write the rounded lag into `manual_lags[kind]` when present, and wire the drag callbacks as `_wrap_drag("los", ...)` / `_wrap_drag("echo", ...)`, while preserving any external callbacks.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` which succeeded with `9 passed` tests; an initial run without `PYTHONPATH` failed during collection due to `ModuleNotFoundError` (expected without package path).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfae971d2c83218595c3ec82110529)