### PR TITLE
Enable double-click removal of echo markers in mission measurement review

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -53,6 +53,7 @@ sys.modules.setdefault("uhd", types.ModuleType("uhd"))
 from transceiver.__main__ import (
     TransceiverUI,
     _build_crosscorr_ctx,
+    _find_echo_marker_slot_near_lag,
     _format_echo_delay_display,
     _format_rx_stats_rows,
     _update_echo_indices_after_manual_drag,
@@ -203,6 +204,28 @@ def test_update_echo_indices_after_manual_drag_keeps_overlapping_slots() -> None
     assert updated == [1, 3, 3]
 
 
+def test_find_echo_marker_slot_near_lag_returns_nearest_slot_within_threshold() -> None:
+    lags = np.array([-20, -10, 0, 10, 20], dtype=float)
+    marker_slot = _find_echo_marker_slot_near_lag(
+        lags,
+        echo_indices=[1, 3, 4],
+        target_lag=9.2,
+        max_lag_distance=1.5,
+    )
+    assert marker_slot == 1
+
+
+def test_find_echo_marker_slot_near_lag_returns_none_outside_threshold() -> None:
+    lags = np.array([-20, -10, 0, 10, 20], dtype=float)
+    marker_slot = _find_echo_marker_slot_near_lag(
+        lags,
+        echo_indices=[1, 3, 4],
+        target_lag=0.0,
+        max_lag_distance=0.5,
+    )
+    assert marker_slot is None
+
+
 class _DummyEntryWidget:
     def __init__(self, text: str) -> None:
         self._text = text
@@ -335,3 +358,43 @@ def test_review_echo_delays_hide_duplicates_for_overlapping_markers() -> None:
     delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
 
     assert delays == [20, 30]
+
+
+def test_review_remove_echo_marker_near_lag_removes_matching_marker() -> None:
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)
+    dialog._selected_echo_indices = [1, 2, 3]
+    dialog._base_echo_indices = [1, 2, 3]
+    dialog._manual_lags = {"los": None, "echo": 20}
+    dialog._render_plot = lambda: None
+    dialog._plot = types.SimpleNamespace(
+        getViewBox=lambda: types.SimpleNamespace(viewRange=lambda: ((0.0, 100.0), (0.0, 1.0)))
+    )
+
+    removed = MissionMeasurementReviewDialog._remove_echo_marker_near_lag(dialog, 20.5)
+
+    assert removed is True
+    assert dialog._selected_echo_indices == [1, 3]
+    assert dialog._base_echo_indices == [1, 3]
+
+
+def test_review_remove_echo_marker_near_lag_resets_manual_echo_when_last_removed() -> None:
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0], dtype=float)
+    dialog._selected_echo_indices = [2]
+    dialog._base_echo_indices = [2]
+    dialog._manual_lags = {"los": None, "echo": 20}
+    dialog._render_plot = lambda: None
+    dialog._plot = types.SimpleNamespace(
+        getViewBox=lambda: types.SimpleNamespace(viewRange=lambda: ((0.0, 100.0), (0.0, 1.0)))
+    )
+
+    removed = MissionMeasurementReviewDialog._remove_echo_marker_near_lag(dialog, 20.0)
+
+    assert removed is True
+    assert dialog._selected_echo_indices == []
+    assert dialog._manual_lags["echo"] is None

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1660,6 +1660,36 @@ def _update_echo_indices_after_manual_drag(
     return updated
 
 
+def _find_echo_marker_slot_near_lag(
+    lags: np.ndarray,
+    echo_indices: list[int],
+    target_lag: float,
+    *,
+    max_lag_distance: float,
+) -> int | None:
+    """Return nearest echo marker slot for ``target_lag`` when within threshold."""
+    if not echo_indices:
+        return None
+    try:
+        threshold = float(max_lag_distance)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(threshold) or threshold < 0.0:
+        return None
+
+    nearest_slot: int | None = None
+    nearest_distance: float | None = None
+    target_lag_value = float(target_lag)
+    for marker_slot, peak_idx in enumerate(echo_indices):
+        lag_distance = abs(float(lags[int(peak_idx)]) - target_lag_value)
+        if nearest_distance is None or lag_distance < nearest_distance:
+            nearest_slot = int(marker_slot)
+            nearest_distance = float(lag_distance)
+    if nearest_slot is None or nearest_distance is None or nearest_distance > threshold:
+        return None
+    return nearest_slot
+
+
 class MissionMeasurementReviewDialog(QtWidgets.QDialog):
     """Blocking review dialog for mission cross-correlation peaks."""
 
@@ -1997,6 +2027,12 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             if ev.button() != left_button:
                 return
             modifiers = ev.modifiers()
+            is_double_click = bool(getattr(ev, "double", lambda: False)())
+            if is_double_click and not (modifiers & shift_modifier or modifiers & alt_modifier):
+                pos = self._plot.getViewBox().mapSceneToView(ev.scenePos())
+                self._remove_echo_marker_near_lag(float(pos.x()))
+                ev.accept()
+                return
             if not (modifiers & shift_modifier or modifiers & alt_modifier):
                 return
             pos = self._plot.getViewBox().mapSceneToView(ev.scenePos())
@@ -2009,6 +2045,27 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
 
         self._plot._review_click_handler = _handle_click
         scene.sigMouseClicked.connect(_handle_click)
+
+    def _remove_echo_marker_near_lag(self, target_lag: float) -> bool:
+        if not self._selected_echo_indices:
+            return False
+        visible_x = self._plot.getViewBox().viewRange()[0]
+        visible_width = max(0.0, float(visible_x[1]) - float(visible_x[0]))
+        max_lag_distance = float(np.clip(visible_width * 0.02, 2.0, 25.0))
+        marker_slot = _find_echo_marker_slot_near_lag(
+            self._lags,
+            self._selected_echo_indices,
+            target_lag,
+            max_lag_distance=max_lag_distance,
+        )
+        if marker_slot is None:
+            return False
+        self._selected_echo_indices.pop(marker_slot)
+        self._base_echo_indices = [int(idx) for idx in self._selected_echo_indices]
+        if not self._selected_echo_indices:
+            self._manual_lags["echo"] = None
+        self._render_plot()
+        return True
 
 
 def _build_crosscorr_ctx(


### PR DESCRIPTION
### Motivation
- Allow operators to remove an unwanted echo marker quickly during mission cross-correlation review by supporting a plain left-button double-click on the plot.

### Description
- Add `_find_echo_marker_slot_near_lag(...)` helper to resolve the nearest echo marker slot within a configurable lag-distance threshold.
- Detect plain left-button double-clicks in `MissionMeasurementReviewDialog._connect_click_handler` and route them to a new `._remove_echo_marker_near_lag(...)` method while preserving existing Shift-click (LOS) and Alt-click (Echo) interactions.
- Implement `._remove_echo_marker_near_lag(...)` to remove the resolved marker, keep `_base_echo_indices` consistent, clear `manual_lags['echo']` when the last echo is removed, and re-render the plot.
- Add unit tests in `tests/test_crosscorr_normalization.py` for `_find_echo_marker_slot_near_lag` and for the marker-removal behavior (including reset of `manual_lags['echo']`).

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_number_parser.py` which passed (`2 passed`).
- Ran `python -m compileall transceiver/__main__.py tests/test_crosscorr_normalization.py` which succeeded (bytecode compilation OK).
- Ran `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` which failed during collection in this environment due to a `TypeError: __mro_entries__ must return a tuple` coming from the `pyqtgraph` stub / base-class import path, so the new tests could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e211fe28a88321a18c87a834a01aff)