### PR TITLE
Fix LOS/Echo drag interaction in mission review dialog

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1675,6 +1675,10 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
 
     def _render_plot(self) -> None:
         self._plot.clear()
+        # Keep left-button drag gestures reserved for LOS/Echo marker edits.
+        # Otherwise the default ViewBox panning consumes the drag and only
+        # shifts the viewport instead of moving the selected marker.
+        self._plot.getViewBox().setMouseEnabled(x=False, y=False)
         self._plot.plot(
             self._lags,
             self._magnitudes,
@@ -1738,6 +1742,16 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
         )
         if y_range is not None:
             self._plot.setYRange(*y_range, padding=0.0)
+
+        _add_draggable_markers(
+            self._plot,
+            self._lags,
+            self._magnitudes,
+            self._selected_los_idx,
+            self._selected_echo_indices,
+            on_los_drag_end=lambda _idx, lag: self._apply_manual_lag("los", lag),
+            on_echo_drag_end=lambda _idx, lag: self._apply_manual_lag("echo", lag),
+        )
 
         self._update_stats_label()
 


### PR DESCRIPTION
### Motivation
- In the Mission Measurement Review the left-button drag gestures were being consumed by the plot viewport panning so dragging LOS / Echo markers moved the view instead of the markers.
- The change reserves left-drag for peak editing so operators can reposition LOS / Echo peaks via drag-and-drop.

### Description
- Disable view-box panning in the review plot by calling `self._plot.getViewBox().setMouseEnabled(x=False, y=False)` during plot render. 
- Attach draggable markers to the review plot by calling `_add_draggable_markers(...)` and wire `on_los_drag_end` / `on_echo_drag_end` to `self._apply_manual_lag(...)` so marker moves update manual lag selection.
- Modified file: `transceiver/__main__.py` (update to `MissionMeasurementReviewDialog._render_plot`).

### Testing
- Ran `pytest -q tests/test_receive_for_mission_threading.py` without `PYTHONPATH` which failed at collection due to import path, so tests were rerun with `PYTHONPATH=.`.
- Ran `PYTHONPATH=. pytest -q tests/test_receive_for_mission_threading.py` and it passed: `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfbb5ffdac8321a569d2f660db1eff)