### PR TITLE
Remove manual drive controls from mission workflow UI

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -627,37 +627,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             command=self._on_live_preview_switch_changed,
         ).grid(row=4, column=2, columnspan=2, padx=(8, 3), pady=(0, 4), sticky="w")
 
-        manual_drive_frame = ctk.CTkFrame(controls, fg_color="transparent")
-        manual_drive_frame.grid(row=5, column=0, columnspan=5, padx=8, pady=(0, 4), sticky="w")
-        ctk.CTkLabel(manual_drive_frame, text="Manuelles Verfahren").grid(row=0, column=0, columnspan=3, sticky="w")
-        ctk.CTkButton(
-            manual_drive_frame,
-            text="↑",
-            width=44,
-            command=lambda: self._queue_manual_drive(linear_x=0.15, angular_z=0.0, label="vorwärts"),
-        ).grid(row=1, column=1, padx=3, pady=3)
-        ctk.CTkButton(
-            manual_drive_frame,
-            text="←",
-            width=44,
-            command=lambda: self._queue_manual_drive(linear_x=0.0, angular_z=0.7, label="links"),
-        ).grid(row=2, column=0, padx=3, pady=3)
-        ctk.CTkButton(
-            manual_drive_frame,
-            text="→",
-            width=44,
-            command=lambda: self._queue_manual_drive(linear_x=0.0, angular_z=-0.7, label="rechts"),
-        ).grid(row=2, column=2, padx=3, pady=3)
-        ctk.CTkButton(
-            manual_drive_frame,
-            text="↓",
-            width=44,
-            command=lambda: self._queue_manual_drive(linear_x=-0.15, angular_z=0.0, label="rückwärts"),
-        ).grid(row=3, column=1, padx=3, pady=3)
-
         self.live_var = tk.StringVar(value="Punkt: - | Navigation: idle | Messung: idle | Verbleibend: - | Live-Status: Karte nicht geladen")
         ctk.CTkLabel(controls, textvariable=self.live_var, anchor="w", justify="left").grid(
-            row=6, column=0, columnspan=5, sticky="nsew", padx=8, pady=(4, 8)
+            row=5, column=0, columnspan=5, sticky="nsew", padx=8, pady=(4, 8)
         )
 
         table_frame = ctk.CTkFrame(self)


### PR DESCRIPTION
### Motivation
- Remove the in-GUI manual drive controls ("Manuelles Verfahren") to simplify the mission workflow interface and avoid exposing directional drive buttons in the UI.

### Description
- Deleted the entire "Manuelles Verfahren" control block (directional buttons) from `transceiver/mission_workflow_ui.py`.
- Repositioned the live status label `self.live_var` from row `6` to row `5` to close the layout gap caused by the removal.
- Kept existing manual-navigation toggle and backend helper methods intact so behavior and tests remain minimally impacted.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "manual_drive or live_var"` which passed (`1 passed, 50 deselected`).
- Running `pytest -q tests/test_mission_workflow_ui.py -k "not manual_drive"` without setting `PYTHONPATH` failed during collection with `ModuleNotFoundError: No module named 'transceiver'`, which is an import-setup issue unrelated to the UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8f977748083219b489a1c7b8d3a66)