### PR TITLE
Fix LOS/Echo drag handling in measurement review plot

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -2804,6 +2804,10 @@ def _plot_on_pg(
             plot.setTitle("No TX data")
             plot.showGrid(x=True, y=True)
             return
+        # Keep left-button dragging dedicated to LOS/echo marker interaction.
+        # Otherwise the default ViewBox panning steals drag gestures and moves
+        # only the viewport instead of the selected marker.
+        plot.getViewBox().setMouseEnabled(x=False, y=False)
         step_r = step
         compare_available = crosscorr_compare is not None and crosscorr_compare.size
         if reduce_data:


### PR DESCRIPTION
### Motivation
- Left-button drag gestures in the cross-correlation review plot were being captured by the default PyQtGraph `ViewBox` panning, so attempts to drag LOS/Echo markers only panned the viewport instead of moving the markers.

### Description
- In `_plot_on_pg` for `mode == "Crosscorr"` disable the ViewBox mouse panning via `plot.getViewBox().setMouseEnabled(x=False, y=False)` so left-button drags are dedicated to `DraggableLagMarker` marker interaction.

### Testing
- Ran `python -m pytest -q tests/test_mission_workflow_ui.py` — `34 passed`.
- Ran `python -m pytest -q tests/test_receive_for_mission_threading.py -k review_measurement_for_mission` — `2 passed, 5 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfba6dcd9c8321b1c3b99bd8b411af)