### PR TITLE
Mission workflow: confirm and continue measurement on navigation failures

### DIFF
--- a/tests/test_measurement_run_executor.py
+++ b/tests/test_measurement_run_executor.py
@@ -146,6 +146,51 @@ def test_navigation_failure_retries_then_stop_mission() -> None:
     assert executor.records[0].status == "failed"
 
 
+def test_navigation_failure_can_continue_with_measurement_when_operator_confirms() -> None:
+    nav = FakeNavigator(["timeout"])
+    measured: list[str] = []
+
+    executor = MeasurementRunExecutor(
+        mission=MeasurementMission(name="m2", points=[_mission().points[0]], repeat=1),
+        navigator=nav,
+        trigger_measurement=lambda point: measured.append(point.id or "") or {"ok": True},
+        continue_after_navigation_failure=lambda **_kwargs: True,
+        persist_result=lambda _payload: None,
+        config=MeasurementRunExecutorConfig(on_point_error="stop"),
+    )
+
+    final_state = executor.start()
+
+    assert final_state == "completed"
+    assert measured == ["p1"]
+    assert len(executor.records) == 1
+    assert executor.records[0].status == "succeeded"
+    assert executor.records[0].navigation_state == "timeout"
+    assert executor.records[0].error == "navigation_failed.timeout"
+
+
+def test_navigation_failure_skips_measurement_when_operator_declines() -> None:
+    nav = FakeNavigator(["timeout"])
+    measured: list[str] = []
+
+    executor = MeasurementRunExecutor(
+        mission=MeasurementMission(name="m2", points=[_mission().points[0]], repeat=1),
+        navigator=nav,
+        trigger_measurement=lambda point: measured.append(point.id or "") or {"ok": True},
+        continue_after_navigation_failure=lambda **_kwargs: False,
+        persist_result=lambda _payload: None,
+        config=MeasurementRunExecutorConfig(on_point_error="continue"),
+    )
+
+    final_state = executor.start()
+
+    assert final_state == "completed"
+    assert measured == []
+    assert len(executor.records) == 1
+    assert executor.records[0].status == "failed"
+    assert executor.records[0].navigation_state == "timeout"
+
+
 def test_state_transitions_start_pause_resume_stop() -> None:
     class CancelAwareNavigator(FakeNavigator):
         def __init__(self) -> None:

--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -7,6 +7,7 @@ import pytest
 
 from transceiver.measurement_mission import MeasurementPoint
 from transceiver.mission_workflow_ui import MissionWorkflowWindow, _compute_bistatic_echo_ellipse_axes
+import transceiver.mission_workflow_ui as mission_workflow_ui
 
 
 def test_format_echo_distances_for_table_returns_only_meter_values_for_first_five_echoes() -> None:
@@ -90,6 +91,39 @@ def test_compose_table_outcome_includes_navigation_and_measurement_for_failures(
         MissionWorkflowWindow._compose_table_outcome(payload, "navigation_failed.aborted")
         == "navigation aborted, measurement skipped: navigation_failed.aborted"
     )
+
+
+def test_confirm_measurement_after_navigation_failure_uses_point_index_in_prompt() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.after = lambda _delay, callback: callback()
+    logs: list[str] = []
+    window._append_validation = logs.append
+
+    observed: dict[str, str] = {}
+
+    def _askyesno(title, message, parent):  # type: ignore[no-untyped-def]
+        observed["title"] = title
+        observed["message"] = message
+        assert parent is window
+        return True
+
+    original_askyesno = mission_workflow_ui.messagebox.askyesno
+    mission_workflow_ui.messagebox.askyesno = _askyesno
+    try:
+        decision = window._confirm_measurement_after_navigation_failure(
+            point_context=SimpleNamespace(global_index=2, point=SimpleNamespace(id="p003")),
+            navigation_state="timeout",
+            error="navigation_failed.timeout",
+        )
+    finally:
+        mission_workflow_ui.messagebox.askyesno = original_askyesno
+
+    assert decision is True
+    assert observed["title"] == "Navigation fehlgeschlagen"
+    assert "Punktindex 3" in observed["message"]
+    assert "p003" not in observed["message"]
+    assert logs
+    assert "Punktindex 3" in logs[0]
 
 
 def test_format_distance_to_rx_for_table_uses_measurement_point_coordinates() -> None:

