### PR TITLE
Compute Live Abstand from recorded TX target (use payload.point.target)

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -140,6 +140,23 @@ def test_format_live_distance_to_tx_for_table_returns_dash_without_live_position
     assert distance == "-"
 
 
+def test_format_live_distance_to_tx_for_table_prefers_record_tx_target_coordinates() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission_points = [
+        MeasurementPoint(id="p0", name="P0", x=100.0, y=100.0, yaw=0.0),
+    ]
+
+    distance = window._format_live_distance_to_tx_for_table(
+        {
+            "point_index": 0,
+            "point": {"target": {"x": 4.0, "y": 6.0}},
+            "live_position_at_measurement": {"x": 1.0, "y": 2.0},
+        }
+    )
+
+    assert distance == "5"
+
+
 def test_format_position_for_table_uses_one_decimal_for_x_and_y() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._mission_points = [

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2699,9 +2699,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         return f"{x:.1f},{y:.1f}"
 
     def _format_live_distance_to_tx_for_table(self, payload: dict[str, Any]) -> str:
-        point = self._selected_record_point(payload)
+        tx_position = self._tx_position_for_record(payload)
         position = payload.get("live_position_at_measurement")
-        if point is None or not isinstance(position, dict):
+        if tx_position is None or not isinstance(position, dict):
             return "-"
         x_value = position.get("x")
         y_value = position.get("y")
@@ -2711,10 +2711,27 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         live_y = float(y_value)
         if not math.isfinite(live_x) or not math.isfinite(live_y):
             return "-"
-        distance_m = math.hypot(point.x - live_x, point.y - live_y)
+        distance_m = math.hypot(tx_position[0] - live_x, tx_position[1] - live_y)
         if not math.isfinite(distance_m):
             return "-"
         return f"{distance_m:.2f}".rstrip("0").rstrip(".")
+
+    def _tx_position_for_record(self, payload: dict[str, Any]) -> tuple[float, float] | None:
+        point_payload = payload.get("point")
+        if isinstance(point_payload, dict):
+            target = point_payload.get("target")
+            if isinstance(target, dict):
+                x_value = target.get("x")
+                y_value = target.get("y")
+                if isinstance(x_value, (int, float)) and isinstance(y_value, (int, float)):
+                    x = float(x_value)
+                    y = float(y_value)
+                    if math.isfinite(x) and math.isfinite(y):
+                        return (x, y)
+        point = self._selected_record_point(payload)
+        if point is None:
+            return None
+        return (point.x, point.y)
 
     def _copy_live_position(self) -> dict[str, Any] | None:
         if not isinstance(self._live_position, dict):


### PR DESCRIPTION
### Motivation
- The "Live Abstand" column in the results table measured distance between the mission list point and the live position instead of the actual TX target recorded with the point, which is incorrect when the recorded TX target differs from the mission point.
- The intent is to show the distance from the TX (as recorded for the measurement) to the live position so the column reflects the real transmitter-to-live distance at measurement time.

### Description
- Change `MissionWorkflowWindow._format_live_distance_to_tx_for_table` to compute the distance against the record's TX coordinates by using a new helper `._tx_position_for_record(payload)` instead of always reading the mission point coordinates.
- Add helper `MissionWorkflowWindow._tx_position_for_record` which extracts `payload['point']['target'].x/y` when present and falls back to `._selected_record_point(payload)` for backward compatibility.
- Add regression test `test_format_live_distance_to_tx_for_table_prefers_record_tx_target_coordinates` to ensure `payload.point.target` is preferred over mission-point coordinates.

### Testing
- Running `pytest -q tests/test_mission_workflow_ui.py -k "live_distance_to_tx"` without `PYTHONPATH` failed during collection with `ModuleNotFoundError: transceiver` due to the test environment not finding the package.
- Re-running with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "live_distance_to_tx"` succeeded and reported `3 passed, 34 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfbbe216dc83219528554199fd1f2a)