### PR TITLE
Update Mission Measurement Review echo labels when marker order changes

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -323,6 +323,36 @@ def test_review_echo_numbers_swap_when_markers_cross() -> None:
     assert numbers == {1: 1, 0: 2}
 
 
+def test_review_echo_label_texts_update_when_marker_order_changes() -> None:
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    class _DummyLabel:
+        def __init__(self) -> None:
+            self.text = ""
+            self.pos = (None, None)
+
+        def setText(self, value: str) -> None:
+            self.text = value
+
+        def setPos(self, x: float, y: float) -> None:
+            self.pos = (x, y)
+
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)
+    dialog._magnitudes = np.array([1.0, 2.0, 3.0, 4.0], dtype=float)
+    dialog._selected_echo_indices = [2, 1]
+    dialog._echo_label_items = [_DummyLabel(), _DummyLabel()]
+    dialog._los_label_item = None
+    dialog._selected_los_idx = None
+    dialog._echo_marker_slots_by_lag = lambda: MissionMeasurementReviewDialog._echo_marker_slots_by_lag(dialog)
+    dialog._echo_numbers_by_marker_slot = lambda: MissionMeasurementReviewDialog._echo_numbers_by_marker_slot(dialog)
+
+    MissionMeasurementReviewDialog._update_peak_label_positions(dialog)
+
+    assert dialog._echo_label_items[0].text == "Echo 2"
+    assert dialog._echo_label_items[1].text == "Echo 1"
+
+
 def test_review_echo_delays_hide_duplicates_for_overlapping_markers() -> None:
     from transceiver.__main__ import MissionMeasurementReviewDialog
 

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1793,10 +1793,14 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
                 float(self._lags[los_idx_int]),
                 float(self._magnitudes[los_idx_int]),
             )
+        echo_numbers_by_slot = self._echo_numbers_by_marker_slot()
         for marker_slot, label_item in enumerate(self._echo_label_items):
             if marker_slot >= len(self._selected_echo_indices):
                 break
             echo_idx_int = int(self._selected_echo_indices[marker_slot])
+            label_value = echo_numbers_by_slot.get(int(marker_slot))
+            label_text = f"Echo {label_value}" if label_value is not None else "Echo"
+            label_item.setText(label_text)
             label_item.setPos(
                 float(self._lags[echo_idx_int]),
                 float(self._magnitudes[echo_idx_int]),


### PR DESCRIPTION
### Motivation
- Ensure echo point labels in the Mission Measurement Review UI follow the current ordering when echo marker positions cross during interactive drags.

### Description
- In `MissionMeasurementReviewDialog._update_peak_label_positions` compute the slot-to-display mapping via `_echo_numbers_by_marker_slot()` and call `setText(...)` on each echo label so the visible label text (e.g. `Echo 1`, `Echo 2`) updates immediately.
- Add a regression test `test_review_echo_label_texts_update_when_marker_order_changes` in `tests/test_crosscorr_normalization.py` that verifies label texts swap when marker ordering is `[2, 1]`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py -k "review_echo_label_texts_update_when_marker_order_changes or review_echo_numbers_swap_when_markers_cross or review_echo_drag_preview_updates_selected_slot_live"` and the selected tests passed (`3 passed`, remaining tests deselected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfd3551ed083218c1db1603b7c264a)