### PR TITLE
Tighten LOS detection threshold in `find_los_echo_from_mag` and add tests

### DIFF
--- a/tests/test_correlation_utils.py
+++ b/tests/test_correlation_utils.py
@@ -211,6 +211,28 @@ def test_find_los_echo_uses_classified_peak_group() -> None:
     assert echo_idx == (expected_echoes[0] if expected_echoes else None)
 
 
+def test_find_los_echo_from_mag_uses_stricter_los_threshold() -> None:
+    mag = np.zeros(180, dtype=float)
+    mag[90] = 1.0
+    mag[110] = 0.25  # Below LOS-specific 0.3 threshold.
+
+    los_idx, echo_idx = find_los_echo_from_mag(mag)
+
+    assert los_idx == 90
+    assert echo_idx is None
+
+
+def test_find_los_echo_from_mag_keeps_echo_above_los_threshold() -> None:
+    mag = np.zeros(180, dtype=float)
+    mag[90] = 1.0
+    mag[110] = 0.35  # Above LOS-specific 0.3 threshold.
+
+    los_idx, echo_idx = find_los_echo_from_mag(mag)
+
+    assert los_idx == 90
+    assert echo_idx == 110
+
+
 def test_from_mag_variants_match_cc_wrappers() -> None:
     n = 320
     mag = _sinc_lobe(n, 120, 1.0) + _sinc_lobe(n, 150, 0.72) + _sinc_lobe(n, 180, 0.66)

--- a/transceiver/helpers/correlation_utils.py
+++ b/transceiver/helpers/correlation_utils.py
@@ -58,7 +58,7 @@ def find_los_echo_from_mag(
         mag,
         peaks_before=0,
         peaks_after=1,
-        min_rel_height=0.1,
+        min_rel_height=0.3,
         repetition_period_samples=repetition_period_samples,
     )
     echo_idx = echo_indices[0] if echo_indices else None


### PR DESCRIPTION
### Motivation

- Ensure the LOS detection path uses a stricter relative-height threshold than the general peak-grouping logic to avoid misclassifying low-level echoes as LOS.

### Description

- Increase the `min_rel_height` passed by `find_los_echo_from_mag` from `0.1` to `0.3` in `transceiver/helpers/correlation_utils.py`.
- Add two unit tests in `tests/test_correlation_utils.py`: `test_find_los_echo_from_mag_uses_stricter_los_threshold` and `test_find_los_echo_from_mag_keeps_echo_above_los_threshold` to validate the new LOS-specific threshold behavior.
- Keep existing wrapper behavior for `find_los_echo` which delegates to `find_los_echo_from_mag` unchanged.

### Testing

- Ran the new tests with `pytest tests/test_correlation_utils.py::test_find_los_echo_from_mag_uses_stricter_los_threshold` and `pytest tests/test_correlation_utils.py::test_find_los_echo_from_mag_keeps_echo_above_los_threshold`, and both succeeded.
- Ran the full test module with `pytest tests/test_correlation_utils.py` and it passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e21ae1e72c8321a203d5c79dfb62b2)