### PR TITLE
Add operator confirmation to continue mission after navigation failure

### DIFF
--- a/tests/test_measurement_run_executor.py
+++ b/tests/test_measurement_run_executor.py
@@ -146,6 +146,32 @@ def test_navigation_failure_retries_then_stop_mission() -> None:
     assert executor.records[0].status == "failed"
 
 
+def test_navigation_failure_can_continue_after_operator_confirmation() -> None:
+    nav = FakeNavigator(["timeout", "succeeded"])
+    measured: list[str] = []
+
+    def trigger(point: MeasurementPoint) -> dict:
+        measured.append(point.id or "")
+        return {"ok": True}
+
+    continue_calls: list[str] = []
+    executor = MeasurementRunExecutor(
+        mission=_mission(),
+        navigator=nav,
+        trigger_measurement=trigger,
+        persist_result=lambda _payload: None,
+        continue_after_point_failure=lambda record: continue_calls.append(record.error or "") or True,
+        config=MeasurementRunExecutorConfig(on_point_error="stop"),
+    )
+
+    final_state = executor.start()
+
+    assert final_state == "completed"
+    assert continue_calls == ["navigation_failed.timeout"]
+    assert [record.status for record in executor.records] == ["failed", "succeeded"]
+    assert measured == ["p2"]
+
+
 def test_state_transitions_start_pause_resume_stop() -> None:
     class CancelAwareNavigator(FakeNavigator):
         def __init__(self) -> None:

--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from transceiver.measurement_mission import MeasurementPoint
+from transceiver.measurement_run_executor import PointExecutionRecord
 from transceiver.mission_workflow_ui import MissionWorkflowWindow, _compute_bistatic_echo_ellipse_axes
 
 
@@ -270,6 +271,28 @@ def test_compute_bistatic_echo_ellipse_axes_handles_zero_delta_without_crash() -
 
 def test_compute_bistatic_echo_ellipse_axes_rejects_negative_delta() -> None:
     assert _compute_bistatic_echo_ellipse_axes(distance_rx_to_point=10.0, echo_distance_m=-0.1) is None
+
+
+def test_handle_point_failure_decision_continues_when_operator_confirms() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    logs: list[str] = []
+    window._append_validation = logs.append
+    window._ask_yes_no_on_ui_thread = lambda **_kwargs: True
+    record = PointExecutionRecord(
+        index=0,
+        point_id="p1",
+        point_name="A",
+        status="failed",
+        navigation_state="timeout",
+        navigation_attempts=1,
+        measurement_result=None,
+        error="navigation_failed.timeout",
+    )
+
+    should_continue = window._handle_point_failure_decision(record)
+
+    assert should_continue is True
+    assert "fortgesetzt" in logs[0]
 
 
 class _FakeAdapter:

--- a/transceiver/measurement_run_executor.py
+++ b/transceiver/measurement_run_executor.py
@@ -60,6 +60,11 @@ class RunSummaryStore(Protocol):
         ...
 
 
+class ContinueAfterPointFailureHandler(Protocol):
+    def __call__(self, record: PointExecutionRecord) -> bool:
+        ...
+
+
 @dataclass(frozen=True)
 class PointExecutionContext:
     mission_name: str
@@ -169,6 +174,7 @@ class MeasurementRunExecutor:
         persist_run_summary: RunSummaryStore | None = None,
         run_log_store: JsonRunLogStore | None = None,
         on_runtime_event: Callable[[dict[str, Any]], None] | None = None,
+        continue_after_point_failure: ContinueAfterPointFailureHandler | None = None,
         config: MeasurementRunExecutorConfig | None = None,
     ) -> None:
         self.mission = mission
@@ -181,6 +187,7 @@ class MeasurementRunExecutor:
         self.persist_run_summary = persist_run_summary
         self.run_log_store = run_log_store
         self.on_runtime_event = on_runtime_event
+        self.continue_after_point_failure = continue_after_point_failure
         self.config = config or MeasurementRunExecutorConfig()
         self._validate_start_point_index()
 
@@ -256,6 +263,8 @@ class MeasurementRunExecutor:
                 self.records.append(record)
 
                 if record.status == "failed" and self.config.on_point_error == "stop":
+                    if self._should_continue_after_point_failure(record):
+                        continue
                     with self._state_lock:
                         self._state = "failed"
                     abort_reason = record.error
@@ -296,6 +305,14 @@ class MeasurementRunExecutor:
             points_per_cycle=points_per_cycle,
         )
         return self.state