--- a/transceiver/measurement_run_executor.py
+++ b/transceiver/measurement_run_executor.py
@@ -55,6 +55,17 @@ class MeasurementService(Protocol):
         ...
 
 
+class NavigationFailurePolicy(Protocol):
+    def __call__(
+        self,
+        *,
+        point_context: "PointExecutionContext",
+        navigation_state: TerminalNavigationState,
+        error: str,
+    ) -> bool:
+        ...
+
+
 class RunSummaryStore(Protocol):
     def __call__(self, payload: dict[str, Any]) -> None:
         ...
@@ -169,6 +180,7 @@ class MeasurementRunExecutor:
         persist_run_summary: RunSummaryStore | None = None,
         run_log_store: JsonRunLogStore | None = None,
         on_runtime_event: Callable[[dict[str, Any]], None] | None = None,
+        continue_after_navigation_failure: NavigationFailurePolicy | None = None,
         config: MeasurementRunExecutorConfig | None = None,
     ) -> None:
         self.mission = mission
@@ -181,6 +193,7 @@ class MeasurementRunExecutor:
         self.persist_run_summary = persist_run_summary
         self.run_log_store = run_log_store
         self.on_runtime_event = on_runtime_event
+        self.continue_after_navigation_failure = continue_after_navigation_failure
         self.config = config or MeasurementRunExecutorConfig()
         self._validate_start_point_index()
 
@@ -397,14 +410,107 @@ class MeasurementRunExecutor:
             self._cancel_confirmed = True
 
         if nav_state != "succeeded":
+            point_context = PointExecutionContext(
+                mission_name=self.mission.name,
+                cycle=cycle,
+                point_index=point_index,
+                global_index=global_index,
+                point=point,
+            )
             error = (
                 "run_cancelled.manual_stop"
                 if self._cancel_requested and nav_state == "canceled"
                 else f"navigation_failed.{nav_state}"
             )
-            status: PointExecutionStatus = "skipped" if self._cancel_requested and nav_state == "canceled" else "failed"
+            status: PointExecutionStatus = (
+                "skipped" if self._cancel_requested and nav_state == "canceled" else "failed"
+            )
             measurement_status = "skipped"
