### PR TITLE
Increase TX playback-start wait timeout by 3 seconds

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -8046,7 +8046,7 @@ class TransceiverUI(ctk.CTk):
             return True
         return bool(self._tx_running)
 
-    def activate_transmitter_for_mission(self, timeout_s: float = 15.0) -> tuple[bool, str]:
+    def activate_transmitter_for_mission(self, timeout_s: float = 18.0) -> tuple[bool, str]:
         if self.is_transmitter_active_for_mission():
             return True, "already_active"
 


### PR DESCRIPTION
### Motivation
- Avoid premature `timeout_waiting_for_playback_started` by allowing an extra 3 seconds when activating the transmitter.

### Description
- Increase default `timeout_s` in `activate_transmitter_for_mission` from `15.0` to `18.0` in `transceiver/__main__.py`.

### Testing
- Ran `pytest -q tests/test_mission_workflow_prerequisites.py` which initially failed due to missing `PYTHONPATH`, and then ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_prerequisites.py` which passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfd07e50cc8321b80d7c030c4a663a)