### PR TITLE
Add manual navigation option to mission workflow

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -409,6 +409,66 @@ def test_ui_navigator_navigation_succeeds_without_feedback_position(monkeypatch)
     assert position_updates
 
 
+def test_manual_prompt_navigator_prompts_and_returns_succeeded(monkeypatch) -> None:
+    from transceiver import mission_workflow_ui as module
+
+    parent = SimpleNamespace(after=lambda _delay, callback: callback())
+    status_updates: list[tuple[str, str]] = []
+    operator_messages: list[str] = []
+    prompts: list[str] = []
+
+    def _askokcancel(title: str, message: str, parent=None) -> bool:
+        assert title == "Manuelle Navigation"
+        prompts.append(message)
+        return True
+
+    monkeypatch.setattr("transceiver.mission_workflow_ui.messagebox.askokcancel", _askokcancel)
+    navigator = module._ManualPromptNavigator(
+        parent=parent,
+        on_status=lambda stage, status: status_updates.append((stage, status)),
+        on_operator_message=operator_messages.append,
+        start_index=2,
+    )
+
+    nav_events: list[dict[str, object]] = []
+    result = navigator.navigate_to_point(
+        module.NavigationPoint(x=1.234, y=5.678, z=0.0, qx=0.0, qy=0.0, qz=0.0, qw=1.0),
+        timeout_s=5.0,
+        on_navigation_event=nav_events.append,
+    )
+
+    assert result == "succeeded"
+    assert status_updates == [("navigation", "running"), ("navigation", "succeeded")]
+    assert operator_messages == []
+    assert prompts == ["Roboter zur Position 2 bringen: 1.234,5.678"]
+    assert nav_events == [{"type": "position_update", "position": {"x": 1.234, "y": 5.678, "z": 0.0}}]
+
+
+def test_manual_prompt_navigator_returns_canceled_on_abort(monkeypatch) -> None:
+    from transceiver import mission_workflow_ui as module
+
+    parent = SimpleNamespace(after=lambda _delay, callback: callback())
+    status_updates: list[tuple[str, str]] = []
+    operator_messages: list[str] = []
+
+    monkeypatch.setattr("transceiver.mission_workflow_ui.messagebox.askokcancel", lambda *_args, **_kwargs: False)
+    navigator = module._ManualPromptNavigator(
+        parent=parent,
+        on_status=lambda stage, status: status_updates.append((stage, status)),
+        on_operator_message=operator_messages.append,
+        start_index=0,
+    )
+
+    result = navigator.navigate_to_point(
+        module.NavigationPoint(x=0.0, y=0.0, z=0.0, qx=0.0, qy=0.0, qz=0.0, qw=1.0),
+        timeout_s=5.0,
+    )
+
+    assert result == "canceled"
+    assert status_updates == [("navigation", "running"), ("navigation", "canceled")]
+    assert any("Punktindex 0" in msg for msg in operator_messages)
+
+
 def test_on_map_canvas_click_ignores_click_when_pick_mode_disabled() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._waypoint_map_pick_mode_enabled = False

