### PR TITLE
Enable double-click echo marker add/remove in mission measurement review

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -398,3 +398,45 @@ def test_review_remove_echo_marker_near_lag_resets_manual_echo_when_last_removed
     assert removed is True
     assert dialog._selected_echo_indices == []
     assert dialog._manual_lags["echo"] is None
+
+
+def test_review_add_echo_marker_near_lag_adds_marker_at_nearest_lag() -> None:
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)
+    dialog._selected_echo_indices = [1, 3]
+    dialog._base_echo_indices = [1, 3]
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._render_plot = lambda: None
+    dialog._plot = types.SimpleNamespace(
+        getViewBox=lambda: types.SimpleNamespace(viewRange=lambda: ((0.0, 100.0), (0.0, 1.0)))
+    )
+
+    added = MissionMeasurementReviewDialog._add_echo_marker_near_lag(dialog, 21.0)
+
+    assert added is True
+    assert dialog._selected_echo_indices == [1, 3, 2]
+    assert dialog._base_echo_indices == [1, 3, 2]
+    assert dialog._manual_lags["echo"] == 20
+
+
+def test_review_add_echo_marker_near_lag_ignores_existing_marker() -> None:
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0], dtype=float)
+    dialog._selected_echo_indices = [1]
+    dialog._base_echo_indices = [1]
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._render_plot = lambda: None
+    dialog._plot = types.SimpleNamespace(
+        getViewBox=lambda: types.SimpleNamespace(viewRange=lambda: ((0.0, 100.0), (0.0, 1.0)))
+    )
+
+    added = MissionMeasurementReviewDialog._add_echo_marker_near_lag(dialog, 11.0)
+
+    assert added is False
+    assert dialog._selected_echo_indices == [1]
+    assert dialog._base_echo_indices == [1]
+    assert dialog._manual_lags["echo"] is None

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -2041,7 +2041,9 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             is_double_click = bool(getattr(ev, "double", lambda: False)())
             if is_double_click and not (modifiers & shift_modifier or modifiers & alt_modifier):
                 pos = self._plot.getViewBox().mapSceneToView(ev.scenePos())
-                self._remove_echo_marker_near_lag(float(pos.x()))
+                target_lag = float(pos.x())
+                if not self._remove_echo_marker_near_lag(target_lag):
+                    self._add_echo_marker_near_lag(target_lag)
                 ev.accept()
                 return
             if not (modifiers & shift_modifier or modifiers & alt_modifier):
@@ -2081,6 +2083,23 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             preserve_y_range=(float(view_range[1][0]), float(view_range[1][1])),
         )
         return True
+
+    def _add_echo_marker_near_lag(self, target_lag: float) -> bool:
+        if self._lags.size == 0:
+            return False
+        view_range = self._plot.getViewBox().viewRange()
+        nearest_idx = int(np.abs(self._lags - float(target_lag)).argmin())
+        if nearest_idx in self._selected_echo_indices:
+            return False
+        self._selected_echo_indices.append(nearest_idx)
+        self._base_echo_indices = [int(idx) for idx in self._selected_echo_indices]
+        self._manual_lags["echo"] = int(round(float(self._lags[nearest_idx])))
+        self._render_plot(
+            preserve_x_range=(float(view_range[0][0]), float(view_range[0][1])),
+            preserve_y_range=(float(view_range[1][0]), float(view_range[1][1])),
+        )
+        return True
+
 
 
 def _build_crosscorr_ctx(


### PR DESCRIPTION
### Motivation
- Users should be able to add echo markers with a plain double-click in the mission measurement review dialog, analogous to the existing remove-on-double-click behavior, to make manual review faster and more intuitive.
- The click handler needs toggle behavior: remove if a marker is near the click, otherwise add a new marker at the nearest lag.

### Description
- Updated the `MissionMeasurementReviewDialog` click handler so a plain double-click now attempts to remove a nearby echo marker and, if none is close enough, adds a new echo marker at the nearest lag (toggle behavior) by calling `_remove_echo_marker_near_lag` or `_add_echo_marker_near_lag`.
- Added a new method `._add_echo_marker_near_lag(target_lag: float) -> bool` that finds the nearest lag index, prevents duplicates, appends the marker, updates `_base_echo_indices` and `_manual_lags["echo"]`, and re-renders while preserving the current view ranges.
- Added two unit tests to `tests/test_crosscorr_normalization.py`: `test_review_add_echo_marker_near_lag_adds_marker_at_nearest_lag` and `test_review_add_echo_marker_near_lag_ignores_existing_marker` to cover adding markers and duplicate-avoidance behavior.

### Testing
- Ran `pytest -q tests/test_crosscorr_normalization.py` which failed during collection with `ModuleNotFoundError: No module named 'transceiver'` in this environment.
- Re-ran with `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` which failed during import of `transceiver.__main__` with `TypeError: __mro_entries__ must return a tuple` in this environment, so the new tests could not be executed to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e29f2ebd7c8321a98fc0e0ad8ec99e)