### PR TITLE
Harden map_config persistence and restore consistency in mission workflow UI

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from transceiver.measurement_mission import MeasurementPoint
+from transceiver.measurement_mission import MapConfig, MeasurementMission, MeasurementPoint
 from transceiver.mission_workflow_ui import MissionWorkflowWindow, _compute_bistatic_echo_ellipse_axes
 
 
@@ -712,6 +712,119 @@ def test_on_live_pose_stream_switch_changed_persists_and_syncs() -> None:
     window._on_live_pose_stream_switch_changed()
 
     assert calls == ["persist", "sync", "label"]
+
+
+
+
+def _build_state_window_stub(tmp_path) -> MissionWorkflowWindow:
+    class _Var:
+        def __init__(self, value):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value) -> None:
+            self._value = value
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._workflow_state_file = tmp_path / "mission_workflow_state.json"
+    window._is_restoring_workflow_state = False
+    window.mission_name_var = _Var("Mission")
+    window.repeat_var = _Var("1")
+    window.start_point_var = _Var("1")
+    window.lidar_reference_enabled_var = _Var(True)
+    window.manual_review_enabled_var = _Var(True)
+    window.test_run_enabled_var = _Var(False)
+    window.manual_navigation_enabled_var = _Var(False)
+    window.reverse_point_order_var = _Var(False)
+    window.live_pose_stream_enabled_var = _Var(False)
+    window.live_preview_enabled_var = _Var(False)
+    window._mission_points = [MeasurementPoint(id="p1", name="", x=0.0, y=0.0, yaw=0.0)]
+    window._selected_start_point_index = lambda: 0
+    window._serialize_point = MissionWorkflowWindow._serialize_point
+    window._serialize_rx_antenna_global_position = lambda: None
+    window._selected_map_config_file = None
+    window._selected_map_config = None
+    window._mission = MeasurementMission(name="Mission", points=list(window._mission_points), repeat=1, map_config=None)
+    return window
+
+
+def test_live_position_toggle_persists_and_keeps_map_config_inline(tmp_path) -> None:
+    window = _build_state_window_stub(tmp_path)
+    window.live_pose_stream_enabled_var.set(True)
+    window._mission = MeasurementMission(
+        name="Mission",
+        points=list(window._mission_points),
+        repeat=1,
+        map_config=MapConfig(
+            image="maps/fallback.pgm",
+            resolution=0.05,
+            origin=(1.0, 2.0, 0.0),
+            frame_id="map",
+            negate=0,
+            occupied_thresh=0.65,
+            free_thresh=0.2,
+        ),
+    )
+    window._sync_live_pose_stream_state = lambda: None
+    window._update_live_label = lambda: None
+
+    window._on_live_pose_stream_switch_changed()
+
+    payload = json.loads(window._workflow_state_file.read_text(encoding="utf-8"))
+    assert payload["live_pose_stream_enabled"] is True
+    assert payload["map_config_inline"]["image"] == "maps/fallback.pgm"
+
+
+def test_nav2point_start_does_not_drop_map_config_fields_in_state(tmp_path) -> None:
+    window = _build_state_window_stub(tmp_path)
+    initial_payload = {
+        "name": "Mission",
+        "repeat": 1,
+        "points": [{"id": "p1", "x": 0.0, "y": 0.0, "yaw": 0.0}],
+        "map_config_file": "/tmp/map.yaml",
+        "map_config_inline": {"image": "maps/inline_map.pgm", "resolution": 0.05, "origin": [0.0, 0.0, 0.0]},
+    }
+    window._workflow_state_file.write_text(json.dumps(initial_payload), encoding="utf-8")
+    window._build_workflow_state_payload = lambda: {
+        "name": "Mission",
+        "repeat": 1,
+        "points": [{"id": "p1", "x": 0.0, "y": 0.0, "yaw": 0.0}],
+        "map_config_file": None,
+        "map_config_inline": None,
+    }
+
+    window._persist_workflow_state()
+
+    payload = json.loads(window._workflow_state_file.read_text(encoding="utf-8"))
+    assert payload["map_config_file"] == "/tmp/map.yaml"
+    assert payload["map_config_inline"]["image"] == "maps/inline_map.pgm"
+
+
+def test_build_workflow_state_payload_falls_back_to_mission_map_config_when_selected_none(tmp_path) -> None:
+    window = _build_state_window_stub(tmp_path)
+    window._selected_map_config = None
+    window._mission = MeasurementMission(
+        name="Mission",
+        points=list(window._mission_points),
+        repeat=1,
+        map_config=MapConfig(
+            image="maps/mission_map.pgm",
+            resolution=0.1,
+            origin=(3.0, 4.0, 0.0),
+            frame_id="map",
+            negate=0,
+            occupied_thresh=0.7,
+            free_thresh=0.3,
+        ),
+    )
+
+    payload = window._build_workflow_state_payload()
+
+    assert payload["map_config_file"] is None
+    assert payload["map_config_inline"]["image"] == "maps/mission_map.pgm"
+    assert payload["map_config_inline"]["resolution"] == 0.1
 
 
 def test_restore_workflow_state_uses_inline_map_config_without_file(tmp_path) -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2389,15 +2389,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         except ValueError:
             repeat = repeat_raw
         inline_map_config = None
