### PR TITLE
Add nav2point button and map-pick mode to mission workflow

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -238,6 +238,24 @@ def test_build_manual_drive_command_reuses_remote_ssh_transport_builder() -> Non
     assert "{linear: {x: 0.150, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: -0.700}}" in remote_cmd
 
 
+def test_map_click_in_nav2point_mode_dispatches_navigation() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._nav2point_map_pick_mode_enabled = True
+    window._measurement_map_pick_mode_enabled = False
+    window._waypoint_map_pick_mode_enabled = False
+    window._rx_antenna_map_pick_mode_enabled = False
+    window._preview_pixel_to_world = lambda **_kwargs: (2.5, -1.75)
+    mode_switch_calls: list[bool] = []
+    navigation_targets: list[tuple[float, float]] = []
+    window._set_nav2point_map_pick_mode = lambda enabled: mode_switch_calls.append(enabled)
+    window._navigate_to_map_position = lambda *, x, y: navigation_targets.append((x, y))
+
+    window._on_map_canvas_click(SimpleNamespace(x=10, y=20))
+
+    assert mode_switch_calls == [False]
+    assert navigation_targets == [(2.5, -1.75)]
+
+
 def test_format_position_for_table_uses_one_decimal_for_x_and_y() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._mission_points = [

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -423,6 +423,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             width=110,
         )
         self.measurement_map_pick_mode_btn.grid(row=0, column=1, padx=(6, 0), sticky="w")