+
+    def _should_continue_after_point_failure(self, record: PointExecutionRecord) -> bool:
+        if self.continue_after_point_failure is None:
+            return False
+        try:
+            return bool(self.continue_after_point_failure(record))
+        except Exception:
+            return False
 
     @staticmethod
     def _resolve_measurement_service(

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -23,6 +23,7 @@ from .measurement_run_executor import (
     JsonRunLogStore,
     MeasurementRunExecutor,
     MeasurementRunExecutorConfig,
+    PointExecutionRecord,
 )
 from .mission_measurement_service import (
     MissionRxMeasurementService,
@@ -2097,6 +2098,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             persist_result=_persist,
             run_log_store=store,
             on_runtime_event=self._on_executor_runtime_event,
+            continue_after_point_failure=self._handle_point_failure_decision,
             config=MeasurementRunExecutorConfig(
                 on_point_error="stop",
                 goal_reached_timeout_s=self._runtime_config.goal_reached_timeout_s,
@@ -2112,6 +2114,53 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._set_run_buttons(running=True, paused=False)
         self._run_thread = threading.Thread(target=self._run_executor_thread, daemon=True)
         self._run_thread.start()
+
+    def _handle_point_failure_decision(self, record: PointExecutionRecord) -> bool:
+        if not (record.error or "").startswith("navigation_failed."):
+            return False
+        point_label = record.point_id or record.point_name or f"#{record.index + 1}"
+        prompt = (
+            f"Navigation zu Punkt {point_label} ist fehlgeschlagen.\n\n"
+            "Soll die Messung trotzdem mit dem nächsten Punkt fortgesetzt werden?"
+        )
+        should_continue = self._ask_yes_no_on_ui_thread(
+            title="Navigation fehlgeschlagen",
+            message=prompt,
+            default=False,
+        )
+        if should_continue:
+            self._append_validation(
+                f"⚠️ Navigation fehlgeschlagen ({record.error}) – Mission wird auf Operator-Wunsch fortgesetzt."
+            )
+        else:
+            self._append_validation(
+                f"❌ Navigation fehlgeschlagen ({record.error}) – Mission wird beendet."
+            )
+        return should_continue
+
+    def _ask_yes_no_on_ui_thread(self, *, title: str, message: str, default: bool = False) -> bool:
+        if threading.current_thread() is threading.main_thread():
+            try:
+                return bool(messagebox.askyesno(title, message, parent=self))
+            except Exception:
+                return default
+        result = {"value": default}
+        done = threading.Event()
+
+        def _ask() -> None:
+            try:
+                result["value"] = bool(messagebox.askyesno(title, message, parent=self))
+            except Exception:
+                result["value"] = default
+            finally:
+                done.set()
+
+        try:
+            self.after(0, _ask)
+        except Exception:
+            return default
+        done.wait()
+        return bool(result["value"])
 
     def _ensure_transmitter_before_run(self) -> bool:
         is_active_fn = getattr(self.master, "is_transmitter_active_for_mission", None)


### PR DESCRIPTION
### Motivation
- Bei Navigationfehlern im Missions-Workflow soll der Operator gefragt werden, ob die Messung trotzdem mit dem nächsten Wegpunkt fortgesetzt werden soll.
- Die Ausführung (executor) muss zur Laufzeit unterstützt werden, diese Entscheidung entgegenzunehmen, ohne bestehende Fehler-Handling-Logik zu brechen.

### Description
- Füge das `ContinueAfterPointFailureHandler`-Protocol und den optionalen Konstruktorparameter `continue_after_point_failure` zu `MeasurementRunExecutor` hinzu. (Datei: `transceiver/measurement_run_executor.py`)
- Nutze die neue Callback-Option beim Fehlerfall in `MeasurementRunExecutor.start()` um bei `on_point_error="stop"` optional weiterzufahren, falls der Callback dies erlaubt. (Datei: `transceiver/measurement_run_executor.py`)
- Implementiere im UI-Fenster `MissionWorkflowWindow` die Methode `_handle_point_failure_decision(record: PointExecutionRecord) -> bool`, die bei Navigationsfehlern eine Yes/No-Abfrage an den Operator stellt und das Ergebnis an den Executor weitergibt. (Datei: `transceiver/mission_workflow_ui.py`)
- Ergänze einen thread-sicheren Helfer `_ask_yes_no_on_ui_thread(...)`, damit die UI-Dialoge sicher aus dem Executor-Background-Thread aufgerufen werden können. (Datei: `transceiver/mission_workflow_ui.py`)
- Ergänze Tests: ein Executor-Test, der die Fortsetzung nach Navigationsfehler über den Callback prüft, und ein UI-Test für die Entscheidungslogik. (Dateien: `tests/test_measurement_run_executor.py`, `tests/test_mission_workflow_ui.py`)

### Testing
- Lauf 1: `pytest -q tests/test_measurement_run_executor.py tests/test_mission_workflow_ui.py` scheiterte mit `ModuleNotFoundError` wegen fehlendem `PYTHONPATH` beim Test-Collector (Import-Fehler), siehe Fehlerausgabe.
- Lauf 2: `PYTHONPATH=. pytest -q tests/test_measurement_run_executor.py tests/test_mission_workflow_ui.py` wurde ausgeführt und ergab `59 passed` (alle ausgeführten Tests bestanden).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfc5321b788321a4779f094579dfad)