### PR TITLE
Use live measurement pose for selected lidar overlay

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -171,6 +171,45 @@ def test_draw_selected_echo_overlay_uses_live_measurement_position() -> None:
     assert calls[0]["measurement_position"] == (7.0, -2.0)
 
 
+def test_selected_record_overlay_point_prefers_live_yaw() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission_points = [MeasurementPoint(id="p0", name="P0", x=50.0, y=50.0, yaw=0.5)]
+
+    overlay_point = window._selected_record_overlay_point(
+        {"point_index": 0, "live_position_at_measurement": {"x": 7.0, "y": -2.0, "yaw": 1.25}},
+        measurement_position=(7.0, -2.0),
+    )
+
+    assert overlay_point is not None
+    assert overlay_point.x == 7.0
+    assert overlay_point.y == -2.0
+    assert overlay_point.yaw == 1.25
+
+
+def test_draw_selected_lidar_reference_overlay_uses_live_measurement_position() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._selected_result_index = 0
+    window._records = [
+        {
+            "point_index": 0,
+            "live_position_at_measurement": {"x": 7.0, "y": -2.0, "yaw": 0.25},
+            "measurement": {"result": {"lidar_reference": {"output_file": "scan.yaml"}}},
+        }
+    ]
+    window._mission_points = [MeasurementPoint(id="p0", name="P0", x=50.0, y=50.0, yaw=0.0)]
+    window._load_lidar_scan_for_overlay = lambda _path: {"angle_min": 0.0, "angle_increment": 0.1, "ranges": [1.0]}
+    calls: list[dict[str, object]] = []
+    window._draw_lidar_scan_overlay_for_point = lambda **kwargs: calls.append(kwargs)
+
+    window._draw_selected_lidar_reference_overlay()
+
+    assert len(calls) == 1
+    point = calls[0]["point"]
+    assert isinstance(point, MeasurementPoint)
+    assert point.x == 7.0
+    assert point.y == -2.0
+
+
 def test_format_position_for_table_uses_one_decimal_for_x_and_y() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._mission_points = [

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1312,6 +1312,26 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             return None
         return (x, y)
 
+    def _selected_record_overlay_point(
+        self,
+        record: dict[str, Any],
+        *,
+        measurement_position: tuple[float, float],
+    ) -> MeasurementPoint | None:
+        x, y = measurement_position
+        live_position = record.get("live_position_at_measurement")
+        live_yaw = live_position.get("yaw") if isinstance(live_position, dict) else None
+        yaw: float | None = None
+        if isinstance(live_yaw, (int, float)) and math.isfinite(float(live_yaw)):
+            yaw = float(live_yaw)
+        else:
+            point = self._selected_record_point(record)
+            if point is not None and isinstance(point.yaw, (int, float)) and math.isfinite(float(point.yaw)):
+                yaw = float(point.yaw)
+        if yaw is None:
+            return None
+        return MeasurementPoint(id=None, name=None, x=x, y=y, yaw=yaw)
+
     @staticmethod
     def _extract_echo_distances(value: Any, *, limit: int) -> list[float]:
         if not isinstance(value, list) or limit <= 0:
@@ -1404,8 +1424,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         record = self._selected_record_payload()
         if record is None:
             return
-        point = self._selected_record_point(record)
-        if point is None:
+        measurement_position = self._selected_record_measurement_position(record)
+        if measurement_position is None:
             return
         measurement = record.get("measurement")
         if not isinstance(measurement, dict):
@@ -1422,7 +1442,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         scan = self._load_lidar_scan_for_overlay(lidar_file)
         if scan is None:
             return
-        self._draw_lidar_scan_overlay_for_point(point=point, scan=scan)
+        overlay_point = self._selected_record_overlay_point(record, measurement_position=measurement_position)
+        if overlay_point is None:
+            return
+        self._draw_lidar_scan_overlay_for_point(point=overlay_point, scan=scan)
 
     def _selected_record_payload(self) -> dict[str, Any] | None:
         selected_idx = self._selected_result_index


### PR DESCRIPTION
### Motivation
- When clicking a measurement result the map overlay should highlight the live position recorded at measurement time (`live_position_at_measurement`) instead of the stored mission point so the overlay matches the table `Position` column. 
- Avoid drawing overlays at stale waypoint coordinates when live pose information is available.

### Description
- Updated `_draw_selected_lidar_reference_overlay` to anchor the lidar overlay on the measurement's live position by using `_selected_record_measurement_position` and an overlay point built from that live pose. 
- Added `_selected_record_overlay_point(...)` which builds a `MeasurementPoint` from live X/Y and prefers live `yaw` with a fallback to the waypoint `yaw`; returns `None` when no valid yaw is available to keep behavior defensive. 
- Adjusted lidar overlay call to use the constructed overlay `MeasurementPoint` when available instead of the stored mission point. 
- Added tests in `tests/test_mission_workflow_ui.py` for preferring live yaw and for drawing the selected lidar overlay from the live measurement position.

### Testing
- Running `pytest -q tests/test_mission_workflow_ui.py -k "selected_lidar_reference_overlay or selected_record_overlay_point or selected_echo_overlay"` without `PYTHONPATH` failed due to import configuration (`ModuleNotFoundError`).
- Running `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "selected_lidar_reference_overlay or selected_record_overlay_point or selected_echo_overlay"` succeeded with `3 passed, 41 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2a6e9b1148321bcd1d08fb079bf63)