### PR TITLE
Prompt operator to continue measurement on navigation failure

### DIFF
--- a/tests/test_measurement_run_executor.py
+++ b/tests/test_measurement_run_executor.py
@@ -146,6 +146,43 @@ def test_navigation_failure_retries_then_stop_mission() -> None:
     assert executor.records[0].status == "failed"
 
 
+def test_navigation_failure_can_run_measurement_after_operator_confirmation() -> None:
+    nav = FakeNavigator(["timeout", "aborted"])
+    measured: list[int] = []
+    persisted: list[dict] = []
+    confirmations: list[tuple[int, str]] = []
+
+    def _confirm(point_context, nav_state: str) -> bool:
+        confirmations.append((point_context.global_index, nav_state))
+        return True
+
+    def _trigger(point: MeasurementPoint) -> dict:
+        measured.append(1)
+        return {"ok": point.id}
+
+    executor = MeasurementRunExecutor(
+        mission=MeasurementMission(name="m2", points=[_mission().points[0]], repeat=1),
+        navigator=nav,
+        trigger_measurement=_trigger,
+        persist_result=persisted.append,
+        config=MeasurementRunExecutorConfig(
+            navigation_retry_attempts=1,
+            on_point_error="stop",
+            confirm_measurement_after_navigation_failure=_confirm,
+        ),
+    )
+
+    final_state = executor.start()
+
+    assert final_state == "completed"
+    assert confirmations == [(0, "aborted")]
+    assert measured == [1]
+    assert executor.records[0].status == "succeeded"
+    assert executor.records[0].navigation_state == "aborted"
+    assert persisted[0]["measurement"]["status"] == "succeeded"
+    assert persisted[0]["navigation"]["state"] == "aborted"
+
+
 def test_state_transitions_start_pause_resume_stop() -> None:
     class CancelAwareNavigator(FakeNavigator):
         def __init__(self) -> None:

--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -515,6 +515,35 @@ def test_review_measurement_auto_approves_when_manual_review_disabled() -> None:
     }
 
 
+def test_confirm_measurement_after_navigation_failure_uses_point_index_in_prompt(monkeypatch) -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    messages: list[str] = []
+    asked: dict[str, str] = {}
+    window.after = lambda _delay, callback: callback()
+    window._append_validation = messages.append
+
+    def _askyesno(title: str, message: str, parent=None) -> bool:
+        asked["title"] = title
+        asked["message"] = message
+        return True
+
+    monkeypatch.setattr("transceiver.mission_workflow_ui.messagebox.askyesno", _askyesno)
+
+    decision = window._confirm_measurement_after_navigation_failure(
+        point_context=SimpleNamespace(
+            global_index=3,
+            point=SimpleNamespace(id="point-007", name="Alpha"),
+        ),
+        navigation_state="timeout",
+    )
+
+    assert decision is True
+    assert asked["title"] == "Navigation fehlgeschlagen"
+    assert "Punktindex 3" in asked["message"]
+    assert "point-007" not in asked["message"]
+    assert any("Punktindex 3" in msg for msg in messages)
+
+
 def test_check_run_prerequisites_skips_review_requirements_when_manual_review_disabled() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window.manual_review_enabled_var = SimpleNamespace(get=lambda: False)

--- a/transceiver/measurement_run_executor.py
+++ b/transceiver/measurement_run_executor.py
@@ -132,6 +132,9 @@ class MeasurementRunExecutorConfig:
     start_point_index: int = 0
     reverse_point_order: bool = False
     enable_measurements: bool = True
+    confirm_measurement_after_navigation_failure: (
+        Callable[[PointExecutionContext, TerminalNavigationState], bool] | None
+    ) = None
 
 
 @dataclass(frozen=True)
@@ -396,41 +399,66 @@ class MeasurementRunExecutor:
         if self._cancel_requested and nav_state == "canceled":
             self._cancel_confirmed = True
 
