### PR TITLE
Add 'Live Abstand' column to mission workflow results and compute live RX distance

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -116,6 +116,26 @@ def test_format_distance_to_rx_for_table_returns_dash_without_rx_position() -> N
     assert distance == "-"
 
 
+def test_format_live_distance_to_rx_for_table_uses_live_position_coordinates() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._rx_antenna_global_position = (1.0, 2.0)
+
+    distance = window._format_live_distance_to_rx_for_table(
+        {"live_position_at_measurement": {"x": 4.0, "y": 6.0}}
+    )
+
+    assert distance == "5"
+
+
+def test_format_live_distance_to_rx_for_table_returns_dash_without_live_position() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._rx_antenna_global_position = (1.0, 2.0)
+
+    distance = window._format_live_distance_to_rx_for_table({"point_index": 0})
+
+    assert distance == "-"
+
+
 def test_format_position_for_table_uses_one_decimal_for_x_and_y() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._mission_points = [

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -522,6 +522,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "position",
             "live_position",
             "distance_to_rx_m",
+            "live_distance_to_rx_m",
             "echo_1_m",
             "echo_2_m",
             "echo_3_m",
@@ -537,6 +538,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "position": "Pos.",
             "live_position": "Live Pos.",
             "distance_to_rx_m": "Abstand",
+            "live_distance_to_rx_m": "Live Abstand",
             "echo_1_m": f"{ECHO_HEADING_MARKERS[0]} E1",
             "echo_2_m": f"{ECHO_HEADING_MARKERS[1]} E2",
             "echo_3_m": f"{ECHO_HEADING_MARKERS[2]} E3",
@@ -551,6 +553,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.results_table.column("position", width=100)
         self.results_table.column("live_position", width=100)
         self.results_table.column("distance_to_rx_m", width=90)
+        self.results_table.column("live_distance_to_rx_m", width=90)
         self.results_table.column("echo_1_m", width=80)
         self.results_table.column("echo_2_m", width=80)
         self.results_table.column("echo_3_m", width=80)
@@ -2577,6 +2580,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         position_text = self._format_position_for_table(payload)
         live_position_text = self._format_live_position_for_table(payload)
         distance_to_rx = self._format_distance_to_rx_for_table(payload)
+        live_distance_to_rx = self._format_live_distance_to_rx_for_table(payload)
         self.results_table.insert(
             "",
             "end",
@@ -2586,6 +2590,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 position_text,
                 live_position_text,
                 distance_to_rx,
+                live_distance_to_rx,
                 *echo_distances,
                 combined_status,
             ),
@@ -2669,6 +2674,26 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if point is None:
             return "-"
         distance_m = math.hypot(point.x - rx_position[0], point.y - rx_position[1])
+        if not math.isfinite(distance_m):
+            return "-"
+        return f"{distance_m:.2f}".rstrip("0").rstrip(".")
+
+    def _format_live_distance_to_rx_for_table(self, payload: dict[str, Any]) -> str:
+        rx_position = self._rx_antenna_global_position
+        if rx_position is None:
+            return "-"
+        position = payload.get("live_position_at_measurement")
+        if not isinstance(position, dict):
+            return "-"
+        x_value = position.get("x")
+        y_value = position.get("y")
+        if not isinstance(x_value, (int, float)) or not isinstance(y_value, (int, float)):
+            return "-"
+        x = float(x_value)
+        y = float(y_value)
+        if not math.isfinite(x) or not math.isfinite(y):
+            return "-"
+        distance_m = math.hypot(x - rx_position[0], y - rx_position[1])
         if not math.isfinite(distance_m):
             return "-"
         return f"{distance_m:.2f}".rstrip("0").rstrip(".")


### PR DESCRIPTION
### Motivation
- Provide a visible, per-measurement live distance value in the mission results table that shows the distance between the RX antenna global coordinates and the live position captured at the time of the measurement.

### Description
- Add a new column `live_distance_to_rx_m` with heading "Live Abstand" to the results `Treeview` and set a dedicated column width.
- Populate the new column when inserting a measurement record by calling a new helper `_format_live_distance_to_rx_for_table(...)` next to the existing `distance_to_rx_m` value.
- Implement `_format_live_distance_to_rx_for_table(...)` which computes `math.hypot(x - rx_x, y - rx_y)` from `live_position_at_measurement` and `_rx_antenna_global_position` and returns `"-"` for missing/invalid inputs.
- Add unit tests in `tests/test_mission_workflow_ui.py` to verify correct numeric formatting and fallback behavior for the live-distance formatter.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py`, which executed the UI tests and completed successfully with `36 passed`.
- The added tests specifically for live-distance formatting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfc4a257d883219216193d94626ebd)