### PR TITLE
Fix LOS/echo marker dragging in measurement workflow review plot

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1440,7 +1440,8 @@ class DraggableLagMarker(pg.ScatterPlotItem):
         brush = pg.mkBrush(color)
         super().__init__(symbol="o", size=size, pen=pen, brush=brush)
         self.setZValue(10)
-        self.setAcceptedMouseButtons(QtCore.Qt.LeftButton)
+        left_button = getattr(QtCore.Qt, "LeftButton", QtCore.Qt.MouseButton.LeftButton)
+        self.setAcceptedMouseButtons(left_button)
         self._update_position(self._index)
 
     def _update_position(self, index: int) -> None:
@@ -1452,11 +1453,17 @@ class DraggableLagMarker(pg.ScatterPlotItem):
         self._update_position(index)
 
     def mouseDragEvent(self, ev) -> None:
-        if ev.button() != QtCore.Qt.LeftButton:
+        left_button = getattr(QtCore.Qt, "LeftButton", QtCore.Qt.MouseButton.LeftButton)
+        active_buttons = getattr(ev, "buttons", lambda: left_button)()
+        if ev.isStart() and ev.button() != left_button:
+            ev.ignore()
+            return
+        if not ev.isStart() and not (active_buttons & left_button):
             ev.ignore()
             return
         if ev.isStart():
             self._dragging = True
+            ev.accept()
         if not self._dragging:
             ev.ignore()
             return
@@ -1794,16 +1801,19 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             return
 
         def _handle_click(ev) -> None:
-            if ev.button() != QtCore.Qt.LeftButton:
+            left_button = getattr(QtCore.Qt, "LeftButton", QtCore.Qt.MouseButton.LeftButton)
+            shift_modifier = getattr(QtCore.Qt, "ShiftModifier", QtCore.Qt.KeyboardModifier.ShiftModifier)
+            alt_modifier = getattr(QtCore.Qt, "AltModifier", QtCore.Qt.KeyboardModifier.AltModifier)
+            if ev.button() != left_button:
                 return
             modifiers = ev.modifiers()
-            if not (modifiers & QtCore.Qt.ShiftModifier or modifiers & QtCore.Qt.AltModifier):
+            if not (modifiers & shift_modifier or modifiers & alt_modifier):
                 return
             pos = self._plot.getViewBox().mapSceneToView(ev.scenePos())
-            if modifiers & QtCore.Qt.ShiftModifier:
+            if modifiers & shift_modifier:
                 idx = int(np.abs(self._lags - pos.x()).argmin())
                 self._apply_manual_lag("los", float(self._lags[idx]))
-            if modifiers & QtCore.Qt.AltModifier:
+            if modifiers & alt_modifier:
                 idx = int(np.abs(self._lags - pos.x()).argmin())
                 self._apply_manual_lag("echo", float(self._lags[idx]))
 
@@ -3038,16 +3048,19 @@ def _plot_on_pg(
         )
         if scene is not None and manual_lags is not None:
             def _handle_click(ev) -> None:
-                if ev.button() != QtCore.Qt.LeftButton:
+                left_button = getattr(QtCore.Qt, "LeftButton", QtCore.Qt.MouseButton.LeftButton)
+                shift_modifier = getattr(QtCore.Qt, "ShiftModifier", QtCore.Qt.KeyboardModifier.ShiftModifier)
+                alt_modifier = getattr(QtCore.Qt, "AltModifier", QtCore.Qt.KeyboardModifier.AltModifier)
+                if ev.button() != left_button:
                     return
                 modifiers = ev.modifiers()
                 if not (
-                    modifiers & QtCore.Qt.ShiftModifier
-                    or modifiers & QtCore.Qt.AltModifier
+                    modifiers & shift_modifier
+                    or modifiers & alt_modifier
                 ):
                     return
                 pos = plot.getViewBox().mapSceneToView(ev.scenePos())
-                if modifiers & QtCore.Qt.ShiftModifier:
+                if modifiers & shift_modifier:
                     idx = int(np.abs(los_lags - pos.x()).argmin())
                     lag_value = float(los_lags[idx])
                     manual_lags["los"] = int(round(lag_value))
@@ -3056,7 +3069,7 @@ def _plot_on_pg(
                     callback = los_drag_callback or los_end_callback
                     if callback is not None:
                         callback(idx, lag_value)
-                if modifiers & QtCore.Qt.AltModifier:
+                if modifiers & alt_modifier:
                     idx = int(np.abs(lags - pos.x()).argmin())
                     lag_value = float(lags[idx])
                     manual_lags["echo"] = int(round(lag_value))


### PR DESCRIPTION
### Motivation
- The LOS/Echo draggable markers and modifier-click handlers were unreliable under different Qt/PySide6 enum variants, causing drag and click interactions in the measurement review to fail.
- Drag events sometimes weren't recognized because the mouse-button enum and active-button checks were incompatible across Qt versions.

### Description
- Make the accepted mouse button resolution robust by using `getattr(QtCore.Qt, "LeftButton", QtCore.Qt.MouseButton.LeftButton)` before calling `setAcceptedMouseButtons` in `transceiver/__main__.py`.
- Improve drag handling by checking active buttons via `ev.buttons()` with a fallback and explicitly accepting the start event in `DraggableLagMarker.mouseDragEvent` to ensure consistent drag lifecycle handling.
- Replace direct references to `QtCore.Qt.ShiftModifier`/`AltModifier` with guarded `getattr` lookups for `ShiftModifier`/`AltModifier` (falling back to `QtCore.Qt.KeyboardModifier.*`) and apply these in both the review dialog and plot click handlers in `transceiver/__main__.py`.

### Testing
- Ran `pytest -q tests/test_mission_workflow_ui.py` without `PYTHONPATH` which failed during collection due to import setup (expected test environment issue).
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` which completed successfully with `34 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfb4addf988321a6faa9b38d692891)