### PR TITLE
Fix cross-correlation review echo drag slot selection

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -270,6 +270,24 @@ def test_review_manual_echo_click_updates_first_echo_distance() -> None:
     assert delays == [10, 30]
 
 
+def test_review_manual_echo_drag_fallback_updates_nearest_echo_slot() -> None:
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0, 40.0, 50.0], dtype=float)
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._selected_los_idx = 0
+    dialog._selected_echo_indices = [1, 4]
+    dialog._base_echo_indices = [1, 4]
+    dialog._render_plot = lambda: None
+
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    MissionMeasurementReviewDialog._apply_manual_lag(dialog, "echo", 30.0)
+
+    delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
+    assert dialog._selected_echo_indices == [1, 3]
+    assert delays == [10, 30]
+
+
 def test_review_drag_preview_updates_echo_distances_live() -> None:
     dialog = types.SimpleNamespace()
     dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)
@@ -286,6 +304,24 @@ def test_review_drag_preview_updates_echo_distances_live() -> None:
     delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
     assert dialog._selected_los_idx == 1
     assert delays == [10, 20]
+
+
+def test_review_echo_drag_preview_fallback_updates_nearest_echo_slot() -> None:
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0, 40.0, 50.0], dtype=float)
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._selected_los_idx = 0
+    dialog._selected_echo_indices = [1, 4]
+    dialog._base_echo_indices = [1, 4]
+    dialog._update_stats_label = lambda: None
+
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    MissionMeasurementReviewDialog._preview_manual_lag(dialog, "echo", 30.0)
+
+    delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
+    assert dialog._selected_echo_indices == [1, 3]
+    assert delays == [10, 30]
 
 
 def test_review_echo_drag_preview_updates_selected_slot_live() -> None:

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1604,6 +1604,29 @@ def _update_echo_indices_after_manual_drag(
     return deduplicated
 
 
+def _nearest_echo_marker_slot(
+    lags: np.ndarray,
+    echo_indices: list[int],
+    lag_value: float,
+) -> int:
+    """Return the Echo marker slot whose current lag is nearest to ``lag_value``."""
+    if not echo_indices:
+        return 0
+    lag_array = np.asarray(lags, dtype=float)
+    target_lag = float(lag_value)
+    nearest_slot = 0
+    nearest_distance = float("inf")
+    for slot, echo_idx in enumerate(echo_indices):
+        idx = int(echo_idx)
+        if idx < 0 or idx >= lag_array.size:
+            continue
+        distance = abs(float(lag_array[idx]) - target_lag)
+        if distance < nearest_distance:
+            nearest_distance = distance
+            nearest_slot = slot
+    return int(nearest_slot)
+
+
 class MissionMeasurementReviewDialog(QtWidgets.QDialog):
     """Blocking review dialog for mission cross-correlation peaks."""
 
@@ -1811,10 +1834,15 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             return
 
         if self._selected_echo_indices:
+            marker_slot = _nearest_echo_marker_slot(
+                self._lags,
+                self._selected_echo_indices,
+                float(lag_value),
+            )
             self._selected_echo_indices = _update_echo_indices_after_manual_drag(
                 self._lags,
                 self._selected_echo_indices,
-                0,
+                marker_slot,
                 float(lag_value),
             )
             self._base_echo_indices = [int(idx) for idx in self._selected_echo_indices]
@@ -1833,10 +1861,15 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             return
 
         if self._selected_echo_indices:
+            marker_slot = _nearest_echo_marker_slot(
+                self._lags,
+                self._selected_echo_indices,
+                float(lag_value),
+            )
             self._selected_echo_indices = _update_echo_indices_after_manual_drag(
                 self._lags,
                 self._selected_echo_indices,
-                0,
+                marker_slot,
                 float(lag_value),
             )
             self._update_stats_label()


### PR DESCRIPTION
### Motivation
- Dragging an echo marker in the cross-correlation PyQt review dialog always updated the first visible Echo slot (Echo 1) when a generic echo update was applied, causing the wrong echo distance to be changed when other echoes were moved.

### Description
- Add helper `_nearest_echo_marker_slot(lags, echo_indices, lag_value)` to pick the currently-selected echo marker slot whose lag is nearest to a given `lag_value`.
- Use `_nearest_echo_marker_slot` in `MissionMeasurementReviewDialog._apply_manual_lag(..., "echo", ...)` and `_preview_manual_lag(..., "echo", ...)` so fallback updates modify the nearest selected marker rather than always slot `0`.
- Add two regression tests `test_review_manual_echo_drag_fallback_updates_nearest_echo_slot` and `test_review_echo_drag_preview_fallback_updates_nearest_echo_slot` to cover the non-first-echo fallback behavior.

### Testing
- Ran `pytest -q tests/test_crosscorr_normalization.py` which initially errored when invoked without `PYTHONPATH` due to `ModuleNotFoundError: transceiver`.
- Ran `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfc4571a588321ac3dfb06c98e2036)