### PR TITLE
Rename mission workflow live columns to Position/Abstand

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -617,8 +617,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         headings = {
             "measurement_idx": "Messung",
             "idx": "Punktindex",
-            "live_position": "Live Pos.",
-            "live_distance_to_rx_m": "Live Abstand",
+            "live_position": "Position",
+            "live_distance_to_rx_m": "Abstand",
             "echo_1_m": f"{ECHO_HEADING_MARKERS[0]} E1",
             "echo_2_m": f"{ECHO_HEADING_MARKERS[1]} E2",
             "echo_3_m": f"{ECHO_HEADING_MARKERS[2]} E3",


### PR DESCRIPTION
### Motivation
- Clarify the mission workflow results table by renaming the live column labels from `Live Pos.` and `Live Abstand` to `Position` and `Abstand`.

### Description
- Adjusted the `headings` mapping in `transceiver/mission_workflow_ui.py` to replace `"live_position": "Live Pos."` with `"live_position": "Position"` and `"live_distance_to_rx_m": "Live Abstand"` with `"live_distance_to_rx_m": "Abstand"`.

### Testing
- No automated test suite was run; the change was validated by inspecting the diff and file contents with `git diff` and by printing the relevant lines of `transceiver/mission_workflow_ui.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2a38f93b083219d0baa8737f2f077)