### PR TITLE
Fix MissionMeasurementReviewDialog echo marker drag updates

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -55,6 +55,7 @@ from transceiver.__main__ import (
     _build_crosscorr_ctx,
     _format_echo_delay_display,
     _format_rx_stats_rows,
+    _update_echo_indices_after_manual_drag,
 )
 
 
@@ -178,6 +179,28 @@ def test_format_rx_stats_rows_does_not_scale_echo_when_interpolation_not_applied
 
     as_dict = dict(rows)
     assert as_dict["LOS-Echo"] == "12 samp (18.0 m)"
+
+
+def test_update_echo_indices_after_manual_drag_updates_selected_marker_slot() -> None:
+    lags = np.array([-20, -10, 0, 10, 20], dtype=float)
+    updated = _update_echo_indices_after_manual_drag(
+        lags,
+        echo_indices=[1, 3, 4],
+        marker_slot=1,
+        lag_value=0.1,
+    )
+    assert updated == [1, 2, 4]
+
+
+def test_update_echo_indices_after_manual_drag_deduplicates_indices() -> None:
+    lags = np.array([-20, -10, 0, 10, 20], dtype=float)
+    updated = _update_echo_indices_after_manual_drag(
+        lags,
+        echo_indices=[1, 3, 4],
+        marker_slot=2,
+        lag_value=10.0,
+    )
+    assert updated == [1, 3]
 
 
 class _DummyEntryWidget:

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1577,6 +1577,33 @@ def _echo_delay_samples(
     return int(abs(lags[echo_idx] - lags[los_idx]))
 
 
+def _update_echo_indices_after_manual_drag(
+    lags: np.ndarray,
+    echo_indices: list[int],
+    marker_slot: int,
+    lag_value: float,
+) -> list[int]:
+    """Update one Echo marker slot to the nearest lag index.
+
+    ``marker_slot`` refers to the visible Echo marker order (Echo 1..N).
+    Duplicate indices are removed while preserving left-to-right marker order.
+    """
+    if marker_slot < 0 or marker_slot >= len(echo_indices):
+        return [int(idx) for idx in echo_indices]
+    updated = [int(idx) for idx in echo_indices]
+    nearest_idx = int(np.abs(np.asarray(lags) - float(lag_value)).argmin())
+    updated[marker_slot] = nearest_idx
+
+    deduplicated: list[int] = []
+    seen: set[int] = set()
+    for idx in updated:
+        if idx in seen:
+            continue
+        seen.add(idx)
+        deduplicated.append(idx)
+    return deduplicated
+
+
 class MissionMeasurementReviewDialog(QtWidgets.QDialog):
     """Blocking review dialog for mission cross-correlation peaks."""
 
@@ -1743,15 +1770,29 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
         if y_range is not None:
             self._plot.setYRange(*y_range, padding=0.0)
 
-        _add_draggable_markers(
-            self._plot,
-            self._lags,
-            self._magnitudes,
-            self._selected_los_idx,
-            self._selected_echo_indices,
-            on_los_drag_end=lambda _idx, lag: self._apply_manual_lag("los", lag),
-            on_echo_drag_end=lambda _idx, lag: self._apply_manual_lag("echo", lag),
-        )
+        view_box = self._plot.getViewBox()
+        if self._selected_los_idx is not None:
+            los_marker = DraggableLagMarker(
+                view_box,
+                self._lags,
+                self._magnitudes,
+                self._selected_los_idx,
+                PLOT_COLORS["los"],
+                on_drag_end=lambda _idx, lag: self._apply_manual_lag("los", lag),
+            )
+            self._plot.addItem(los_marker)
+        echo_palette = [PLOT_COLORS["echo"], *XCORR_EXTRA_PEAK_COLORS]
+        for marker_slot, echo_idx in enumerate(self._selected_echo_indices):
+            marker_color = echo_palette[marker_slot % len(echo_palette)]
+            echo_marker = DraggableLagMarker(
+                view_box,
+                self._lags,
+                self._magnitudes,
+                int(echo_idx),
+                marker_color,
+                on_drag_end=lambda _idx, lag, slot=marker_slot: self._apply_manual_echo_lag(slot, lag),
+            )
+            self._plot.addItem(echo_marker)
 
         self._update_stats_label()
 
@@ -1800,6 +1841,17 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
                 if echo_idx is None or int(idx) != int(echo_idx)
             )
             self._selected_echo_indices = reordered
+        self._render_plot()
+
+    def _apply_manual_echo_lag(self, marker_slot: int, lag_value: float) -> None:
+        self._manual_lags["echo"] = int(round(lag_value))
+        self._selected_echo_indices = _update_echo_indices_after_manual_drag(
+            self._lags,
+            self._selected_echo_indices,
+            int(marker_slot),
+            float(lag_value),
+        )
+        self._base_echo_indices = [int(idx) for idx in self._selected_echo_indices]
         self._render_plot()
 
     def _update_stats_label(self) -> None:


### PR DESCRIPTION
### Motivation

- Dragging individual echo markers in the mission measurement review previously did not update the LOS-Echo distances shown in the dialog and saved result because marker drags only updated a generic echo selection instead of the specific marker slot.
- The change ensures manual per-marker edits update the correct echo slot and that duplicate indices are handled, so the stats label and exported measurement data reflect the user edits.

### Description

- Add helper `_update_echo_indices_after_manual_drag(lags, echo_indices, marker_slot, lag_value)` to map a dragged marker to the nearest lag index and deduplicate while preserving left-to-right order.
- Replace the generic marker creation in `MissionMeasurementReviewDialog._render_plot` with explicit per-marker `DraggableLagMarker` instances that bind their `on_drag_end` to the marker slot, so each echo marker updates its own slot.
- Add `MissionMeasurementReviewDialog._apply_manual_echo_lag` which updates `self._manual_lags`, recomputes `self._selected_echo_indices` via the new helper, updates `self._base_echo_indices`, and re-renders the plot.
- Add unit tests `test_update_echo_indices_after_manual_drag_updates_selected_marker_slot` and `test_update_echo_indices_after_manual_drag_deduplicates_indices` in `tests/test_crosscorr_normalization.py` to cover slot-specific updates and deduplication.

### Testing

- Ran `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` which passed with `11 passed`.
- An initial `pytest` run without `PYTHONPATH` failed during collection due to a missing import (`ModuleNotFoundError: No module named 'transceiver'`) but this is an environment invocation issue and the tests pass when run with `PYTHONPATH=.` as shown above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfbce3b4cc83218b742191edf03374)