--- a/tests/test_mission_workflow_ui_state.py
+++ b/tests/test_mission_workflow_ui_state.py
@@ -146,3 +146,19 @@ def test_save_and_load_json_dict_preserves_live_pose_stream_enabled_flag(tmp_pat
     loaded = _load_json_dict(state_file)
 
     assert loaded["live_pose_stream_enabled"] is True
+
+
+def test_save_and_load_json_dict_preserves_manual_navigation_enabled_flag(tmp_path) -> None:
+    state_file = tmp_path / "mission-workflow-state.json"
+    payload = {
+        "name": "scan-manual-navigation-toggle",
+        "repeat": 1,
+        "start_point_index": 0,
+        "manual_navigation_enabled": True,
+        "points": [{"id": "p001", "x": 0.0, "y": 0.0, "z": 0.0, "yaw": 0.0, "enabled": True}],
+    }
+
+    _save_json_dict(state_file, payload)
+    loaded = _load_json_dict(state_file)
+
+    assert loaded["manual_navigation_enabled"] is True

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -35,7 +35,9 @@ from .navigation_adapter import (
     NavigationAdapter,
     NavigationAdapterConfig,
     NavigationEvent,
+    NavigationPoint,
     RosbridgePoseStreamTransport,
+    TerminalNavigationState,
 )
 from .window_utils import configure_child_window
 
@@ -216,6 +218,85 @@ class _UiNavigator:
         self._adapter.cancel_current_goal()
 
 
+class _ManualPromptNavigator:
+    def __init__(
+        self,
+        *,
+        parent: tk.Misc,
+        on_status: Callable[[str, str], None],
+        on_operator_message: Callable[[str], None],
+        start_index: int,
+    ) -> None:
+        self._parent = parent
+        self._on_status = on_status
+        self._on_operator_message = on_operator_message
+        self._next_global_index = max(0, start_index)
+        self._index_lock = threading.Lock()
+        self._cancel_requested = threading.Event()
+
+    def navigate_to_point(
+        self,
+        point: NavigationPoint,
+        *,
+        timeout_s: float,
+        on_navigation_event: Callable[[dict[str, Any]], None] | None = None,
+    ) -> TerminalNavigationState:
+        del timeout_s
+        if self._cancel_requested.is_set():
+            return "canceled"
+        with self._index_lock:
+            current_index = self._next_global_index
+            self._next_global_index += 1
+        self._on_status("navigation", "running")
+        decision_ready = threading.Event()
+        decision: dict[str, bool] = {"ok": False}
+
+        def _ask_operator() -> None:
+            if self._cancel_requested.is_set():
+                decision_ready.set()
+                return
+            prompt = (
+                f"Roboter zur Position {current_index} bringen: "
+                f"{point.x:.3f},{point.y:.3f}"
+            )
+            decision["ok"] = bool(
+                messagebox.askokcancel(
+                    "Manuelle Navigation",
+                    prompt,
+                    parent=self._parent,
+                )
+            )
+            decision_ready.set()
+
+        try:
+            self._parent.after(0, _ask_operator)
+        except tk.TclError:
+            return "aborted"
+        while not decision_ready.wait(timeout=0.1):
+            if self._cancel_requested.is_set():
+                return "canceled"
+        if self._cancel_requested.is_set():
+            return "canceled"
+        if not decision["ok"]:
+            self._on_status("navigation", "canceled")
+            self._on_operator_message(
+                f"⚠️ Manuelle Navigation für Punktindex {current_index} wurde abgebrochen."
+            )
+            return "canceled"
+        if on_navigation_event is not None:
+            on_navigation_event(
+                {
+                    "type": "position_update",
+                    "position": {"x": point.x, "y": point.y, "z": point.z},
+                }
+            )
+        self._on_status("navigation", "succeeded")
+        return "succeeded"
+
+    def cancel_current_goal(self) -> None:
+        self._cancel_requested.set()
+
+
 class MissionWorkflowWindow(ctk.CTkToplevel):
     def __init__(self, parent: ctk.CTk) -> None:
         super().__init__(parent)
@@ -245,6 +326,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.lidar_reference_enabled_var = tk.BooleanVar(value=True)
         self.manual_review_enabled_var = tk.BooleanVar(value=True)
         self.test_run_enabled_var = tk.BooleanVar(value=False)
+        self.manual_navigation_enabled_var = tk.BooleanVar(value=False)
         self.live_pose_stream_enabled_var = tk.BooleanVar(value=False)
         self._live_pose_stream_active = False
 
@@ -499,16 +581,22 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             variable=self.test_run_enabled_var,
             command=self._on_test_run_toggle_changed,
         ).grid(row=3, column=3, padx=(8, 3), pady=(0, 4), sticky="w")
