### PR TITLE
Preserve overlapping echo marker slots in review and hide duplicates in outputs

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -192,7 +192,7 @@ def test_update_echo_indices_after_manual_drag_updates_selected_marker_slot() ->
     assert updated == [1, 2, 4]
 
 
-def test_update_echo_indices_after_manual_drag_deduplicates_indices() -> None:
+def test_update_echo_indices_after_manual_drag_keeps_overlapping_slots() -> None:
     lags = np.array([-20, -10, 0, 10, 20], dtype=float)
     updated = _update_echo_indices_after_manual_drag(
         lags,
@@ -200,7 +200,7 @@ def test_update_echo_indices_after_manual_drag_deduplicates_indices() -> None:
         marker_slot=2,
         lag_value=10.0,
     )
-    assert updated == [1, 3]
+    assert updated == [1, 3, 3]
 
 
 class _DummyEntryWidget:
@@ -304,3 +304,17 @@ def test_review_echo_drag_preview_updates_selected_slot_live() -> None:
     delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
     assert dialog._selected_echo_indices == [2, 1]
     assert delays == [20, 10]
+
+
+def test_review_echo_delays_hide_duplicates_for_overlapping_markers() -> None:
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)
+    dialog._selected_los_idx = 0
+    dialog._selected_echo_indices = [2, 2, 3]
+    dialog._unique_echo_indices = MissionMeasurementReviewDialog._unique_echo_indices
+
+    delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
+
+    assert delays == [20, 30]

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1586,22 +1586,15 @@ def _update_echo_indices_after_manual_drag(
     """Update one Echo marker slot to the nearest lag index.
 
     ``marker_slot`` refers to the visible Echo marker order (Echo 1..N).
-    Duplicate indices are removed while preserving left-to-right marker order.
+    Duplicate indices are intentionally preserved so overlapping markers can
+    be separated again by dragging one marker away afterwards.
     """
     if marker_slot < 0 or marker_slot >= len(echo_indices):
         return [int(idx) for idx in echo_indices]
     updated = [int(idx) for idx in echo_indices]
     nearest_idx = int(np.abs(np.asarray(lags) - float(lag_value)).argmin())
     updated[marker_slot] = nearest_idx
-
-    deduplicated: list[int] = []
-    seen: set[int] = set()
-    for idx in updated:
-        if idx in seen:
-            continue
-        seen.add(idx)
-        deduplicated.append(idx)
-    return deduplicated
+    return updated
 
 
 class MissionMeasurementReviewDialog(QtWidgets.QDialog):
@@ -1686,7 +1679,7 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
 
     @property
     def selected_echo_indices(self) -> list[int]:
-        return list(self._selected_echo_indices)
+        return MissionMeasurementReviewDialog._unique_echo_indices(self._selected_echo_indices)
 
     @property
     def echo_delays(self) -> list[int]:
@@ -1694,11 +1687,23 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
         if los_idx is None:
             return []
         delays: list[int] = []
-        for echo_idx in self._selected_echo_indices:
+        for echo_idx in MissionMeasurementReviewDialog._unique_echo_indices(self._selected_echo_indices):
             delay = _echo_delay_samples(self._lags, los_idx, int(echo_idx))
             if delay is not None:
                 delays.append(int(delay))
         return delays
+
+    @staticmethod
+    def _unique_echo_indices(echo_indices: list[int]) -> list[int]:
+        unique_indices: list[int] = []
+        seen: set[int] = set()
+        for idx in echo_indices:
+            normalized_idx = int(idx)
+            if normalized_idx in seen:
+                continue
+            seen.add(normalized_idx)
+            unique_indices.append(normalized_idx)
+        return unique_indices
 
     def _render_plot(self) -> None:
         self._plot.clear()


### PR DESCRIPTION
### Motivation
- Dragging two echo markers exactly onto the same lag previously removed the second slot, preventing it from being dragged away again to restore its value.
- The UI should keep marker slots so an overlapped marker can be separated later, while still hiding duplicate echo values in the stats/output.

### Description
- ` _update_echo_indices_after_manual_drag` now preserves duplicate indices and returns the updated list so overlapping marker slots remain present.
- Added `MissionMeasurementReviewDialog._unique_echo_indices` to provide a deduplicated view for presentation and export.
- `selected_echo_indices` and `echo_delays` now use `_unique_echo_indices` so duplicate overlaps are hidden in the review stats and exported delays.
- Updated tests in `tests/test_crosscorr_normalization.py` to assert the new overlap-and-restore behavior and to verify duplicates are hidden for `echo_delays`.

### Testing
- `pytest -q tests/test_crosscorr_normalization.py` initially failed due to an import environment issue (`ModuleNotFoundError`).
- `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` succeeded with `16 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfc74483ec8321bbd276bc2db809e5)