### PR TITLE
Persist inline MapConfig in workflow state and fallback on restore

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -711,6 +712,70 @@ def test_on_live_pose_stream_switch_changed_persists_and_syncs() -> None:
     window._on_live_pose_stream_switch_changed()
 
     assert calls == ["persist", "sync", "label"]
+
+
+def test_restore_workflow_state_uses_inline_map_config_without_file(tmp_path) -> None:
+    class _Var:
+        def __init__(self, value):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value) -> None:
+            self._value = value
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._workflow_state_file = tmp_path / "mission_workflow_state.json"
+    window._is_restoring_workflow_state = False
+    window.mission_name_var = _Var("")
+    window.repeat_var = _Var("")
+    window.start_point_var = _Var("")
+    window.lidar_reference_enabled_var = _Var(True)
+    window.manual_review_enabled_var = _Var(True)
+    window.test_run_enabled_var = _Var(False)
+    window.manual_navigation_enabled_var = _Var(False)
+    window.reverse_point_order_var = _Var(False)
+    window.live_pose_stream_enabled_var = _Var(False)
+    window.live_preview_enabled_var = _Var(False)
+    window._mission_points = []
+    window._mission = None
+    window._selected_map_config = None
+    window._selected_map_config_file = None
+    window._parse_rx_antenna_global_position = MissionWorkflowWindow._parse_rx_antenna_global_position
+    window._clear_rx_antenna_position = lambda *, persist: None
+    window._set_rx_antenna_position = lambda *, x, y, persist: None
+    window._refresh_points_table = lambda: None
+    window._refresh_map_section = lambda: None
+    window._active_start_points = lambda: []
+    window._format_start_point_label = MissionWorkflowWindow._format_start_point_label
+    window._set_validation_text = lambda _text: None
+    window._append_validation = lambda _text: None
+    window._refresh_review_ready_indicator = lambda: None
+    window._load_map_config_from_file = lambda _path: None
+
+    payload = {
+        "name": "Inline Map Mission",
+        "repeat": 1,
+        "points": [{"id": "p1", "x": 0.0, "y": 0.0, "yaw": 0.0}],
+        "map_config_inline": {
+            "image": "maps/inline_map.pgm",
+            "resolution": 0.05,
+            "origin": [1.0, 2.0, 0.0],
+            "frame_id": "map",
+            "negate": 0,
+            "occupied_thresh": 0.65,
+            "free_thresh": 0.2,
+        },
+    }
+    window._workflow_state_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    window._restore_workflow_state()
+
+    assert window._selected_map_config is not None
+    assert window._selected_map_config.image == "maps/inline_map.pgm"
+    assert window._selected_map_config.resolution == 0.05
+    assert window._selected_map_config_file is None
 
 
 def test_measurement_distance_m_returns_hypotenuse_for_two_points() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2378,12 +2378,24 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             repeat = int(repeat_raw)
         except ValueError:
             repeat = repeat_raw
+        inline_map_config = None
+        if self._selected_map_config is not None:
+            inline_map_config = {
+                "image": self._selected_map_config.image,
+                "resolution": self._selected_map_config.resolution,
+                "origin": list(self._selected_map_config.origin),
+                "frame_id": self._selected_map_config.frame_id,
+                "negate": self._selected_map_config.negate,
+                "occupied_thresh": self._selected_map_config.occupied_thresh,
+                "free_thresh": self._selected_map_config.free_thresh,
+            }
         return {
             "name": self.mission_name_var.get().strip(),
             "repeat": repeat,
             "points": [self._serialize_point(point) for point in self._mission_points],
             "start_point_index": self._selected_start_point_index(),
             "map_config_file": self._selected_map_config_file,
+            "map_config_inline": inline_map_config,
             "rx_antenna_global_position": self._serialize_rx_antenna_global_position(),
             "lidar_reference_enabled": bool(self.lidar_reference_enabled_var.get()),
             "manual_review_enabled": bool(self.manual_review_enabled_var.get()),
@@ -2428,9 +2440,20 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._is_restoring_workflow_state = True
         try:
             map_config_file = payload.get("map_config_file")
+            map_config_inline = payload.get("map_config_inline")
             loaded_map_config: MapConfig | None = None
             if isinstance(map_config_file, str) and map_config_file.strip():
                 loaded_map_config = self._load_map_config_from_file(Path(map_config_file))
+            if loaded_map_config is None and map_config_inline is not None:
+                loaded_map_config = measurement_mission_from_dict(
+                    {
+                        "name": "mission-map-config-inline",
+                        "repeat": 1,
+                        "wait_after_arrival_s": 0.0,
+                        "points": [{"id": "inline-map-config", "x": 0.0, "y": 0.0, "yaw": 0.0}],
+                        "map_config": map_config_inline,
+                    }
+                ).map_config
             mission = measurement_mission_from_dict(
                 {
                     "name": str(payload.get("name") or "mission-ui"),
@@ -2462,7 +2485,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._mission_points = list(mission.points)
             self._mission = mission
             self._selected_map_config = mission.map_config
-            self._selected_map_config_file = payload.get("map_config_file")
+            self._selected_map_config_file = map_config_file.strip() if isinstance(map_config_file, str) and map_config_file.strip() else None
             rx_position = self._parse_rx_antenna_global_position(payload.get("rx_antenna_global_position"))
             if rx_position is None:
                 self._clear_rx_antenna_position(persist=False)


### PR DESCRIPTION
### Motivation
- Ensure an in-memory `MapConfig` is not lost when a persisted workflow has no file path by storing the full map config inline in the workflow payload.
- Prefer loading a `map_config_file` when present but allow restoring from an inline `map_config_inline` payload if file loading fails or no path is available.

### Description
- `transceiver/mission_workflow_ui.py`: Extended `_build_workflow_state_payload()` to include a `map_config_inline` entry containing the full `MapConfig` (`image`, `resolution`, `origin`, `frame_id`, `negate`, `occupied_thresh`, `free_thresh`) when `self._selected_map_config` is set.
- `transceiver/mission_workflow_ui.py`: Updated `_restore_workflow_state()` to first attempt loading `map_config_file` and, if that yields no `MapConfig`, fall back to `map_config_inline` and reconstruct a `MapConfig` via `measurement_mission_from_dict()` (using a small dummy point to satisfy validation).
- `transceiver/mission_workflow_ui.py`: Normalize assignment of `self._selected_map_config_file` so it is set to `None` unless `map_config_file` is a non-empty string.
- `tests/test_mission_workflow_ui.py`: Added `test_restore_workflow_state_uses_inline_map_config_without_file` to verify saving/restoring a state that contains `map_config_inline` but no `map_config_file` keeps `_selected_map_config` set and results in `_selected_map_config_file` being `None`, and added a `json` import used by the test.

### Testing
- Ran the focused test: `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "inline_map_config"`, and the new test passed (`1 passed`).
- Ran the full test module: `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py`, and the run showed two existing failures unrelated to this change in lidar overlay tests that expect a `layer_tag` argument; these failures pre-existed and are not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8dc9b76208321b144a8bebb264eee)