### PR TITLE
Remove emission of position_update event from manual prompt navigator

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -441,7 +441,7 @@ def test_manual_prompt_navigator_prompts_and_returns_succeeded(monkeypatch) -> N
     assert status_updates == [("navigation", "running"), ("navigation", "succeeded")]
     assert operator_messages == []
     assert prompts == ["Roboter zur Position 2 bringen: 1.234,5.678"]
-    assert nav_events == [{"type": "position_update", "position": {"x": 1.234, "y": 5.678, "z": 0.0}}]
+    assert nav_events == []
 
 
 def test_manual_prompt_navigator_returns_canceled_on_abort(monkeypatch) -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -283,13 +283,6 @@ class _ManualPromptNavigator:
                 f"⚠️ Manuelle Navigation für Punktindex {current_index} wurde abgebrochen."
             )
             return "canceled"
-        if on_navigation_event is not None:
-            on_navigation_event(
-                {
-                    "type": "position_update",
-                    "position": {"x": point.x, "y": point.y, "z": point.z},
-                }
-            )
         self._on_status("navigation", "succeeded")
         return "succeeded"
 


### PR DESCRIPTION
### Motivation
- The manual prompt flow should not generate a synthetic `position_update` event when the operator confirms movement, so manual confirmation only affects status and operator messages.

### Description
- Removed the call to `on_navigation_event` that emitted a `{"type": "position_update"}` payload from `_ManualPromptNavigator.navigate_to_point`.
- Updated `tests/test_mission_workflow_ui.py` to no longer expect a navigation event from manual prompts and to assert an empty `nav_events` list.

### Testing
- Ran `pytest tests/test_mission_workflow_ui.py` which exercises the manual prompt navigator behavior, and the updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e21b4e2f6c8321b1810ab085cebf62)