### PR TITLE
Fix: Echo-Abstände aktualisieren nach Verschieben von LOS/Echo im Mission-Review

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -232,3 +232,39 @@ def test_rx_interpolation_factor_prefers_single_value_on_single_tab() -> None:
 
     value = TransceiverUI._rx_interpolation_factor_text(dummy)  # type: ignore[arg-type]
     assert value == "5"
+
+
+def test_review_manual_los_drag_updates_echo_distances() -> None:
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._selected_los_idx = 0
+    dialog._selected_echo_indices = [2, 3]
+    dialog._base_echo_indices = [2, 3]
+    dialog._render_plot = lambda: None
+
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    MissionMeasurementReviewDialog._apply_manual_lag(dialog, "los", 10.0)
+
+    delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
+    assert dialog._selected_los_idx == 1
+    assert delays == [10, 20]
+
+
+def test_review_manual_echo_click_updates_first_echo_distance() -> None:
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._selected_los_idx = 0
+    dialog._selected_echo_indices = [2, 3]
+    dialog._base_echo_indices = [2, 3]
+    dialog._render_plot = lambda: None
+
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    MissionMeasurementReviewDialog._apply_manual_lag(dialog, "echo", 10.0)
+
+    delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
+    assert dialog._selected_echo_indices == [1, 3]
+    assert delays == [10, 30]

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1817,31 +1817,24 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
     def _apply_manual_lag(self, kind: str, lag_value: float) -> None:
         if kind not in ("los", "echo"):
             return
+
+        nearest_idx = int(np.abs(self._lags - float(lag_value)).argmin())
         self._manual_lags[kind] = int(round(lag_value))
-        base_echo_idx = None
-        if self._selected_los_idx is not None and self._base_echo_indices:
-            base_echo_idx = min(
-                self._base_echo_indices,
-                key=lambda idx: abs(float(self._lags[int(idx)]) - float(self._lags[int(self._selected_los_idx)])),
+
+        if kind == "los":
+            self._selected_los_idx = nearest_idx
+            self._render_plot()
+            return
+
+        if self._selected_echo_indices:
+            self._selected_echo_indices = _update_echo_indices_after_manual_drag(
+                self._lags,
+                self._selected_echo_indices,
+                0,
+                float(lag_value),
             )
-        los_idx, echo_idx = _apply_manual_lags(
-            self._lags,
-            self._selected_los_idx,
-            base_echo_idx,
-            self._manual_lags,
-        )
-        self._selected_los_idx = los_idx
-        if los_idx is None:
-            self._selected_echo_indices = []
-        else:
-            reordered = [int(echo_idx)] if echo_idx is not None else []
-            reordered.extend(
-                int(idx)
-                for idx in self._base_echo_indices
-                if echo_idx is None or int(idx) != int(echo_idx)
-            )
-            self._selected_echo_indices = reordered
-        self._render_plot()
+            self._base_echo_indices = [int(idx) for idx in self._selected_echo_indices]
+            self._render_plot()
 
     def _apply_manual_echo_lag(self, marker_slot: int, lag_value: float) -> None:
         self._manual_lags["echo"] = int(round(lag_value))


### PR DESCRIPTION
### Motivation
- Beim manuellen Verschieben von LOS- oder Echo-Markern im Mission-Review wurden die angezeigten Echo-Abstandswerte nicht korrekt neu berechnet, weil die alte Logik die Auswahl über den gemeinsamen `manual_lags`-Pfad neu berechnete und dabei die ursprüngliche Marker-Ordnung verfälschen konnte.
- Ziel ist, LOS- und Echo-Änderungen deterministisch zu handhaben und die Statistik-/Overlay-Anzeige sofort konsistent zu aktualisieren.

### Description
- Vereinfachung von `MissionMeasurementReviewDialog._apply_manual_lag` so, dass der nächstliegende Index (`nearest_idx`) direkt berechnet wird und LOS-Drags nur `self._selected_los_idx` setzen und neu rendern. (Änderung in `transceiver/__main__.py`).
- Alt+Click-/Echo-Anpassungen aktualisieren deterministisch nur den ersten Echo-Slot via `_update_echo_indices_after_manual_drag` und setzen danach `self._base_echo_indices` bevor das Plotting neu gerendert wird. (Änderung in `transceiver/__main__.py`).
- Zwei Regressionstests hinzugefügt, die prüfen, dass ein manueller LOS-Drag bzw. ein manueller Echo-Drag die berechneten `echo_delays` anpasst. (Änderungen in `tests/test_crosscorr_normalization.py`).
- Betroffene Dateien: `transceiver/__main__.py` und `tests/test_crosscorr_normalization.py`.

### Testing
- `pytest -q tests/test_crosscorr_normalization.py` initially failed during collection due to missing import path (ModuleNotFoundError), which is an environment issue and not test logic failure. 
- `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` succeeded with `13 passed` and exit code 0, confirming the new logic and added tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfbf77133c8321b34df928fec3a218)