-        if self._selected_map_config is not None:
+        selected_map_config = self._selected_map_config
+        mission_map_config = self._mission.map_config if self._mission is not None else None
+        effective_map_config = selected_map_config or mission_map_config
+        if effective_map_config is not None:
             inline_map_config = {
-                "image": self._selected_map_config.image,
-                "resolution": self._selected_map_config.resolution,
-                "origin": list(self._selected_map_config.origin),
-                "frame_id": self._selected_map_config.frame_id,
-                "negate": self._selected_map_config.negate,
-                "occupied_thresh": self._selected_map_config.occupied_thresh,
-                "free_thresh": self._selected_map_config.free_thresh,
+                "image": effective_map_config.image,
+                "resolution": effective_map_config.resolution,
+                "origin": list(effective_map_config.origin),
+                "frame_id": effective_map_config.frame_id,
+                "negate": effective_map_config.negate,
+                "occupied_thresh": effective_map_config.occupied_thresh,
+                "free_thresh": effective_map_config.free_thresh,
             }
         return {
             "name": self.mission_name_var.get().strip(),
@@ -2440,6 +2443,22 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if self._is_restoring_workflow_state:
             return
         payload = self._build_workflow_state_payload()
+        map_config_file = payload.get("map_config_file")
+        map_config_file_value = map_config_file.strip() if isinstance(map_config_file, str) and map_config_file.strip() else None
+        map_config_inline = payload.get("map_config_inline")
+        if map_config_file_value is None and map_config_inline is None:
+            previous_payload = _load_json_dict(self._workflow_state_file)
+            previous_map_config_file = previous_payload.get("map_config_file")
+            previous_map_config_inline = previous_payload.get("map_config_inline")
+            previous_map_config_file_value = (
+                previous_map_config_file.strip()
+                if isinstance(previous_map_config_file, str) and previous_map_config_file.strip()
+                else None
+            )
+            if previous_map_config_file_value is not None or previous_map_config_inline is not None:
+                payload["map_config_file"] = previous_map_config_file
+                payload["map_config_inline"] = previous_map_config_inline
+
         _diag_log(
             "persistiere Workflow-State: "
             f"selected_map_config_file={self._selected_map_config_file!r}, "
@@ -2526,10 +2545,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             if mission.map_config is not None:
                 self._selected_map_config = mission.map_config
                 self._selected_map_config_file = map_config_file_value if loaded_map_config_from_file else None
+            elif self._selected_map_config is not None:
+                self._mission = replace(self._mission, map_config=self._selected_map_config)
             else:
                 _diag_log(
                     "mission.map_config ist None beim Restore; bestehende Map-Selection bleibt unverändert."
                 )
+
+            if self._mission is not None and self._mission.map_config != self._selected_map_config:
+                if self._selected_map_config is not None:
+                    self._mission = replace(self._mission, map_config=self._selected_map_config)
+                elif self._mission.map_config is not None:
+                    self._selected_map_config = self._mission.map_config
             rx_position = self._parse_rx_antenna_global_position(payload.get("rx_antenna_global_position"))
             if rx_position is None:
                 self._clear_rx_antenna_position(persist=False)


### PR DESCRIPTION
### Motivation
- Persisting workflow state sometimes overwrote or dropped map configuration fields when `_selected_map_config` was unset or when intermediate actions produced a payload lacking map fields.
- Restoring state could leave `self._mission.map_config` and `self._selected_map_config` inconsistent which can cause the UI to lose the effective map configuration.
- Regression tests were missing for scenarios where toggles or navigation actions might inadvertently remove `map_config_*` fields from the persisted state.

### Description
- `_build_workflow_state_payload()` now builds `map_config_inline` from `self._selected_map_config` with a fallback to `self._mission.map_config` when `_selected_map_config` is `None` so the payload reflects the effective map config.
- `_persist_workflow_state()` now validates the freshly built payload and, if both `map_config_file` and `map_config_inline` are missing, loads the previous persisted state and restores `map_config_file` / `map_config_inline` from it instead of overwriting them with `None`.
- `_restore_workflow_state()` was extended with post-restore consistency synchronization that ensures `self._selected_map_config` and `self._mission.map_config` have the same value, using `replace(...)` to keep `self._mission` immutable when reconciling differences.
- Added regression tests and a small test stub in `tests/test_mission_workflow_ui.py` covering: live-position toggle persistence keeping `map_config_inline`, nav2point/start persistence not dropping `map_config_*` fields, and payload fallback to `mission.map_config` when `_selected_map_config` is `None`.

### Testing
- Ran targeted tests with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "live_position_toggle_persists_and_keeps_map_config_inline or nav2point_start_does_not_drop_map_config_fields_in_state or build_workflow_state_payload_falls_back_to_mission_map_config_when_selected_none"` and all selected tests passed (`3 passed`).
- Ran restore-related tests with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "restore_workflow_state_uses_inline_map_config_without_file or restore_workflow_state_falls_back_to_inline_map_config_when_file_load_fails"` and they passed (`2 passed`).
- Note: an initial test collection run without `PYTHONPATH=.` failed due to import resolution, after which the above successful runs were executed with `PYTHONPATH=.` set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8ed9175a483219c3a5c0f87db36c8)