### PR TITLE
Optimize echo overlay ellipse rendering

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -12,6 +12,7 @@ import re
 from fractions import Fraction
 from pathlib import Path
 import json
+import os
 from tkinter import filedialog, messagebox, ttk
 import tkinter as tk
 from typing import Any, Callable
@@ -59,6 +60,10 @@ MEASUREMENT_START_LIVE_POSITION_WAIT_INTERVAL_S = 0.1
 MAP_LAYER_BASE_TAG = "map_base"
 MAP_LAYER_STATIC_OVERLAY_TAG = "static_overlay"
 MAP_LAYER_LIVE_OVERLAY_TAG = "live_overlay"
+ECHO_OVERLAY_MIN_SAMPLES = 24
+ECHO_OVERLAY_MAX_SAMPLES = 48
+ECHO_OVERLAY_MAX_LIVE_ECHOS = 3
+ECHO_OVERLAY_PROFILE_DEBUG = os.getenv("TRANSCEIVER_ECHO_OVERLAY_PROFILE", "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _load_json_dict(path: Path) -> dict[str, Any]:
@@ -463,6 +468,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._last_live_diagnosis_key: str | None = None
         self._emit_live_diagnostics_to_validation = True
         self._rx_antenna_global_position: tuple[float, float] | None = None
+        self._echo_unit_ellipse_cache: dict[int, tuple[tuple[float, float], ...]] = {}
+        self._echo_overlay_profile_debug = ECHO_OVERLAY_PROFILE_DEBUG
         self._rx_antenna_map_pick_mode_enabled = False
         self._waypoint_map_pick_mode_enabled = False
         self._waypoint_drag_start_preview: tuple[float, float] | None = None
@@ -1212,8 +1219,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _draw_live_overlay(self) -> None:
         self.map_preview_canvas.delete(MAP_LAYER_LIVE_OVERLAY_TAG)
+        start_ts = time.perf_counter() if self._echo_overlay_profile_debug else 0.0
         self._draw_live_echo_preview_overlay()
         self._draw_live_marker()
+        if self._echo_overlay_profile_debug:
+            elapsed_ms = (time.perf_counter() - start_ts) * 1000.0
+            print(f"[echo-overlay] live overlay frame: {elapsed_ms:.2f} ms")
         self._last_live_redraw_ts = time.time()
 
     def _draw_rx_antenna_marker(self) -> None:
@@ -1523,10 +1534,20 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         measurement_position = (float(x_value), float(y_value))
         if not math.isfinite(measurement_position[0]) or not math.isfinite(measurement_position[1]):
             return
-        echo_distances = self._get_live_preview_echo_distances(limit=len(ECHO_OVERLAY_COLORS))
-        if not echo_distances:
+        echo_candidates = self._get_live_preview_echo_candidates(limit=len(ECHO_OVERLAY_COLORS))
+        if not echo_candidates:
             return
-        for echo_index, echo_distance in enumerate(echo_distances):
+        max_live = ECHO_OVERLAY_MAX_LIVE_ECHOS
+        if max_live > 0 and len(echo_candidates) > max_live:
+            if any(strength is not None for _, strength in echo_candidates):
+                echo_candidates = sorted(
+                    echo_candidates,
+                    key=lambda item: item[1] if item[1] is not None else float("-inf"),
+                    reverse=True,
+                )[:max_live]
+            else:
+                echo_candidates = echo_candidates[:max_live]
+        for echo_index, (echo_distance, _strength) in enumerate(echo_candidates):
             color = ECHO_OVERLAY_COLORS[echo_index % len(ECHO_OVERLAY_COLORS)]
             self._draw_echo_ellipse_for_overlay(
                 rx_position=rx_position,
@@ -1580,21 +1601,60 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         return MeasurementPoint(id=None, name=None, x=x, y=y, yaw=yaw)
 
     @staticmethod
-    def _extract_echo_distances(value: Any, *, limit: int) -> list[float]:
+    def _extract_echo_candidates(value: Any, *, limit: int) -> list[tuple[float, float | None]]:
         if not isinstance(value, list) or limit <= 0:
             return []
-        distances: list[float] = []
+        candidates: list[tuple[float, float | None]] = []
+        strength_keys = ("signal_strength", "strength", "amplitude", "power_db", "snr_db")
         for item in value[:limit]:
-            if not isinstance(item, dict):
+            strength: float | None = None
+            if isinstance(item, dict):
+                distance_value = item.get("distance_m")
+                for key in strength_keys:
+                    raw_strength = item.get(key)
+                    if isinstance(raw_strength, (int, float)) and math.isfinite(float(raw_strength)):
+                        strength = float(raw_strength)
+                        break
+            elif isinstance(item, (int, float)):
+                distance_value = item
+            else:
                 continue
-            distance_m = item.get("distance_m")
-            if not isinstance(distance_m, (int, float)):
+            if not isinstance(distance_value, (int, float)):
                 continue
-            numeric = float(distance_m)
-            if not math.isfinite(numeric) or numeric <= 0.0:
+            numeric_distance = float(distance_value)
+            if not math.isfinite(numeric_distance) or numeric_distance <= 0.0:
                 continue
-            distances.append(numeric)
-        return distances
+            candidates.append((numeric_distance, strength))
+        return candidates
+
+    @staticmethod
+    def _extract_echo_distances(value: Any, *, limit: int) -> list[float]:
+        return [distance for distance, _ in MissionWorkflowWindow._extract_echo_candidates(value, limit=limit)]
+
+    def _get_unit_ellipse_points(self, samples: int) -> tuple[tuple[float, float], ...]:
+        cached = self._echo_unit_ellipse_cache.get(samples)
+        if cached is not None:
+            return cached
+        points: list[tuple[float, float]] = []
+        for idx in range(samples + 1):
+            t = (2.0 * math.pi * idx) / samples
+            points.append((math.cos(t), math.sin(t)))
+        cached = tuple(points)
+        self._echo_unit_ellipse_cache[samples] = cached
+        return cached
+
+    def _adaptive_echo_samples(self) -> int:
+        min_samples = ECHO_OVERLAY_MIN_SAMPLES
+        max_samples = ECHO_OVERLAY_MAX_SAMPLES
+        if max_samples <= min_samples:
+            return min_samples
+        canvas_width = max(1, self.map_preview_canvas.winfo_width())
+        canvas_height = max(1, self.map_preview_canvas.winfo_height())
+        max_scale = max(self._map_preview_scale)
+        canvas_factor = min(1.0, max(canvas_width, canvas_height) / 1000.0)
+        zoom_factor = min(1.0, max(0.0, (max_scale - 0.3) / 0.8))
+        quality = 0.55 * zoom_factor + 0.45 * canvas_factor
+        return int(round(min_samples + (max_samples - min_samples) * quality))
 
     def _draw_echo_ellipse_for_overlay(
         self,
@@ -1638,25 +1698,21 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         angle = math.atan2(point_y - rx_y, point_x - rx_x)
         cos_angle = math.cos(angle)
         sin_angle = math.sin(angle)
-        samples = 64
+        samples = self._adaptive_echo_samples()
+        unit_points = self._get_unit_ellipse_points(samples)
+        scale_x, scale_y = self._map_preview_scale
+        offset_x, offset_y = self._map_preview_offset
+        image_height = original.height()
         preview_points: list[float] = []
-        for idx in range(samples + 1):
-            t = (2.0 * math.pi * idx) / samples
-            local_x = semi_major_axis * math.cos(t)
-            local_y = semi_minor_axis * math.sin(t)
+        for unit_x, unit_y in unit_points:
+            local_x = semi_major_axis * unit_x
+            local_y = semi_minor_axis * unit_y
             world_x = center_x + local_x * cos_angle - local_y * sin_angle
             world_y = center_y + local_x * sin_angle + local_y * cos_angle
-            map_pixel = self._world_to_map_pixel(x=world_x, y=world_y, image_height=original.height())
+            map_pixel = self._world_to_map_pixel(x=world_x, y=world_y, image_height=image_height)
             if map_pixel is None:
                 continue
-            scale_x, scale_y = self._map_preview_scale
-            offset_x, offset_y = self._map_preview_offset
-            preview_points.extend(
-                (
-                    map_pixel[0] * scale_x + offset_x,
-                    map_pixel[1] * scale_y + offset_y,
-                )
-        )
+            preview_points.extend((map_pixel[0] * scale_x + offset_x, map_pixel[1] * scale_y + offset_y))
         if len(preview_points) < 6:
             return
         line_width = max(1, int(round((echo_distance_m / resolution) * self._map_preview_scale[0] * 0.03)))
@@ -2953,7 +3009,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
         threading.Thread(target=_worker, daemon=True).start()
 
-    def _get_live_preview_echo_distances(self, *, limit: int) -> list[float]:
+    def _get_live_preview_echo_candidates(self, *, limit: int) -> list[tuple[float, float | None]]:
         if limit <= 0:
             return []
         getter = getattr(self.master, "get_live_echo_distances_for_mission_preview", None)
@@ -2963,17 +3019,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             payload = getter(limit=limit)
         except Exception:
             return []
-        if not isinstance(payload, list):
-            return []
-        distances: list[float] = []
-        for value in payload[:limit]:
-            if not isinstance(value, (int, float)):
-                continue
-            numeric = float(value)
-            if not math.isfinite(numeric) or numeric <= 0.0:
-                continue
-            distances.append(numeric)
-        return distances
+        return self._extract_echo_candidates(payload, limit=limit)
+
+    def _get_live_preview_echo_distances(self, *, limit: int) -> list[float]:
+        return [distance for distance, _ in self._get_live_preview_echo_candidates(limit=limit)]
 
     def _is_continuous_active(self) -> bool:
         cont_thread = getattr(self.master, "_cont_thread", None)


### PR DESCRIPTION
### Motivation
- Reduce CPU work and improve live overlay responsiveness by lowering unnecessary per-frame trig and transform work when drawing echo ellipses.

### Description
- Use an adaptive sample count for ellipse polylines between `ECHO_OVERLAY_MIN_SAMPLES` and `ECHO_OVERLAY_MAX_SAMPLES` instead of a fixed 64 samples to draw fewer points at low zoom/canvas sizes.
- Cache precomputed unit-ellipse points (cos/sin) per sample count in `_echo_unit_ellipse_cache` and add helper ` _get_unit_ellipse_points()` to avoid recomputing trig values each frame.
- Move repeated preview transform lookups (`scale_x/scale_y`, `offset_x/offset_y`) and `image_height` out of the inner loop in `_draw_echo_ellipse_for_overlay()`.
- Introduce echo candidate extraction with optional strength metadata via `_extract_echo_candidates()` and cap concurrently drawn live echoes with `ECHO_OVERLAY_MAX_LIVE_ECHOS`, performing Top‑N selection by strength when available.
- Add optional per-frame profiling logging for live overlay render time controlled by the environment flag `TRANSCEIVER_ECHO_OVERLAY_PROFILE` (constant `ECHO_OVERLAY_PROFILE_DEBUG`).
- New/changed helpers: `_adaptive_echo_samples()`, `_get_unit_ellipse_points()`, `_extract_echo_candidates()`, `_get_live_preview_echo_candidates()` and related constants `ECHO_OVERLAY_MIN_SAMPLES`, `ECHO_OVERLAY_MAX_SAMPLES`, `ECHO_OVERLAY_MAX_LIVE_ECHOS`, `ECHO_OVERLAY_PROFILE_DEBUG`.

### Testing
- Type-compile check ran with `python -m py_compile transceiver/mission_workflow_ui.py` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8d3447b3c8321a8d3346f474ce63a)