### PR TITLE
Use live measurement position for echo ellipse overlay

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -137,6 +137,41 @@ def test_format_live_distance_to_rx_for_table_returns_dash_without_live_position
     assert distance == "-"
 
 
+def test_selected_record_measurement_position_reads_live_coordinates() -> None:
+    position = MissionWorkflowWindow._selected_record_measurement_position(
+        {"live_position_at_measurement": {"x": 1.25, "y": -3.5}}
+    )
+
+    assert position == (1.25, -3.5)
+
+
+def test_selected_record_measurement_position_returns_none_without_live_coordinates() -> None:
+    position = MissionWorkflowWindow._selected_record_measurement_position({"point_index": 0})
+
+    assert position is None
+
+
+def test_draw_selected_echo_overlay_uses_live_measurement_position() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._selected_result_index = 0
+    window._records = [
+        {
+            "point_index": 0,
+            "live_position_at_measurement": {"x": 7.0, "y": -2.0},
+            "measurement": {"result": {"echo_delays": [{"distance_m": 3.0}]}},
+        }
+    ]
+    window._rx_antenna_global_position = (1.0, 1.0)
+    window._mission_points = [MeasurementPoint(id="p0", name="P0", x=50.0, y=50.0, yaw=0.0)]
+    calls: list[dict[str, object]] = []
+    window._draw_echo_ellipse_for_overlay = lambda **kwargs: calls.append(kwargs)
+
+    window._draw_selected_echo_overlay()
+
+    assert len(calls) == 1
+    assert calls[0]["measurement_position"] == (7.0, -2.0)
+
+
 def test_format_position_for_table_uses_one_decimal_for_x_and_y() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._mission_points = [

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1186,11 +1186,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _draw_selected_echo_overlay(self) -> None:
         record = self._selected_record_payload()
-        point = self._selected_record_point(record)
-        if record is None or point is None:
+        if record is None:
             return
         rx_position = self._rx_antenna_global_position
         if rx_position is None:
+            return
+        measurement_position = self._selected_record_measurement_position(record)
+        if measurement_position is None:
             return
         measurement = record.get("measurement")
         if not isinstance(measurement, dict):
@@ -1205,7 +1207,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             color = ECHO_OVERLAY_COLORS[echo_index % len(ECHO_OVERLAY_COLORS)]
             self._draw_echo_ellipse_for_overlay(
                 rx_position=rx_position,
-                point=point,
+                measurement_position=measurement_position,
                 echo_distance_m=echo_distance,
                 color=color,
             )
@@ -1217,6 +1219,21 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not isinstance(point_index, int) or point_index < 0 or point_index >= len(self._mission_points):
             return None
         return self._mission_points[point_index]
+
+    @staticmethod
+    def _selected_record_measurement_position(record: dict[str, Any]) -> tuple[float, float] | None:
+        live_position = record.get("live_position_at_measurement")
+        if not isinstance(live_position, dict):
+            return None
+        x_value = live_position.get("x")
+        y_value = live_position.get("y")
+        if not isinstance(x_value, (int, float)) or not isinstance(y_value, (int, float)):
+            return None
+        x = float(x_value)
+        y = float(y_value)
+        if not math.isfinite(x) or not math.isfinite(y):
+            return None
+        return (x, y)
 
     @staticmethod
     def _extract_echo_distances(value: Any, *, limit: int) -> list[float]:
@@ -1239,7 +1256,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self,
         *,
         rx_position: tuple[float, float],
-        point: MeasurementPoint,
+        measurement_position: tuple[float, float],
         echo_distance_m: float,
         color: str,
     ) -> None:
@@ -1251,16 +1268,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not math.isfinite(resolution) or resolution <= 0.0:
             return
         rx_x, rx_y = rx_position
+        point_x, point_y = measurement_position
         if (
             not math.isfinite(rx_x)
             or not math.isfinite(rx_y)
-            or not math.isfinite(point.x)
-            or not math.isfinite(point.y)
+            or not math.isfinite(point_x)
+            or not math.isfinite(point_y)
             or not math.isfinite(echo_distance_m)
             or echo_distance_m < 0.0
         ):
             return
-        distance_rx_to_point = math.hypot(point.x - rx_x, point.y - rx_y)
+        distance_rx_to_point = math.hypot(point_x - rx_x, point_y - rx_y)
         ellipse_axes = _compute_bistatic_echo_ellipse_axes(
             distance_rx_to_point=distance_rx_to_point,
             echo_distance_m=echo_distance_m,
@@ -1270,9 +1288,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         semi_focal_distance, semi_major_axis, semi_minor_axis = ellipse_axes
         if semi_minor_axis <= 0.0:
             return
-        center_x = (rx_x + point.x) / 2.0
-        center_y = (rx_y + point.y) / 2.0
-        angle = math.atan2(point.y - rx_y, point.x - rx_x)
+        center_x = (rx_x + point_x) / 2.0
+        center_y = (rx_y + point_y) / 2.0
+        angle = math.atan2(point_y - rx_y, point_x - rx_x)
         cos_angle = math.cos(angle)
         sin_angle = math.sin(angle)
         samples = 64


### PR DESCRIPTION
### Motivation
- The echo-ellipse overlay should be drawn from the actual live position recorded at measurement time (`live_position_at_measurement`) instead of the originally targeted mission waypoint to reflect the true measured geometry.

### Description
- Switch selected echo-ellipse generation to read `live_position_at_measurement` from the selected record and bail out when no valid live position is present by adding `_selected_record_measurement_position` for validation and normalization. 
- Change `_draw_selected_echo_overlay` to pass a `measurement_position` into `_draw_echo_ellipse_for_overlay` instead of using the mission `MeasurementPoint`. 
- Update `_draw_echo_ellipse_for_overlay` to accept `measurement_position: tuple[float, float]` and compute distance/center/angle from those coordinates. 
- Add unit tests in `tests/test_mission_workflow_ui.py` that verify parsing of live coordinates and that the selected-overlay flow uses the live measurement position.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` and the test file passed with `40 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfc69f7ce883218047e141df0026d7)