+        ctk.CTkCheckBox(
+            controls,
+            text="Manuelle Navigation",
+            variable=self.manual_navigation_enabled_var,
+            command=self._persist_workflow_state,
+        ).grid(row=3, column=4, padx=(8, 3), pady=(0, 4), sticky="w")
         ctk.CTkSwitch(
             controls,
             text="Live-Position aktivieren",
             variable=self.live_pose_stream_enabled_var,
             command=self._on_live_pose_stream_switch_changed,
-        ).grid(row=3, column=4, columnspan=1, padx=(8, 8), pady=(0, 4), sticky="w")
+        ).grid(row=4, column=0, columnspan=2, padx=(8, 3), pady=(0, 4), sticky="w")
 
         self.live_var = tk.StringVar(value="Punkt: - | Navigation: idle | Messung: idle | Verbleibend: - | Live-Status: Karte nicht geladen")
         ctk.CTkLabel(controls, textvariable=self.live_var, anchor="w", justify="left").grid(
-            row=4, column=0, columnspan=5, sticky="nsew", padx=8, pady=(4, 8)
+            row=5, column=0, columnspan=5, sticky="nsew", padx=8, pady=(4, 8)
         )
 
         table_frame = ctk.CTkFrame(self)
@@ -1890,6 +1978,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "lidar_reference_enabled": bool(self.lidar_reference_enabled_var.get()),
             "manual_review_enabled": bool(self.manual_review_enabled_var.get()),
             "test_run_enabled": bool(self.test_run_enabled_var.get()),
+            "manual_navigation_enabled": bool(self.manual_navigation_enabled_var.get()),
             "reverse_point_order": bool(self.reverse_point_order_var.get()),
             "live_pose_stream_enabled": bool(self.live_pose_stream_enabled_var.get()),
         }
@@ -1971,6 +2060,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self.lidar_reference_enabled_var.set(bool(payload.get("lidar_reference_enabled", True)))
             self.manual_review_enabled_var.set(bool(payload.get("manual_review_enabled", True)))
             self.test_run_enabled_var.set(bool(payload.get("test_run_enabled", False)))
+            self.manual_navigation_enabled_var.set(bool(payload.get("manual_navigation_enabled", False)))
             self.reverse_point_order_var.set(bool(payload.get("reverse_point_order", False)))
             self.live_pose_stream_enabled_var.set(bool(payload.get("live_pose_stream_enabled", False)))
             self._refresh_points_table()
@@ -2097,7 +2187,15 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self.after(0, self._on_record, payload)
 
         self._sync_live_pose_stream_state()
-        navigator = self._ensure_navigator()
+        if bool(self.manual_navigation_enabled_var.get()):
+            navigator = _ManualPromptNavigator(
+                parent=self,
+                on_status=self._on_stage_update,
+                on_operator_message=self._append_validation,
+                start_index=start_point_index,
+            )
+        else:
+            navigator = self._ensure_navigator()
 
         self._executor = MeasurementRunExecutor(
             mission=self._mission,


### PR DESCRIPTION
### Motivation
- Provide an operator-driven alternative to automated ROS navigation so an operator can manually move the robot to the next point and confirm before the measurement is taken.

### Description
- Add `_ManualPromptNavigator` to prompt the operator with `Roboter zur Position <index> bringen: <x>,<y>` and return `succeeded` or `canceled` based on the operator response.
- Add a `Manuelle Navigation` checkbox (`manual_navigation_enabled_var`) in the mission workflow UI and persist/restore the `manual_navigation_enabled` flag in the workflow state JSON.
- Wire run startup to use `_ManualPromptNavigator` when manual navigation is enabled, otherwise fall back to the existing `_UiNavigator`/`NavigationAdapter` path.
- Add unit tests for the manual navigator behavior and state persistence (`tests/test_mission_workflow_ui.py` and `tests/test_mission_workflow_ui_state.py`) and make a small UI layout adjustment for the new control.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py tests/test_mission_workflow_ui_state.py` and the suite succeeded with `52 passed`.
- An initial `pytest` run without `PYTHONPATH=.` failed during collection due to import path configuration, which was resolved by running the tests with `PYTHONPATH=.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfde73f8448321a90647d0e178c2a9)