### PR TITLE
Fix duplicate echo markers in mission review graph

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1721,30 +1721,12 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
 
         if self._selected_los_idx is not None:
             los_idx_int = int(self._selected_los_idx)
-            self._plot.plot(
-                [float(self._lags[los_idx_int])],
-                [float(self._magnitudes[los_idx_int])],
-                pen=None,
-                symbol="o",
-                symbolSize=9,
-                symbolBrush=pg.mkBrush(PLOT_COLORS["los"]),
-                symbolPen=pg.mkPen(PLOT_COLORS["los"]),
-            )
             los_label_item = pg.TextItem("LOS", color=PLOT_COLORS["text"], anchor=(0, 1))
             los_label_item.setPos(float(self._lags[los_idx_int]), float(self._magnitudes[los_idx_int]))
             self._plot.addItem(los_label_item)
 
         for peak_idx in self._selected_echo_indices:
             idx = int(peak_idx)
-            self._plot.plot(
-                [float(self._lags[idx])],
-                [float(self._magnitudes[idx])],
-                pen=None,
-                symbol="o",
-                symbolSize=8,
-                symbolBrush=pg.mkBrush(PLOT_COLORS["echo"]),
-                symbolPen=pg.mkPen(PLOT_COLORS["echo"]),
-            )
             label_value = peak_labels.get(idx)
             label_text = f"Echo {label_value}" if label_value is not None else "Echo"
             label_item = pg.TextItem(label_text, color=PLOT_COLORS["text"], anchor=(0, 1))
@@ -3072,8 +3054,11 @@ def _plot_on_pg(
 
         peak_labels = _crosscorr_peak_labels(visible_group_indices)
 
+        selected_echo_idx_set = {int(idx) for idx in filtered_echo_indices}
         for color_idx, peak_idx in enumerate(visible_peak_indices):
             if peak_idx == los_idx:
+                continue
+            if int(peak_idx) in selected_echo_idx_set:
                 continue
             c = XCORR_EXTRA_PEAK_COLORS[color_idx % len(XCORR_EXTRA_PEAK_COLORS)]
             plot.plot(


### PR DESCRIPTION
### Motivation
- The manual lag editor and mission-review cross-correlation plot rendered both static marker dots and separate draggable markers for the same LOS/echo points, which caused a fixed (non-draggable) point to appear under the draggable marker after a drag operation.

### Description
- Removed static plotting of LOS and selected echo symbols in `_render_plot` so the draggable `DraggableLagMarker` is the single visible representation for selected points in the manual lag editor (`transceiver/__main__.py`).
- In the cross-correlation review plot code, skip drawing local-maxima symbols for echo indices that are currently selected by building `selected_echo_idx_set` and continuing when a peak is selected (`transceiver/__main__.py`).
- These changes prevent a hidden fixed point from being revealed beneath the draggable marker when a point is moved.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py tests/test_mission_measurement_service.py` and all tests passed with `42 passed`.
- Running `pytest -q tests/test_mission_workflow_ui.py tests/test_mission_measurement_service.py` without `PYTHONPATH=.` fails to import the package due to `ModuleNotFoundError`, so the explicit `PYTHONPATH=.` command is noted as the successful invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfc17915d483219959e2e346d69fb7)