-        if nav_state != "succeeded":
-            error = (
-                "run_cancelled.manual_stop"
-                if self._cancel_requested and nav_state == "canceled"
-                else f"navigation_failed.{nav_state}"
-            )
-            status: PointExecutionStatus = "skipped" if self._cancel_requested and nav_state == "canceled" else "failed"
-            measurement_status = "skipped"
-            
-            record = PointExecutionRecord(
-                index=global_index,
-                point_id=point.id,
-                point_name=point.name,
-                status=status,
-                navigation_state=nav_state,
-                navigation_attempts=attempts,
-                measurement_result=None,
-                error=error,
-            )
-            self._persist_point_log(
-                point=point,
-                point_index=point_index,
-                cycle=cycle,
-                global_index=global_index,
-                navigation_state=nav_state,
-                navigation_attempts=attempts,
-                point_started_at=point_started_at,
-                measurement_result=None,
-                measurement_status=measurement_status,
-                error=record.error,
-                navigation_duration_s=max(0.0, time.time() - point_started_at),
-            )
-            return record
+        point_context = PointExecutionContext(
+            mission_name=self.mission.name,
+            cycle=cycle,
+            point_index=point_index,
+            global_index=global_index,
+            point=point,
+        )
 
-        navigation_done_at = time.time()
+        if nav_state != "succeeded":
+            confirm_measurement = self.config.confirm_measurement_after_navigation_failure
+            proceed_with_measurement = False
+            if (
+                not self._cancel_requested
+                and callable(confirm_measurement)
+                and nav_state is not None
+            ):
+                try:
+                    proceed_with_measurement = bool(confirm_measurement(point_context, nav_state))
+                except Exception:
+                    proceed_with_measurement = False
+            if (
+                not self._cancel_requested
+                and proceed_with_measurement
+            ):
+                navigation_done_at = time.time()
+            else:
+                error = (
+                    "run_cancelled.manual_stop"
+                    if self._cancel_requested and nav_state == "canceled"
+                    else f"navigation_failed.{nav_state}"
+                )
+                status: PointExecutionStatus = "skipped" if self._cancel_requested and nav_state == "canceled" else "failed"
+                measurement_status = "skipped"
+
+                record = PointExecutionRecord(
+                    index=global_index,
+                    point_id=point.id,
+                    point_name=point.name,
+                    status=status,
+                    navigation_state=nav_state,
+                    navigation_attempts=attempts,
+                    measurement_result=None,
+                    error=error,
+                )
+                self._persist_point_log(
+                    point=point,
+                    point_index=point_index,
+                    cycle=cycle,
+                    global_index=global_index,
+                    navigation_state=nav_state,
+                    navigation_attempts=attempts,
+                    point_started_at=point_started_at,
+                    measurement_result=None,
+                    measurement_status=measurement_status,
+                    error=record.error,
+                    navigation_duration_s=max(0.0, time.time() - point_started_at),
+                )
+                return record
+        else:
+            navigation_done_at = time.time()
         if self._cancel_requested:
             record = PointExecutionRecord(
                 index=global_index,
@@ -483,15 +511,7 @@ class MeasurementRunExecutor:
             )
 
         try:
-            measurement_result = self.measurement_service.trigger(
-                PointExecutionContext(
-                    mission_name=self.mission.name,
-                    cycle=cycle,
-                    point_index=point_index,
-                    global_index=global_index,
-                    point=point,
-                )
-            )
+            measurement_result = self.measurement_service.trigger(point_context)
         except Exception as exc:
             error_code = str(exc)
             review_reason: str | None = None

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2125,6 +2125,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 start_point_index=start_point_index,
                 reverse_point_order=bool(self.reverse_point_order_var.get()),
                 enable_measurements=not test_run_enabled,
+                confirm_measurement_after_navigation_failure=self._confirm_measurement_after_navigation_failure,
             ),
         )
 
@@ -2209,8 +2210,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _review_measurement(self, *, point_context, output_file: str) -> dict[str, object]:  # type: ignore[no-untyped-def]
         manual_review_enabled = bool(self.manual_review_enabled_var.get())
