### PR TITLE
Fix manual cmd_vel payload YAML formatting

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -235,7 +235,7 @@ def test_build_manual_drive_command_reuses_remote_ssh_transport_builder() -> Non
     remote_cmd = command[-1]
     assert "source /opt/ros/jazzy/setup.bash" in remote_cmd
     assert "ros2 topic pub --once /robot1/cmd_vel geometry_msgs/msg/Twist" in remote_cmd
-    assert "{linear:{x:0.150,y:0.0,z:0.0},angular:{x:0.0,y:0.0,z:-0.700}}" in remote_cmd
+    assert "{linear: {x: 0.150, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -0.700}}" in remote_cmd
 
 
 def test_format_position_for_table_uses_one_decimal_for_x_and_y() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2649,7 +2649,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
     def _build_manual_drive_command(self, *, linear_x: float, angular_z: float) -> list[str]:
         topic = self._resolve_cmd_vel_topic()
         payload = (
-            "{linear:{x:%s,y:0.0,z:0.0},angular:{x:0.0,y:0.0,z:%s}}"
+            "{linear: {x: %s, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: %s}}"
             % (format(float(linear_x), ".3f"), format(float(angular_z), ".3f"))
         )
         remote_command = " ".join(


### PR DESCRIPTION
### Motivation
- The ROS2 `ros2 topic pub` Twist payload was emitted as a compact flow-map (e.g. `x:-0.150`) which can be rejected by YAML parsers/transport layers, causing manual-drive commands (e.g. rückwärts) to fail to parse.

### Description
- Adjusted the payload string in `transceiver/mission_workflow_ui.py` to emit a valid YAML flow mapping with spaces after colons (`{linear: {x: %s, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: %s}}`).
- Updated the unit test expectation in `tests/test_mission_workflow_ui.py` to match the new payload formatting.

### Testing
- Running `pytest -q tests/test_mission_workflow_ui.py -k manual_drive_command` without `PYTHONPATH` initially failed collection due to import configuration (`ModuleNotFoundError`).
- Running `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k manual_drive_command` succeeded with `1 passed, 45 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8aa1b89e08321b04da4f3e52fbe2c)