### PR TITLE
Keep mission measurement review echo markers in correct order

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -203,6 +203,17 @@ def test_update_echo_indices_after_manual_drag_keeps_overlapping_slots() -> None
     assert updated == [1, 3, 3]
 
 
+def test_update_echo_indices_after_manual_drag_reorders_echoes_by_lag_position() -> None:
+    lags = np.array([-20, -10, 0, 10, 20], dtype=float)
+    updated = _update_echo_indices_after_manual_drag(
+        lags,
+        echo_indices=[1, 2],
+        marker_slot=0,
+        lag_value=15.0,
+    )
+    assert updated == [2, 3]
+
+
 class _DummyEntryWidget:
     def __init__(self, text: str) -> None:
         self._text = text
@@ -277,6 +288,7 @@ def test_review_drag_preview_updates_echo_distances_live() -> None:
     dialog._selected_los_idx = 0
     dialog._selected_echo_indices = [2, 3]
     dialog._base_echo_indices = [2, 3]
+    dialog._update_peak_label_positions = lambda: None
     dialog._update_stats_label = lambda: None
 
     from transceiver.__main__ import MissionMeasurementReviewDialog
@@ -295,6 +307,7 @@ def test_review_echo_drag_preview_updates_selected_slot_live() -> None:
     dialog._selected_los_idx = 0
     dialog._selected_echo_indices = [2, 3]
     dialog._base_echo_indices = [2, 3]
+    dialog._update_peak_label_positions = lambda: None
     dialog._update_stats_label = lambda: None
 
     from transceiver.__main__ import MissionMeasurementReviewDialog
@@ -302,8 +315,8 @@ def test_review_echo_drag_preview_updates_selected_slot_live() -> None:
     MissionMeasurementReviewDialog._preview_manual_echo_lag(dialog, 1, 10.0)
 
     delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
-    assert dialog._selected_echo_indices == [2, 1]
-    assert delays == [20, 10]
+    assert dialog._selected_echo_indices == [1, 2]
+    assert delays == [10, 20]
 
 
 def test_review_echo_delays_hide_duplicates_for_overlapping_markers() -> None:

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1594,7 +1594,8 @@ def _update_echo_indices_after_manual_drag(
     updated = [int(idx) for idx in echo_indices]
     nearest_idx = int(np.abs(np.asarray(lags) - float(lag_value)).argmin())
     updated[marker_slot] = nearest_idx
-    return updated
+    lags_array = np.asarray(lags, dtype=float)
+    return sorted(updated, key=lambda idx: float(lags_array[int(idx)]))
 
 
 class MissionMeasurementReviewDialog(QtWidgets.QDialog):


### PR DESCRIPTION
### Motivation
- Ensure that when echo markers are dragged in the Mission Measurement Review dialog their visible numbering (`Echo 1`, `Echo 2`, …) always reflects left-to-right lag order so names swap correctly when markers cross. 
- Prevent confusing label/order mismatches between marker positions and their displayed Echo numbers in the UI. 
- Add test coverage to lock the expected behavior for manual drag and preview flows.

### Description
- Change `_update_echo_indices_after_manual_drag` to return the updated echo indices sorted by their lag positions using the provided `lags` array instead of preserving the input order (file: `transceiver/__main__.py`).
- Add `test_update_echo_indices_after_manual_drag_reorders_echoes_by_lag_position` to validate reordering when a marker is dragged past another, and update existing preview tests to expect the reordered indices (file: `tests/test_crosscorr_normalization.py`).
- Add small test stubs (`_update_peak_label_positions`) in the preview tests to keep the dialog preview tests stable when using `types.SimpleNamespace` test doubles (file: `tests/test_crosscorr_normalization.py`).

### Testing
- Ran `pytest -q tests/test_crosscorr_normalization.py` without `PYTHONPATH` which failed to import the package as expected, indicating test environment import needs `PYTHONPATH` set. 
- Ran `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` twice during development where the first run revealed missing test stubs and then the second run after fixes completed successfully. 
- Final automated run `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` passed with `17 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfca0db350832183560a1339035a26)