### PR TITLE
Fix LOS drag updating echo distances in cross-correlation views

### DIFF
--- a/tests/test_correlation_utils.py
+++ b/tests/test_correlation_utils.py
@@ -151,6 +151,30 @@ def test_resolve_manual_los_idx_resets_outdated_group_selection() -> None:
     assert manual_lags["los"] is None
 
 
+
+
+def test_resolve_manual_los_idx_keeps_manual_selection_when_unconstrained() -> None:
+    lags = np.array([-50, -40, -30, -20, -10, 0, 10, 20, 30, 40, 50], dtype=float)
+    base_los_idx = 8
+    highest_idx = 8
+    period_samples = 40
+    peak_group_indices = [7, 8, 9]
+    manual_lags = {"los": -20, "echo": None}
+
+    los_idx, was_reset = resolve_manual_los_idx(
+        lags,
+        base_los_idx,
+        manual_lags,
+        peak_group_indices=peak_group_indices,
+        highest_idx=highest_idx,
+        period_samples=period_samples,
+        constrain_to_peak_group=False,
+    )
+
+    assert was_reset is False
+    assert los_idx == 3
+    assert manual_lags["los"] == -20
+
 def test_classify_peak_group_returns_sorted_group_and_echoes() -> None:
     n = 220
     mag = _sinc_lobe(n, 80, 0.9) + _sinc_lobe(n, 120, 1.0) + _sinc_lobe(n, 150, 0.75)

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1892,6 +1892,7 @@ def _build_crosscorr_ctx(
         peak_group_indices=current_peak_group,
         highest_idx=highest_idx,
         period_samples=period_samples,
+        constrain_to_peak_group=False,
     )
     filtered_echo_indices = _filter_peak_indices_to_period_group(
         los_lags,
@@ -2888,6 +2889,7 @@ def _plot_on_pg(
                 peak_group_indices=current_peak_group,
                 highest_idx=peak_source_highest_idx,
                 period_samples=period_samples,
+                constrain_to_peak_group=False,
             )
             adj_echo_indices = _echo_indices_for_los(adj_los_idx)
             adj_group_indices = (
@@ -3334,6 +3336,7 @@ def _plot_on_mpl(
             peak_group_indices=current_peak_group,
             highest_idx=highest_idx,
             period_samples=period_samples,
+            constrain_to_peak_group=False,
         )
         filtered_echo_indices = _filter_peak_indices_to_period_group(
             los_lags,

--- a/transceiver/helpers/correlation_utils.py
+++ b/transceiver/helpers/correlation_utils.py
@@ -252,6 +252,7 @@ def resolve_manual_los_idx(
     peak_group_indices: list[int] | None = None,
     highest_idx: int | None = None,
     period_samples: int | None = None,
+    constrain_to_peak_group: bool = True,
 ) -> tuple[int | None, bool]:
     """Return LOS idx with optional validation against the active peak group.
 
@@ -273,7 +274,7 @@ def resolve_manual_los_idx(
     manual_idx = int(np.abs(lags - manual_los).argmin())
     allow_manual = True
 
-    if peak_group_indices:
+    if constrain_to_peak_group and peak_group_indices:
         normalized = {
             int(idx)
             for idx in peak_group_indices
@@ -283,7 +284,8 @@ def resolve_manual_los_idx(
             allow_manual = False
 
     if (
-        allow_manual
+        constrain_to_peak_group
+        and allow_manual
         and highest_idx is not None
         and period_samples is not None
         and period_samples > 1


### PR DESCRIPTION
### Motivation
- Dragging the LOS marker did not update the displayed Echo 1/2/... distances because a manual LOS selection was getting reset to the auto-detected peak group. 
- The interactive cross-correlation views (PyQtGraph preview and opened review dialog / Matplotlib view) must allow the LOS to move freely so echo distance labels follow immediately.

### Description
- Add a new optional parameter `constrain_to_peak_group: bool = True` to `resolve_manual_los_idx` so callers can opt out of automatic peak-group validation. 
- Only apply the peak-group constraint when `constrain_to_peak_group` is true, preserving previous behavior by default in non-interactive code paths. 
- Disable the constraint in the interactive plotting and review code paths in `transceiver/__main__.py` so LOS drag/click updates immediately affect the echo indices/labels. 
- Add a regression test `test_resolve_manual_los_idx_keeps_manual_selection_when_unconstrained` to `tests/test_correlation_utils.py` that verifies an unconstrained manual LOS selection is preserved.

### Testing
- Running `pytest -q tests/test_correlation_utils.py tests/test_crosscorr_normalization.py` without setting `PYTHONPATH` failed during collection with `ModuleNotFoundError: transceiver` (environment issue). 
- Running `PYTHONPATH=. pytest -q tests/test_correlation_utils.py tests/test_crosscorr_normalization.py` completed successfully with `21 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfb056a96c8321be1395c13b4ccf10)