+        self.nav2point_map_pick_mode_btn = ctk.CTkButton(
+            map_top_controls,
+            text="nav2point",
+            command=self._toggle_nav2point_map_pick_mode,
+            width=110,
+        )
+        self.nav2point_map_pick_mode_btn.grid(row=0, column=2, padx=(6, 0), sticky="w")
         self.map_status_var = tk.StringVar(value="Karte nicht konfiguriert.")
         ctk.CTkLabel(map_frame, textvariable=self.map_status_var, anchor="w").grid(
             row=1, column=0, sticky="ew", padx=8, pady=(0, 6)
@@ -464,6 +471,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._measurement_map_pick_mode_enabled = False
         self._measurement_start_world_position: tuple[float, float] | None = None
         self._measurement_end_world_position: tuple[float, float] | None = None
+        self._nav2point_map_pick_mode_enabled = False
+        self._nav2point_navigation_active = False
         self._manual_drive_lock = threading.Lock()
         self._pending_waypoint_world_position: tuple[float, float] | None = None
         self._pending_waypoint_yaw_radians = 0.0
@@ -857,6 +866,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._draw_map_preview()
 
     def _on_map_canvas_click(self, event: tk.Event) -> None:
+        if getattr(self, "_nav2point_map_pick_mode_enabled", False):
+            world_position = self._preview_pixel_to_world(preview_x=float(event.x), preview_y=float(event.y))
+            if world_position is None:
+                return
+            self._set_nav2point_map_pick_mode(False)
+            self._navigate_to_map_position(x=world_position[0], y=world_position[1])
+            return
         if getattr(self, "_measurement_map_pick_mode_enabled", False):
             world_position = self._preview_pixel_to_world(preview_x=float(event.x), preview_y=float(event.y))
             if world_position is None:
@@ -955,6 +971,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if enabled:
             self._set_waypoint_map_pick_mode(False)
             self._set_measurement_map_pick_mode(False)
+            self._disable_nav2point_map_pick_mode()
         button_text = "✕" if enabled else "🖱️"
         self.rx_antenna_map_pick_mode_btn.configure(text=button_text)
         self._update_map_canvas_cursor()
@@ -973,6 +990,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             measurement_button = getattr(self, "measurement_map_pick_mode_btn", None)
             if measurement_button is not None:
                 measurement_button.configure(text="measurement")
+            self._disable_nav2point_map_pick_mode()
         else:
             self._clear_pending_waypoint_marker()
         self.waypoint_map_pick_mode_btn.configure(text="✕" if enabled else "🖱️")
@@ -987,6 +1005,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if enabled:
             self._set_waypoint_map_pick_mode(False)
             self._set_rx_antenna_map_pick_mode(False)
+            self._disable_nav2point_map_pick_mode()
         else:
             self._measurement_start_world_position = None
             self._measurement_end_world_position = None
@@ -998,6 +1017,64 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _toggle_measurement_map_pick_mode(self) -> None:
         self._set_measurement_map_pick_mode(not self._measurement_map_pick_mode_enabled)
+
+    def _disable_nav2point_map_pick_mode(self) -> None:
+        self._nav2point_map_pick_mode_enabled = False
+        nav2point_button = getattr(self, "nav2point_map_pick_mode_btn", None)
+        if nav2point_button is not None:
+            nav2point_button.configure(text="nav2point")
+
+    def _set_nav2point_map_pick_mode(self, enabled: bool) -> None:
+        if enabled and self._nav2point_navigation_active:
+            return
+        self._nav2point_map_pick_mode_enabled = enabled
+        if enabled:
+            self._set_waypoint_map_pick_mode(False)
+            self._set_rx_antenna_map_pick_mode(False)
+            self._set_measurement_map_pick_mode(False)
+        if enabled:
+            nav2point_button = getattr(self, "nav2point_map_pick_mode_btn", None)
+            if nav2point_button is not None:
+                nav2point_button.configure(text="✕")
+        else:
+            self._disable_nav2point_map_pick_mode()
+        self._update_map_canvas_cursor()
+        self._draw_map_preview()
+
+    def _toggle_nav2point_map_pick_mode(self) -> None:
+        self._set_nav2point_map_pick_mode(not self._nav2point_map_pick_mode_enabled)
+
+    def _navigate_to_map_position(self, *, x: float, y: float) -> None:
+        if self._nav2point_navigation_active:
+            self._append_validation("⚠️ nav2point bereits aktiv: Bitte warten, bis die aktuelle Navigation abgeschlossen ist.")
+            return
+        self._nav2point_navigation_active = True
+        self._set_nav2point_map_pick_mode(False)
+        self._append_validation(f"ℹ️ nav2point gestartet: Ziel x={x:.3f}, y={y:.3f}")
+
+        def _run_navigation() -> None:
+            navigator = self._ensure_navigator()
+            target = NavigationPoint(x=float(x), y=float(y))
+            state = navigator.navigate_to_point(
+                target,
+                timeout_s=float(self._runtime_config.goal_reached_timeout_s),
+            )
+
+            def _finish() -> None:
+                self._nav2point_navigation_active = False
+                if state == "succeeded":
+                    self._append_validation(f"✅ nav2point erreicht: x={x:.3f}, y={y:.3f}")
+                else:
+                    self._append_validation(
+                        f"❌ nav2point fehlgeschlagen ({state}): Ziel x={x:.3f}, y={y:.3f}"
+                    )
+
+            try:
+                self.after(0, _finish)
+            except tk.TclError:
+                self._nav2point_navigation_active = False
+
+        threading.Thread(target=_run_navigation, daemon=True).start()
 
     @staticmethod
     def _measurement_distance_m(
@@ -1062,6 +1139,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._rx_antenna_map_pick_mode_enabled
             or self._waypoint_map_pick_mode_enabled
             or getattr(self, "_measurement_map_pick_mode_enabled", False)
+            or getattr(self, "_nav2point_map_pick_mode_enabled", False)
         )
         self.map_preview_canvas.configure(cursor="crosshair" if pick_mode_active else "")
 


### PR DESCRIPTION
### Motivation
- Ermöglichen, durch einen Button im Measurement-Workflow auf der Karte einen Punkt anzuklicken und den Roboter einmalig dorthin fahren zu lassen (einfacher Operator-Shortcut für ad-hoc Navigation). 

### Description
- Fügt einen neuen Button `nav2point` in den Karten-Top-Controls hinzu und führt eine dedizierte Nav2Point-Pick-Mode-Flag (`_nav2point_map_pick_mode_enabled`) ein. 
- Beim Klick in diesem Modus wird die Pixelposition in Weltkoordinaten konvertiert, der Pick-Mode beendet und ein einmaliges `NavigationPoint`-Ziel via `navigate_to_point` asynchron gestartet; Statusnachrichten werden ins Validation-Log geschrieben. 
- Macht `nav2point` gegenseitig exklusiv zu vorhandenen Map-Pick-Modi (`measurement`, `waypoint`, `rx_antenna`) und aktualisiert den Map-Cursor, sodass er den neuen Pick-Mode berücksichtigt. 
- Fügt einen Regressionstest hinzu, der bestätigt, dass ein Kartenklick im `nav2point`-Modus den Mode deaktiviert und die Navigation mit den erwarteten Koordinaten auslöst. 

### Testing
- `pytest -q tests/test_mission_workflow_ui.py` initially errored due to missing import when run without module path (`ModuleNotFoundError: No module named 'transceiver'`).
- `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py::test_map_click_in_nav2point_mode_dispatches_navigation` succeeded (`1 passed`).
- `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py tests/test_mission_workflow_ui_state.py` succeeded (`61 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8d26706d88321a09b2a3d874eb4d9)