### PR TITLE
Fallback to inline map-config when persisted map file cannot be loaded

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -778,6 +778,76 @@ def test_restore_workflow_state_uses_inline_map_config_without_file(tmp_path) ->
     assert window._selected_map_config_file is None
 
 
+def test_restore_workflow_state_falls_back_to_inline_map_config_when_file_load_fails(tmp_path) -> None:
+    class _Var:
+        def __init__(self, value):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value) -> None:
+            self._value = value
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._workflow_state_file = tmp_path / "mission_workflow_state.json"
+    window._is_restoring_workflow_state = False
+    window.mission_name_var = _Var("")
+    window.repeat_var = _Var("")
+    window.start_point_var = _Var("")
+    window.lidar_reference_enabled_var = _Var(True)
+    window.manual_review_enabled_var = _Var(True)
+    window.test_run_enabled_var = _Var(False)
+    window.manual_navigation_enabled_var = _Var(False)
+    window.reverse_point_order_var = _Var(False)
+    window.live_pose_stream_enabled_var = _Var(False)
+    window.live_preview_enabled_var = _Var(False)
+    window._mission_points = []
+    window._mission = None
+    window._selected_map_config = None
+    window._selected_map_config_file = None
+    window._parse_rx_antenna_global_position = MissionWorkflowWindow._parse_rx_antenna_global_position
+    window._clear_rx_antenna_position = lambda *, persist: None
+    window._set_rx_antenna_position = lambda *, x, y, persist: None
+    window._refresh_points_table = lambda: None
+    window._refresh_map_section = lambda: None
+    window._active_start_points = lambda: []
+    window._format_start_point_label = MissionWorkflowWindow._format_start_point_label
+    window._set_validation_text = lambda _text: None
+    messages: list[str] = []
+    window._append_validation = messages.append
+    window._refresh_review_ready_indicator = lambda: None
+
+    def _raise_on_file_load(_path):
+        raise FileNotFoundError("missing map config")
+
+    window._load_map_config_from_file = _raise_on_file_load
+
+    payload = {
+        "name": "Inline Fallback Mission",
+        "repeat": 1,
+        "points": [{"id": "p1", "x": 0.0, "y": 0.0, "yaw": 0.0}],
+        "map_config_file": "/tmp/does-not-exist/map.yaml",
+        "map_config_inline": {
+            "image": "maps/inline_map.pgm",
+            "resolution": 0.05,
+            "origin": [1.0, 2.0, 0.0],
+            "frame_id": "map",
+            "negate": 0,
+            "occupied_thresh": 0.65,
+            "free_thresh": 0.2,
+        },
+    }
+    window._workflow_state_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    window._restore_workflow_state()
+
+    assert window._selected_map_config is not None
+    assert window._selected_map_config.image == "maps/inline_map.pgm"
+    assert window._selected_map_config_file is None
+    assert any("Inline-Map-Config" in message for message in messages)
+
+
 def test_measurement_distance_m_returns_hypotenuse_for_two_points() -> None:
     distance = MissionWorkflowWindow._measurement_distance_m((1.0, 2.0), (4.0, 6.0))
 

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2442,8 +2442,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             map_config_file = payload.get("map_config_file")
             map_config_inline = payload.get("map_config_inline")
             loaded_map_config: MapConfig | None = None
+            map_config_file_value: str | None = (
+                map_config_file.strip() if isinstance(map_config_file, str) and map_config_file.strip() else None
+            )
+            loaded_map_config_from_file = False
             if isinstance(map_config_file, str) and map_config_file.strip():
-                loaded_map_config = self._load_map_config_from_file(Path(map_config_file))
+                try:
+                    loaded_map_config = self._load_map_config_from_file(Path(map_config_file))
+                    loaded_map_config_from_file = loaded_map_config is not None
+                except Exception:
+                    self._append_validation(
+                        "⚠️ Persistierte Map-Config-Datei konnte nicht geladen werden; verwende Inline-Map-Config."
+                    )
             if loaded_map_config is None and map_config_inline is not None:
                 loaded_map_config = measurement_mission_from_dict(
                     {
@@ -2485,7 +2495,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._mission_points = list(mission.points)
             self._mission = mission
             self._selected_map_config = mission.map_config
-            self._selected_map_config_file = map_config_file.strip() if isinstance(map_config_file, str) and map_config_file.strip() else None
+            self._selected_map_config_file = map_config_file_value if loaded_map_config_from_file else None
             rx_position = self._parse_rx_antenna_global_position(payload.get("rx_antenna_global_position"))
             if rx_position is None:
                 self._clear_rx_antenna_position(persist=False)


### PR DESCRIPTION
### Motivation
- Restoring the persisted workflow state aborted when a previously saved `map_config_file` existed but could not be loaded, which prevented falling back to the persisted `map_config_inline` and caused the UI to lose the map.
- The intent is to preserve the map shown in the UI across restarts/toggles by making restore resilient to missing/invalid persisted map files.

### Description
- Catch exceptions when loading `map_config_file` during `_restore_workflow_state` and append a validation message instead of aborting, then attempt to use `map_config_inline` if present.
- Track whether the file-based config was actually loaded (`loaded_map_config_from_file`) and only set `self._selected_map_config_file` when the file was successfully loaded; otherwise leave it as `None` to avoid keeping a broken path.
- Add a regression test `test_restore_workflow_state_falls_back_to_inline_map_config_when_file_load_fails` to assert that a failing file load falls back to the inline map and that a validation message is emitted.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "restore_workflow_state or live_pose_stream_switch_changed"` which completed successfully with `3 passed, 49 deselected`.
- An earlier test invocation without `PYTHONPATH` failed with `ModuleNotFoundError` (environment issue), but the proper test run with `PYTHONPATH=.` passed as shown above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8ddfdbbc08321843893df48777d18)