-        point_id = point_context.point.id or point_context.point.name or f"point-{point_context.global_index}"
-        point_label = f"Punkt {point_context.global_index} ({point_id})"
+        point_label = f"Punktindex {point_context.global_index}"
         review_fn = getattr(self.master, "review_measurement_for_mission", None)
         if not manual_review_enabled and callable(review_fn):
             try:
@@ -2270,6 +2270,40 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         result_payload["reason"] = reason_text
         result_payload["detail"] = detail_text
         return result_payload
+
+    def _confirm_measurement_after_navigation_failure(self, point_context, navigation_state: str) -> bool:  # type: ignore[no-untyped-def]
+        decision_ready = threading.Event()
+        decision = {"continue": False}
+
+        def _ask_operator() -> None:
+            detail = (
+                f"Navigation zu Punktindex {point_context.global_index} ist fehlgeschlagen "
+                f"({navigation_state}).\n\n"
+                "Soll die Messung an der aktuellen Position trotzdem durchgeführt werden?"
+            )
+            decision["continue"] = bool(
+                messagebox.askyesno(
+                    "Navigation fehlgeschlagen",
+                    detail,
+                    parent=self,
+                )
+            )
+            decision_ready.set()
+
+        try:
+            self.after(0, _ask_operator)
+        except tk.TclError:
+            return False
+        decision_ready.wait()
+        if decision["continue"]:
+            self._append_validation(
+                f"⚠️ Navigation zu Punktindex {point_context.global_index} fehlgeschlagen ({navigation_state}); Messung wird trotzdem ausgeführt."
+            )
+        else:
+            self._append_validation(
+                f"⚠️ Navigation zu Punktindex {point_context.global_index} fehlgeschlagen ({navigation_state}); Messung wird übersprungen."
+            )
+        return bool(decision["continue"])
 
     def _get_crosscorr_reference_for_mission(self) -> Any:
         get_reference = getattr(self.master, "_get_crosscorr_reference", None)


### PR DESCRIPTION
### Motivation
- Allow the mission to continue with a measurement even when navigation to a waypoint fails by asking the operator for confirmation. 
- Ensure that operator-approved measurements follow the normal measurement/review flow and then the mission continues to the next point. 
- Use the point's index (not its id) in prompts and logs to avoid exposing internal identifiers.

### Description
- Added a new callback config `confirm_measurement_after_navigation_failure` to `MeasurementRunExecutorConfig` to let callers decide whether to proceed with a measurement after navigation fails (`transceiver/measurement_run_executor.py`).
- Updated `_execute_point` to build a `PointExecutionContext` and call the new callback; if confirmed, measurement is executed as normal (including review handling), otherwise the point is recorded as failed/skipped and persisted (`transceiver/measurement_run_executor.py`).
- Wire the UI to the new hook by passing `self._confirm_measurement_after_navigation_failure` into the executor config (`transceiver/mission_workflow_ui.py`).
- Implemented a thread-safe operator confirmation dialog `_confirm_measurement_after_navigation_failure` in the UI that uses `after` + `Event`, logs the decision, and references the waypoint by `Punktindex <n>` (no point id) (`transceiver/mission_workflow_ui.py`).
- Adjusted the mission review label to use `Punktindex {global_index}` instead of including the point id (`transceiver/mission_workflow_ui.py`).
- Added automated tests: an executor test that ensures measurements run when the confirmation callback returns true, and a UI test that verifies the prompt message uses the point index and logs the decision (`tests/test_measurement_run_executor.py`, `tests/test_mission_workflow_ui.py`).

### Testing
- Ran the modified tests with `PYTHONPATH=. pytest -q tests/test_measurement_run_executor.py tests/test_mission_workflow_ui.py` and all tests passed (`64 passed`).
- Note: running the same `pytest` command without `PYTHONPATH=.` fails collection due to import resolution; the validated test run above uses `PYTHONPATH=.` as shown.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfce66a1208321b51d16be3bd74247)