-            
+            if (
+                status == "failed"
+                and self.config.enable_measurements
+                and self.continue_after_navigation_failure is not None
+            ):
+                try:
+                    continue_measurement = self.continue_after_navigation_failure(
+                        point_context=point_context,
+                        navigation_state=nav_state,
+                        error=error,
+                    )
+                except Exception:
+                    continue_measurement = False
+                if continue_measurement:
+                    navigation_done_at = time.time()
+                    try:
+                        measurement_result = self.measurement_service.trigger(point_context)
+                    except Exception as exc:
+                        error_code = str(exc)
+                        review_reason: str | None = None
+                        review_detail: str | None = None
+                        if isinstance(exc, RuntimeError) and exc.args:
+                            first = exc.args[0]
+                            if isinstance(first, str) and first.strip():
+                                error_code = first.strip()
+                            if len(exc.args) > 1 and isinstance(exc.args[1], str) and exc.args[1].strip():
+                                review_reason = exc.args[1].strip()
+                            if len(exc.args) > 2 and isinstance(exc.args[2], str) and exc.args[2].strip():
+                                review_detail = exc.args[2].strip()
+                        failed_measurement_payload: dict[str, Any] | None = None
+                        if review_reason is not None or review_detail is not None:
+                            failed_measurement_payload = {
+                                "review": {
+                                    "approved": False,
+                                    "reason": review_reason,
+                                    "detail": review_detail,
+                                }
+                            }
+                        record = PointExecutionRecord(
+                            index=global_index,
+                            point_id=point.id,
+                            point_name=point.name,
+                            status="failed",
+                            navigation_state=nav_state,
+                            navigation_attempts=attempt,
+                            measurement_result=None,
+                            error=error_code,
+                        )
+                        self._persist_point_log(
+                            point=point,
+                            point_index=point_index,
+                            cycle=cycle,
+                            global_index=global_index,
+                            navigation_state=nav_state,
+                            navigation_attempts=attempt,
+                            point_started_at=point_started_at,
+                            measurement_result=failed_measurement_payload,
+                            measurement_status="failed",
+                            error=record.error,
+                            navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
+                        )
+                        return record
+                    self._persist_point_log(
+                        point=point,
+                        point_index=point_index,
+                        cycle=cycle,
+                        global_index=global_index,
+                        navigation_state=nav_state,
+                        navigation_attempts=attempt,
+                        point_started_at=point_started_at,
+                        measurement_result=measurement_result,
+                        measurement_status="succeeded",
+                        error=error,
+                        navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
+                    )
+                    return PointExecutionRecord(
+                        index=global_index,
+                        point_id=point.id,
+                        point_name=point.name,
+                        status="succeeded",
+                        navigation_state=nav_state,
+                        navigation_attempts=attempt,
+                        measurement_result=measurement_result,
+                        error=error,
+                    )
             record = PointExecutionRecord(
                 index=global_index,
                 point_id=point.id,

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2118,6 +2118,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             persist_result=_persist,
             run_log_store=store,
             on_runtime_event=self._on_executor_runtime_event,
+            continue_after_navigation_failure=self._confirm_measurement_after_navigation_failure,
             config=MeasurementRunExecutorConfig(
                 on_point_error="stop",
                 goal_reached_timeout_s=self._runtime_config.goal_reached_timeout_s,
@@ -2133,6 +2134,45 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._set_run_buttons(running=True, paused=False)
         self._run_thread = threading.Thread(target=self._run_executor_thread, daemon=True)
         self._run_thread.start()
+
+    def _confirm_measurement_after_navigation_failure(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        point_context,
+        navigation_state,
+        error,
+    ) -> bool:
+        decision_holder: dict[str, bool] = {"continue": False}
+        decision_ready = threading.Event()
+
+        def _ask_operator() -> None:
+            point_index = int(getattr(point_context, "global_index", 0)) + 1
+            state_label = str(navigation_state)
+            decision = messagebox.askyesno(
+                "Navigation fehlgeschlagen",
+                f"Navigation zu Punktindex {point_index} ist fehlgeschlagen ({state_label}).\n\n"
+                "Soll die Messung trotzdem durchgeführt werden?",
+                parent=self,
+            )
+            decision_holder["continue"] = bool(decision)
+            if decision:
+                self._append_validation(
+                    f"⚠️ Navigation fehlgeschlagen ({error}) bei Punktindex {point_index}; "
+                    "Messung wird trotzdem durchgeführt."
+                )
+            else:
+                self._append_validation(
+                    f"ℹ️ Navigation fehlgeschlagen ({error}) bei Punktindex {point_index}; "
+                    "Messung wird übersprungen."
+                )
+            decision_ready.set()
+
+        try:
+            self.after(0, _ask_operator)
+        except tk.TclError:
+            return False
+        decision_ready.wait()
+        return decision_holder["continue"]
 
     def _ensure_transmitter_before_run(self) -> bool:
         is_active_fn = getattr(self.master, "is_transmitter_active_for_mission", None)


### PR DESCRIPTION
### Motivation
- Allow the operator to decide whether to still perform a measurement when navigation to a waypoint fails so useful data can still be collected despite navigation issues. 
- Ensure the operator-facing prompt and logs refer to the waypoint by its UI index (1-based) rather than by internal point id.

### Description
- Add a `NavigationFailurePolicy` protocol and an optional `continue_after_navigation_failure` hook to `MeasurementRunExecutor` so callers can decide per-point whether to proceed with measurement after navigation failure by returning `True`/`False`.
- Extend `MeasurementRunExecutor._execute_point` to call the hook on navigation failure and, when it returns `True`, trigger and persist the measurement (keeping the navigation failure state/error in the persisted log and returned record).
- Wire the mission UI to the new hook by passing `continue_after_navigation_failure=self._confirm_measurement_after_navigation_failure` and implement `_confirm_measurement_after_navigation_failure` to ask the operator via `messagebox.askyesno`, referencing the 1-based point index and appending a validation log entry.
- Add unit tests: two executor tests for continuing/skipping measurements on navigation failure, and a UI test that checks the prompt uses the point index and not the point id.

### Testing
- Running `pytest -q tests/test_measurement_run_executor.py tests/test_mission_workflow_ui.py` initially failed to collect due to module import path (missing `PYTHONPATH`).
- Running `PYTHONPATH=. pytest -q tests/test_measurement_run_executor.py tests/test_mission_workflow_ui.py` succeeded with `65 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfcc0dafd88321b587a13cc7b7732c)