### PR TITLE
Suppress noisy CycloneDDS type-hash warnings in RX subprocess output

### DIFF
--- a/tests/test_receive_for_mission_threading.py
+++ b/tests/test_receive_for_mission_threading.py
@@ -5,6 +5,7 @@ import threading
 import time
 import types
 import queue
+import subprocess
 
 
 def _install_pyqtgraph_stub() -> None:
@@ -446,3 +447,70 @@ def test_review_measurement_for_mission_uses_persisted_tx_reference_without_sing
     np.testing.assert_allclose(captured_ctx_input["ref_data"], np.array([10.0 + 20.0j, 30.0 + 40.0j]))
     assert ui.tx_data.size == 2
     assert outcome["reason"] != "missing_tx_reference"
+
+
+def test_execute_rx_subprocess_suppresses_cyclonedds_type_hash_warning(monkeypatch) -> None:
+    ui = object.__new__(TransceiverUI)
+    ui._out_queue = queue.Queue()
+    ui._proc = None
+    ui._mission_rx_proc = None
+
+    class _FakePopen:
+        def __init__(self, *args, **kwargs) -> None:
+            self.stdout = iter(
+                [
+                    "[WARN] [1776451936.407520401] [rmw_cyclonedds_cpp]: Failed to parse type hash for topic 'rt/_internal/mouse_raw' with type 'brewst::msg::dds_::MouseRaw_' from USER_DATA '(null)'.\n",
+                    "RX normal line\n",
+                ]
+            )
+
+        def wait(self) -> int:
+            return 0
+
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+
+    return_code = TransceiverUI._execute_rx_subprocess(
+        ui,
+        arg_list=["--output-file", "signals/rx/test.bin"],
+        mission_mode=False,
+        point_context=None,
+        rx_mode="mission",
+    )
+
+    assert return_code == 0
+    assert ui._out_queue.get_nowait() == "RX normal line\n"
+    assert ui._out_queue.empty()
+
+
+def test_execute_rx_subprocess_keeps_other_warning_lines(monkeypatch) -> None:
+    ui = object.__new__(TransceiverUI)
+    ui._out_queue = queue.Queue()
+    ui._proc = None
+    ui._mission_rx_proc = None
+
+    class _FakePopen:
+        def __init__(self, *args, **kwargs) -> None:
+            self.stdout = iter(
+                [
+                    "[WARN] some other warning\n",
+                    "RX normal line\n",
+                ]
+            )
+
+        def wait(self) -> int:
+            return 0
+
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+
+    return_code = TransceiverUI._execute_rx_subprocess(
+        ui,
+        arg_list=["--output-file", "signals/rx/test.bin"],
+        mission_mode=False,
+        point_context=None,
+        rx_mode="mission",
+    )
+
+    assert return_code == 0
+    assert ui._out_queue.get_nowait() == "[WARN] some other warning\n"
+    assert ui._out_queue.get_nowait() == "RX normal line\n"
+    assert ui._out_queue.empty()

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -6928,6 +6928,8 @@ class TransceiverUI(ctk.CTk):
             self._proc = proc
         if proc.stdout is not None:
             for line in proc.stdout:
+                if self._should_suppress_rx_log_line(line):
+                    continue
                 self._out_queue.put(line)
         return_code = proc.wait()
         if mission_mode:
@@ -6946,6 +6948,16 @@ class TransceiverUI(ctk.CTk):
         if return_code != 0:
             raise RuntimeError(f"rx_to_file exited with return code {return_code}")
         return return_code
+
+    @staticmethod
+    def _should_suppress_rx_log_line(line: str) -> bool:
+        normalized = line.strip()
+        if not normalized:
+            return False
+        return (
+            "[rmw_cyclonedds_cpp]: Failed to parse type hash for topic" in normalized
+            and "from USER_DATA '(null)'." in normalized
+        )
 
     def _extract_output_file_from_args(self, arg_list: list[str]) -> str | None:
         try:


### PR DESCRIPTION
### Motivation
- The RX subprocess output contains repetitive CycloneDDS warnings like `Failed to parse type hash ... from USER_DATA '(null)'.` that should not be shown in the measurement review log stream.
- Those noisy lines make the UI logs harder to read and obscure relevant messages.

### Description
- Add a filter hook `TransceiverUI._should_suppress_rx_log_line(line: str)` to detect the known CycloneDDS type-hash warning pattern.
- Integrate the filter into `TransceiverUI._execute_rx_subprocess(...)` so lines detected by the filter are skipped before being forwarded to the UI queue.
- Add two unit tests in `tests/test_receive_for_mission_threading.py` that validate suppression of the specific CycloneDDS warning and that unrelated warnings are still forwarded unchanged.
- Files changed: `transceiver/__main__.py`, `tests/test_receive_for_mission_threading.py`.

### Testing
- `python -m py_compile transceiver/__main__.py tests/test_receive_for_mission_threading.py` succeeded.
- `PYTHONPATH=. pytest -q tests/test_receive_for_mission_threading.py -k "execute_rx_subprocess_suppresses_cyclonedds_type_hash_warning or execute_rx_subprocess_keeps_other_warning_lines"` failed during test collection with an import-time error (`TypeError: __mro_entries__ must return a tuple`) arising from the test environment's Qt/pyqtgraph stubbing before the new tests execute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e281e6a3488321885d8ead0aef6da8)