### PR TITLE
Ergänze „Live Abstand“ Spalte in Ergebnistabelle des Mission-Workflows

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -116,6 +116,30 @@ def test_format_distance_to_rx_for_table_returns_dash_without_rx_position() -> N
     assert distance == "-"
 
 
+def test_format_live_distance_to_tx_for_table_uses_live_position_and_point() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission_points = [
+        MeasurementPoint(id="p0", name="P0", x=4.0, y=6.0, yaw=0.0),
+    ]
+
+    distance = window._format_live_distance_to_tx_for_table(
+        {"point_index": 0, "live_position_at_measurement": {"x": 1.0, "y": 2.0}}
+    )
+
+    assert distance == "5"
+
+
+def test_format_live_distance_to_tx_for_table_returns_dash_without_live_position() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission_points = [
+        MeasurementPoint(id="p0", name="P0", x=4.0, y=6.0, yaw=0.0),
+    ]
+
+    distance = window._format_live_distance_to_tx_for_table({"point_index": 0})
+
+    assert distance == "-"
+
+
 def test_format_position_for_table_uses_one_decimal_for_x_and_y() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._mission_points = [

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -522,6 +522,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "position",
             "live_position",
             "distance_to_rx_m",
+            "live_distance_to_tx_m",
             "echo_1_m",
             "echo_2_m",
             "echo_3_m",
@@ -537,6 +538,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "position": "Pos.",
             "live_position": "Live Pos.",
             "distance_to_rx_m": "Abstand",
+            "live_distance_to_tx_m": "Live Abstand",
             "echo_1_m": f"{ECHO_HEADING_MARKERS[0]} E1",
             "echo_2_m": f"{ECHO_HEADING_MARKERS[1]} E2",
             "echo_3_m": f"{ECHO_HEADING_MARKERS[2]} E3",
@@ -551,6 +553,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.results_table.column("position", width=100)
         self.results_table.column("live_position", width=100)
         self.results_table.column("distance_to_rx_m", width=90)
+        self.results_table.column("live_distance_to_tx_m", width=100)
         self.results_table.column("echo_1_m", width=80)
         self.results_table.column("echo_2_m", width=80)
         self.results_table.column("echo_3_m", width=80)
@@ -2577,6 +2580,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         position_text = self._format_position_for_table(payload)
         live_position_text = self._format_live_position_for_table(payload)
         distance_to_rx = self._format_distance_to_rx_for_table(payload)
+        live_distance_to_tx = self._format_live_distance_to_tx_for_table(payload)
         self.results_table.insert(
             "",
             "end",
@@ -2586,6 +2590,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 position_text,
                 live_position_text,
                 distance_to_rx,
+                live_distance_to_tx,
                 *echo_distances,
                 combined_status,
             ),
@@ -2692,6 +2697,24 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not math.isfinite(x) or not math.isfinite(y):
             return "-"
         return f"{x:.1f},{y:.1f}"
+
+    def _format_live_distance_to_tx_for_table(self, payload: dict[str, Any]) -> str:
+        point = self._selected_record_point(payload)
+        position = payload.get("live_position_at_measurement")
+        if point is None or not isinstance(position, dict):
+            return "-"
+        x_value = position.get("x")
+        y_value = position.get("y")
+        if not isinstance(x_value, (int, float)) or not isinstance(y_value, (int, float)):
+            return "-"
+        live_x = float(x_value)
+        live_y = float(y_value)
+        if not math.isfinite(live_x) or not math.isfinite(live_y):
+            return "-"
+        distance_m = math.hypot(point.x - live_x, point.y - live_y)
+        if not math.isfinite(distance_m):
+            return "-"
+        return f"{distance_m:.2f}".rstrip("0").rstrip(".")
 
     def _copy_live_position(self) -> dict[str, Any] | None:
         if not isinstance(self._live_position, dict):


### PR DESCRIPTION
### Motivation
- In der Ergebnistabelle des Mission-Workflows soll neben der Spalte `Abstand` eine Spalte `Live Abstand` angezeigt werden, die den Abstand vom Missions-TX-Punkt zur Live-Position beim Messbeginn zeigt.

### Description
- Füge die neue Spalte `"live_distance_to_tx_m"` in die `columns`-Definition und die `headings`-Zuordnung mit dem Titel `Live Abstand` hinzu. 
- Lege die Spaltenbreite für `live_distance_to_tx_m` auf `100` fest und registriere die Spalten-Heading im Treeview-Setup. 
- Erweitere `_on_record` um das Einfügen des neuen Wertes mittels `live_distance_to_tx = self._format_live_distance_to_tx_for_table(payload)` in die `self.results_table.insert(...)`-Aufrufwerte. 
- Implementiere die Hilfsmethode `_format_live_distance_to_tx_for_table(payload)` zur Berechnung der euklidischen Distanz zwischen Missionspunkt und Live-Position (mit Formatierung) und füge zwei Unit-Tests in `tests/test_mission_workflow_ui.py` hinzu, die korrekte Berechnung und Fallback (`"-"`) prüfen.

### Testing
- Ein initialer `pytest -q tests/test_mission_workflow_ui.py` ohne gesetzten Importpfad schlug fehl mit einem ImportError wegen fehlendem `PYTHONPATH` (erwartetes Umgebungsproblem). 
- Mit gesetztem Pfad wurde `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` ausgeführt und alle Tests liefen durch (`36 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfba5c684c8321b9981800585c3be6)