### PR TITLE
Add live preview in mission workflow with continuous echo overlays

### DIFF
--- a/tests/test_mission_workflow_ui_state.py
+++ b/tests/test_mission_workflow_ui_state.py
@@ -148,6 +148,22 @@ def test_save_and_load_json_dict_preserves_live_pose_stream_enabled_flag(tmp_pat
     assert loaded["live_pose_stream_enabled"] is True
 
 
+def test_save_and_load_json_dict_preserves_live_preview_enabled_flag(tmp_path) -> None:
+    state_file = tmp_path / "mission-workflow-state.json"
+    payload = {
+        "name": "scan-live-preview-toggle",
+        "repeat": 1,
+        "start_point_index": 0,
+        "live_preview_enabled": True,
+        "points": [{"id": "p001", "x": 0.0, "y": 0.0, "z": 0.0, "yaw": 0.0, "enabled": True}],
+    }
+
+    _save_json_dict(state_file, payload)
+    loaded = _load_json_dict(state_file)
+
+    assert loaded["live_preview_enabled"] is True
+
+
 def test_save_and_load_json_dict_preserves_manual_navigation_enabled_flag(tmp_path) -> None:
     state_file = tmp_path / "mission-workflow-state.json"
     payload = {

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -7021,6 +7021,91 @@ class TransceiverUI(ctk.CTk):
         except Exception:
             return True
 
+    def get_live_echo_distances_for_mission_preview(self, *, limit: int = 5) -> list[float]:
+        if limit <= 0:
+            return []
+        payload = getattr(self, "_last_continuous_payload", None)
+        if not isinstance(payload, dict):
+            return []
+        cont_thread = getattr(self, "_cont_thread", None)
+        if cont_thread is None or not cont_thread.is_alive():
+            return []
+
+        raw_data = payload.get("plot_data")
+        data = np.asarray(raw_data) if raw_data is not None else np.array([], dtype=np.complex64)
+        if data.size == 0:
+            return []
+
+        ref_data = np.asarray(payload.get("plot_ref_data", np.array([], dtype=np.complex64)))
+        if ref_data.size == 0:
+            ref_candidate = None
+            get_reference = getattr(self, "_get_crosscorr_reference", None)
+            if callable(get_reference):
+                try:
+                    reference_payload = get_reference()
+                except Exception:
+                    reference_payload = None
+                if isinstance(reference_payload, tuple) and reference_payload:
+                    ref_candidate = reference_payload[0]
+                else:
+                    ref_candidate = reference_payload
+            if ref_candidate is None:
+                return []
+            ref_data = np.asarray(ref_candidate)
+        if ref_data.size == 0:
+            return []
+
+        try:
+            reduced_data, reduced_ref, lag_step = _reduce_pair(np.asarray(data), np.asarray(ref_data))
+            ctx = _build_crosscorr_ctx(
+                reduced_data,
+                reduced_ref,
+                normalize=bool(getattr(self, "rx_xcorr_normalized_enable", None).get())
+                if hasattr(getattr(self, "rx_xcorr_normalized_enable", None), "get")
+                else False,
+                lag_step=lag_step,
+            )
+        except Exception:
+            return []
+
+        lags = ctx.get("lags2")
+        if not isinstance(lags, np.ndarray):
+            lags = ctx.get("lags")
+        if not isinstance(lags, np.ndarray) or lags.size == 0:
+            return []
+        los_idx = ctx.get("los_idx")
+        echo_indices = ctx.get("echo_indices")
+        if los_idx is None or not isinstance(echo_indices, list):
+            return []
+
+        try:
+            los_lag = float(lags[int(los_idx)])
+        except Exception:
+            return []
+
+        interpolation_factor = 1.0
+        if bool(getattr(self, "_latest_rx_data_interpolated", False)):
+            try:
+                interpolation_factor = float(self._rx_effective_interpolation_factor())
+            except Exception:
+                interpolation_factor = 1.0
+            if not np.isfinite(interpolation_factor) or interpolation_factor <= 0.0:
+                interpolation_factor = 1.0
+
+        distances_m: list[float] = []
+        for idx in echo_indices:
+            if len(distances_m) >= limit:
+                break
+            try:
+                echo_lag = float(lags[int(idx)])
+            except Exception:
+                continue
+            delay_samples = abs(echo_lag - los_lag) / interpolation_factor
+            if not np.isfinite(delay_samples) or delay_samples <= 0.0:
+                continue
+            distances_m.append(float(delay_samples * 1.5))
+        return distances_m
+
     def _build_receive_arg_list(self, *, output_file: str | None = None) -> tuple[list[str], int, float]:
         out_file = output_file if output_file is not None else ""
         rx_args = self.rx_args.get()

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -323,11 +323,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.test_run_enabled_var = tk.BooleanVar(value=False)
         self.manual_navigation_enabled_var = tk.BooleanVar(value=False)
         self.live_pose_stream_enabled_var = tk.BooleanVar(value=False)
+        self.live_preview_enabled_var = tk.BooleanVar(value=False)
         self._live_pose_stream_active = False
 
         self._build_ui()
         self._restore_workflow_state()
         self._sync_live_pose_stream_state()
+        self._sync_live_preview_state()
         self.after_idle(self._stabilize_initial_geometry)
         self.after_idle(self._open_maximized)
 
@@ -589,6 +591,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             variable=self.live_pose_stream_enabled_var,
             command=self._on_live_pose_stream_switch_changed,
         ).grid(row=4, column=0, columnspan=2, padx=(8, 3), pady=(0, 4), sticky="w")
+        ctk.CTkSwitch(
+            controls,
+            text="Live-Preview aktivieren",
+            variable=self.live_preview_enabled_var,
+            command=self._on_live_preview_switch_changed,
+        ).grid(row=4, column=2, columnspan=2, padx=(8, 3), pady=(0, 4), sticky="w")
 
         self.live_var = tk.StringVar(value="Punkt: - | Navigation: idle | Messung: idle | Verbleibend: - | Live-Status: Karte nicht geladen")
         ctk.CTkLabel(controls, textvariable=self.live_var, anchor="w", justify="left").grid(
@@ -1015,6 +1023,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._draw_rx_antenna_marker()
         self._draw_selected_echo_overlay()
         self._draw_selected_lidar_reference_overlay()
+        self._draw_live_echo_preview_overlay()
         self._draw_live_marker()
 
     def _draw_rx_antenna_marker(self) -> None:
@@ -1278,6 +1287,34 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not isinstance(result, dict):
             return
         echo_distances = self._extract_echo_distances(result.get("echo_delays"), limit=len(ECHO_OVERLAY_COLORS))
+        if not echo_distances:
+            return
+        for echo_index, echo_distance in enumerate(echo_distances):
+            color = ECHO_OVERLAY_COLORS[echo_index % len(ECHO_OVERLAY_COLORS)]
+            self._draw_echo_ellipse_for_overlay(
+                rx_position=rx_position,
+                measurement_position=measurement_position,
+                echo_distance_m=echo_distance,
+                color=color,
+            )
+
+    def _draw_live_echo_preview_overlay(self) -> None:
+        if not bool(self.live_preview_enabled_var.get()):
+            return
+        rx_position = self._rx_antenna_global_position
+        if rx_position is None:
+            return
+        live_position = self._copy_valid_live_position()
+        if live_position is None:
+            return
+        x_value = live_position.get("x")
+        y_value = live_position.get("y")
+        if not isinstance(x_value, (int, float)) or not isinstance(y_value, (int, float)):
+            return
+        measurement_position = (float(x_value), float(y_value))
+        if not math.isfinite(measurement_position[0]) or not math.isfinite(measurement_position[1]):
+            return
+        echo_distances = self._get_live_preview_echo_distances(limit=len(ECHO_OVERLAY_COLORS))
         if not echo_distances:
             return
         for echo_index, echo_distance in enumerate(echo_distances):
@@ -1994,6 +2031,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "manual_navigation_enabled": bool(self.manual_navigation_enabled_var.get()),
             "reverse_point_order": bool(self.reverse_point_order_var.get()),
             "live_pose_stream_enabled": bool(self.live_pose_stream_enabled_var.get()),
+            "live_preview_enabled": bool(self.live_preview_enabled_var.get()),
         }
 
     def _serialize_rx_antenna_global_position(self) -> dict[str, float] | None:
@@ -2076,6 +2114,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self.manual_navigation_enabled_var.set(bool(payload.get("manual_navigation_enabled", False)))
             self.reverse_point_order_var.set(bool(payload.get("reverse_point_order", False)))
             self.live_pose_stream_enabled_var.set(bool(payload.get("live_pose_stream_enabled", False)))
+            self.live_preview_enabled_var.set(bool(payload.get("live_preview_enabled", False)))
             self._refresh_points_table()
             self._refresh_map_section()
             persisted_start_point = payload.get("start_point_index")
@@ -2306,6 +2345,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._live_label_ticker_job = None
         if not self._live_label_ticker_active:
             return
+        if bool(self.live_preview_enabled_var.get()):
+            self._draw_map_preview()
         self._update_live_label()
         self._schedule_live_label_ticker()
 
@@ -2528,6 +2569,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._persist_workflow_state()
         self._sync_live_pose_stream_state()
         self._update_live_label()
+        self._draw_map_preview()
+
+    def _on_live_preview_switch_changed(self) -> None:
+        self._persist_workflow_state()
+        self._sync_live_preview_state()
+        self._draw_map_preview()
 
     def _sync_live_pose_stream_state(self) -> None:
         should_run = bool(self.live_pose_stream_enabled_var.get())
@@ -2543,6 +2590,47 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if self._navigator is not None and self._live_pose_stream_active:
             self._navigator.stop_pose_stream()
         self._live_pose_stream_active = False
+
+    def _sync_live_preview_state(self) -> None:
+        if bool(self.live_preview_enabled_var.get()):
+            self._sync_live_pose_stream_state()
+            start_continuous = getattr(self.master, "start_continuous", None)
+            if not self._is_continuous_active() and callable(start_continuous):
+                try:
+                    start_continuous()
+                    self._append_validation("ℹ️ Live-Preview aktiv: Continuous-Modus wurde gestartet.")
+                except Exception as exc:
+                    self._append_validation(f"⚠️ Live-Preview: Continuous-Start fehlgeschlagen ({exc}).")
+            return
+        stop_continuous = getattr(self.master, "stop_continuous", None)
+        if self._is_continuous_active() and callable(stop_continuous):
+            try:
+                stop_continuous()
+                self._append_validation("ℹ️ Live-Preview deaktiviert: Continuous-Modus wurde gestoppt.")
+            except Exception as exc:
+                self._append_validation(f"⚠️ Live-Preview: Continuous-Stop fehlgeschlagen ({exc}).")
+
+    def _get_live_preview_echo_distances(self, *, limit: int) -> list[float]:
+        if limit <= 0:
+            return []
+        getter = getattr(self.master, "get_live_echo_distances_for_mission_preview", None)
+        if not callable(getter):
+            return []
+        try:
+            payload = getter(limit=limit)
+        except Exception:
+            return []
+        if not isinstance(payload, list):
+            return []
+        distances: list[float] = []
+        for value in payload[:limit]:
+            if not isinstance(value, (int, float)):
+                continue
+            numeric = float(value)
+            if not math.isfinite(numeric) or numeric <= 0.0:
+                continue
+            distances.append(numeric)
+        return distances
 
     def _is_continuous_active(self) -> bool:
         cont_thread = getattr(self.master, "_cont_thread", None)
@@ -2921,6 +3009,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
     def _on_run_finished(self, state: str) -> None:
         self._stop_live_label_ticker()
         self._sync_live_pose_stream_state()
+        self._sync_live_preview_state()
         self._set_run_buttons(running=False, paused=False)
         completion_substatus = None
         if self._run_log_dir is not None:
@@ -2944,6 +3033,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _on_window_close(self) -> None:
         self._stop_live_label_ticker()
+        self.live_preview_enabled_var.set(False)
+        self._sync_live_preview_state()
         if self._navigator is not None:
             self._navigator.stop_pose_stream()
             self._navigator = None


### PR DESCRIPTION
### Motivation
- Provide a live preview mode in the mission workflow that visualizes detected echoes on the map as ellipses using the live TX position from ROS and the configured RX antenna, to help operators monitor echoes in real time.

### Description
- Added a `Live-Preview aktivieren` switch backed by `live_preview_enabled_var` and persisted in the workflow state (`live_preview_enabled`) so the setting is saved/restored via the workflow payload and state file.
- When live preview is enabled the window will ensure the live pose stream is active and will attempt to start the continuous receive pipeline (and stop it when preview is disabled) via best-effort calls to `start_continuous`/`stop_continuous` on the main UI.
- Render live echo overlays by introducing `_draw_live_echo_preview_overlay()` that queries live TX position (`_copy_valid_live_position`) and echo distances and reuses the existing `_draw_echo_ellipse_for_overlay()` to draw ellipses on the map; map is refreshed periodically while preview is active by invoking `_draw_map_preview()` from the live ticker.
- Added `TransceiverUI.get_live_echo_distances_for_mission_preview()` which derives current echo distances (meters) from the latest continuous payload / cross-correlation context, and wired a mission-side helper `_get_live_preview_echo_distances()` that calls it.
- Small UI and lifecycle hooks to keep preview state in sync (`_on_live_preview_switch_changed`, `_sync_live_preview_state`) and to stop preview on window close.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui_state.py` and the suite completed successfully (`11 passed`).
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_prerequisites.py` and the suite completed successfully (`8 passed`).
- An initial collection run without `PYTHONPATH` failed due to import path configuration, but all targeted tests ran successfully when executed with `PYTHONPATH=.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2af3c07588321aacb01f903a73136)