### PR TITLE
Hide redundant highest-peak marker at LOS in cross-correlation popup

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -3018,7 +3018,7 @@ def _plot_on_pg(
             extra_legend.setData([0], [0])
             legend.addItem(extra_legend, "lokale Maxima")
 
-        if peak_source_highest_idx is not None:
+        if peak_source_highest_idx is not None and peak_source_highest_idx != los_idx:
             plot.plot(
                 [los_lags[peak_source_highest_idx]],
                 [los_mag[peak_source_highest_idx]],


### PR DESCRIPTION
### Motivation
- The cross-correlation PyQt popup showed both a white triangle for the highest peak and a red LOS marker when they refer to the same index, creating a redundant visual; keep the LOS indicated only by the LOS marker.

### Description
- Add a guard in `transceiver/__main__.py` so the white "highest peak" triangle is only drawn when `peak_source_highest_idx` is not equal to `los_idx` (avoid redundant marker).

### Testing
- Running `pytest -q tests/test_crosscorr_normalization.py` without `PYTHONPATH` failed during collection with `ModuleNotFoundError: transceiver` due to test environment import path configuration. 
- Running `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` succeeded with `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfbda38d408321bcae808e345b0de2)