### PR TITLE
Use persisted TX signal as fallback in continuous X‑Corr mode

### DIFF
--- a/tests/test_continuous_processing_worker.py
+++ b/tests/test_continuous_processing_worker.py
@@ -3,7 +3,7 @@ import threading
 
 import numpy as np
 
-from transceiver.helpers.continuous_processing import continuous_processing_worker
+from transceiver.helpers.continuous_processing import _load_tx_samples, continuous_processing_worker
 
 
 def test_continuous_worker_is_importable_from_non_main_module():
@@ -159,3 +159,19 @@ def test_continuous_worker_does_not_inject_default_interpolation_factor_when_mis
     worker.join(timeout=5)
 
     assert result["interpolation_factor"] is None
+
+
+def test_load_tx_samples_falls_back_to_persisted_session_signal(monkeypatch):
+    persisted = np.array([1, 2, 3, 4], dtype=np.int16)
+
+    def _fake_fromfile(path, dtype):
+        if str(path) == "tx_signal.bin":
+            return persisted
+        raise OSError("missing file")
+
+    monkeypatch.setattr(np, "fromfile", _fake_fromfile)
+
+    out = _load_tx_samples("signals/tx/new_not_yet_created.bin")
+
+    assert out.size == 2
+    assert np.allclose(out, np.array([1 + 2j, 3 + 4j], dtype=np.complex64))

--- a/transceiver/helpers/continuous_processing.py
+++ b/transceiver/helpers/continuous_processing.py
@@ -38,18 +38,37 @@ def _put_latest_result(result_queue: multiprocessing.Queue, payload: dict[str, o
 
 
 def _load_tx_samples(path: object) -> np.ndarray:
-    if not path:
-        return np.array([], dtype=np.complex64)
-    try:
-        raw = np.fromfile(str(path), dtype=np.int16)
-    except Exception:
-        return np.array([], dtype=np.complex64)
-    if raw.size % 2:
-        raw = raw[:-1]
-    if raw.size == 0:
-        return np.array([], dtype=np.complex64)
-    raw = raw.reshape(-1, 2).astype(np.float32)
-    return raw[:, 0] + 1j * raw[:, 1]
+    candidates: list[str] = []
+    if path:
+        primary = str(path).strip()
+        if primary:
+            candidates.append(primary)
+            suffix = "_zeros"
+            try:
+                stem, ext = primary.rsplit(".", 1)
+                if stem.endswith(suffix):
+                    candidates.append(f"{stem[:-len(suffix)]}.{ext}")
+            except ValueError:
+                if primary.endswith(suffix):
+                    candidates.append(primary[:-len(suffix)])
+
+    # Fallback auf persistiertes Standardsignal aus der letzten Session.
+    if "tx_signal.bin" not in candidates:
+        candidates.append("tx_signal.bin")
+
+    for candidate in candidates:
+        try:
+            raw = np.fromfile(candidate, dtype=np.int16)
+        except Exception:
+            continue
+        if raw.size % 2:
+            raw = raw[:-1]
+        if raw.size == 0:
+            continue
+        raw = raw.reshape(-1, 2).astype(np.float32)
+        return raw[:, 0] + 1j * raw[:, 1]
+
+    return np.array([], dtype=np.complex64)
 
 
 def _select_channel_and_trim(


### PR DESCRIPTION
### Motivation
- In continuous receive/X‑Corr mode the worker could end up with no TX reference if the configured TX file was not yet generated, causing empty cross‑correlation results.
- The change aligns continuous processing with single receive behavior by reusing the persisted TX signal from the last session when no newer file exists.

### Description
- Update `_load_tx_samples` in `transceiver/helpers/continuous_processing.py` to try multiple candidates: the configured TX path, a `_zeros` → base filename variant, and finally the persisted `tx_signal.bin` fallback before returning an empty array.
- Preserve existing parsing logic (int16 → complex IQ) and skip candidates that cannot be read or are empty.
- Add a unit test `test_load_tx_samples_falls_back_to_persisted_session_signal` in `tests/test_continuous_processing_worker.py` and expose `_load_tx_samples` for testing.

### Testing
- Running `PYTHONPATH=. pytest -q tests/test_continuous_processing_worker.py tests/test_continuous_processing_correlation.py` completed successfully with all tests passing (`12 passed`).
- An initial `pytest` invocation without `PYTHONPATH=.` failed during collection due to import path setup in the test environment (addressed by the validated command above).
- The new test verifies that `_load_tx_samples` falls back to `tx_signal.bin` when the configured TX file is missing and the decoded IQ matches the expected complex values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2ada7610483219911fc75e63b0e4e)