### PR TITLE
Update mission review: live-update echo distances while dragging

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -268,3 +268,39 @@ def test_review_manual_echo_click_updates_first_echo_distance() -> None:
     delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
     assert dialog._selected_echo_indices == [1, 3]
     assert delays == [10, 30]
+
+
+def test_review_drag_preview_updates_echo_distances_live() -> None:
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._selected_los_idx = 0
+    dialog._selected_echo_indices = [2, 3]
+    dialog._base_echo_indices = [2, 3]
+    dialog._update_stats_label = lambda: None
+
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    MissionMeasurementReviewDialog._preview_manual_lag(dialog, "los", 10.0)
+
+    delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
+    assert dialog._selected_los_idx == 1
+    assert delays == [10, 20]
+
+
+def test_review_echo_drag_preview_updates_selected_slot_live() -> None:
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._selected_los_idx = 0
+    dialog._selected_echo_indices = [2, 3]
+    dialog._base_echo_indices = [2, 3]
+    dialog._update_stats_label = lambda: None
+
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    MissionMeasurementReviewDialog._preview_manual_echo_lag(dialog, 1, 10.0)
+
+    delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
+    assert dialog._selected_echo_indices == [2, 1]
+    assert delays == [20, 10]

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1760,6 +1760,7 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
                 self._magnitudes,
                 self._selected_los_idx,
                 PLOT_COLORS["los"],
+                on_drag=lambda _idx, lag: self._preview_manual_lag("los", lag),
                 on_drag_end=lambda _idx, lag: self._apply_manual_lag("los", lag),
             )
             self._plot.addItem(los_marker)
@@ -1772,6 +1773,7 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
                 self._magnitudes,
                 int(echo_idx),
                 marker_color,
+                on_drag=lambda _idx, lag, slot=marker_slot: self._preview_manual_echo_lag(slot, lag),
                 on_drag_end=lambda _idx, lag, slot=marker_slot: self._apply_manual_echo_lag(slot, lag),
             )
             self._plot.addItem(echo_marker)
@@ -1818,6 +1820,27 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             self._base_echo_indices = [int(idx) for idx in self._selected_echo_indices]
             self._render_plot()
 
+    def _preview_manual_lag(self, kind: str, lag_value: float) -> None:
+        if kind not in ("los", "echo"):
+            return
+
+        nearest_idx = int(np.abs(self._lags - float(lag_value)).argmin())
+        self._manual_lags[kind] = int(round(lag_value))
+
+        if kind == "los":
+            self._selected_los_idx = nearest_idx
+            self._update_stats_label()
+            return
+
+        if self._selected_echo_indices:
+            self._selected_echo_indices = _update_echo_indices_after_manual_drag(
+                self._lags,
+                self._selected_echo_indices,
+                0,
+                float(lag_value),
+            )
+            self._update_stats_label()
+
     def _apply_manual_echo_lag(self, marker_slot: int, lag_value: float) -> None:
         self._manual_lags["echo"] = int(round(lag_value))
         self._selected_echo_indices = _update_echo_indices_after_manual_drag(
@@ -1828,6 +1851,16 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
         )
         self._base_echo_indices = [int(idx) for idx in self._selected_echo_indices]
         self._render_plot()
+
+    def _preview_manual_echo_lag(self, marker_slot: int, lag_value: float) -> None:
+        self._manual_lags["echo"] = int(round(lag_value))
+        self._selected_echo_indices = _update_echo_indices_after_manual_drag(
+            self._lags,
+            self._selected_echo_indices,
+            int(marker_slot),
+            float(lag_value),
+        )
+        self._update_stats_label()
 
     def _update_stats_label(self) -> None:
         if self._selected_los_idx is None or not self._selected_echo_indices:


### PR DESCRIPTION
### Motivation
- Improve UX in the Mission Measurement Review dialog by making LOS/Echo distance stats update immediately while the user drags markers instead of only after drag end.
- Provide a non-destructive live preview so the final drag-end behavior and re-render remain unchanged.

### Description
- Wire `DraggableLagMarker` instances to new live-preview callbacks by adding `on_drag` handlers for LOS and Echo markers in `transceiver/__main__.py`.
- Add `_preview_manual_lag` and `_preview_manual_echo_lag` methods that update selected LOS/Echo indices and call `_update_stats_label()` during dragging without triggering a full re-render.
- Keep existing `_apply_manual_lag` and `_apply_manual_echo_lag` behavior on drag end to perform the final index updates and full re-render.
- Add two regression tests in `tests/test_crosscorr_normalization.py` that assert live-preview updates for LOS dragging and Echo-slot dragging.

### Testing
- Running `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` executed the cross-correlation tests and all tests passed (`15 passed`).
- Running `pytest -q tests/test_crosscorr_normalization.py` without `PYTHONPATH` in this environment raised `ModuleNotFoundError` due to import path setup, which is an environment issue and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfc298dba083218a10dc9c781e3bd3)