### PR TITLE
Use local noise prominence to detect echoes (improve robustness)

### DIFF
--- a/tests/test_correlation_utils.py
+++ b/tests/test_correlation_utils.py
@@ -200,15 +200,10 @@ def test_find_los_echo_uses_classified_peak_group() -> None:
     cc = mag.astype(np.complex128)
 
     los_idx, echo_idx = find_los_echo(cc)
-    _highest_idx, expected_los_idx, expected_echoes, _group = classify_peak_group(
-        cc,
-        peaks_before=0,
-        peaks_after=1,
-        min_rel_height=0.1,
-    )
+    expected_los_idx, expected_echo_idx = find_los_echo_from_mag(mag)
 
     assert los_idx == expected_los_idx
-    assert echo_idx == (expected_echoes[0] if expected_echoes else None)
+    assert echo_idx == expected_echo_idx
 
 
 
@@ -233,23 +228,35 @@ def test_classify_peak_group_from_mag_with_los_threshold_filters_weak_echoes() -
 def test_find_los_echo_from_mag_uses_stricter_los_threshold() -> None:
     mag = np.zeros(180, dtype=float)
     mag[90] = 1.0
-    mag[110] = 0.25  # Below LOS-specific 0.3 threshold.
-
-    los_idx, echo_idx = find_los_echo_from_mag(mag)
-
-    assert los_idx == 90
-    assert echo_idx is None
-
-
-def test_find_los_echo_from_mag_keeps_echo_above_los_threshold() -> None:
-    mag = np.zeros(180, dtype=float)
-    mag[90] = 1.0
-    mag[110] = 0.35  # Above LOS-specific 0.3 threshold.
+    mag[110] = 0.25
 
     los_idx, echo_idx = find_los_echo_from_mag(mag)
 
     assert los_idx == 90
     assert echo_idx == 110
+
+
+def test_find_los_echo_from_mag_keeps_echo_above_los_threshold() -> None:
+    mag = np.zeros(180, dtype=float)
+    mag[90] = 1.0
+    mag[110] = 0.35
+
+    los_idx, echo_idx = find_los_echo_from_mag(mag)
+
+    assert los_idx == 90
+    assert echo_idx == 110
+
+
+def test_find_los_echo_from_mag_rejects_non_prominent_echo_in_noise() -> None:
+    rng = np.random.default_rng(123)
+    mag = np.abs(rng.normal(0.0, 0.04, 240))
+    mag[120] = 1.0
+    mag[150] = float(np.median(mag[142:159]) + 0.02)
+
+    los_idx, echo_idx = find_los_echo_from_mag(mag)
+
+    assert los_idx == 120
+    assert echo_idx is None
 
 
 def test_find_los_echo_from_mag_ignores_echo_before_los_peak() -> None:

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -41,6 +41,7 @@ from .helpers.correlation_utils import (
     apply_manual_lags as _apply_manual_lags,
     autocorr_fft as _autocorr_fft,
     classify_peak_group_from_mag as _classify_peak_group_from_mag,
+    filter_echo_indices_by_noise_prominence as _filter_echo_indices_by_noise_prominence,
     find_los_echo_from_mag as _find_los_echo_from_mag,
     filter_peak_indices_to_period_group as _filter_peak_indices_to_period_group,
     lag_overlap as _lag_overlap,
@@ -189,7 +190,12 @@ def _classify_visible_xcorr_peaks(
     )
     if los_idx is None:
         los_idx = visible_los_idx
-        los_echo_indices = visible_echo_indices
+    los_echo_indices = _filter_echo_indices_by_noise_prominence(
+        mag,
+        los_idx=los_idx,
+        echo_indices=(los_echo_indices if los_idx is not None else visible_echo_indices),
+        repetition_period_samples=repetition_period_samples,
+    )
     return highest_idx, los_idx, los_echo_indices
 
 

--- a/transceiver/helpers/correlation_utils.py
+++ b/transceiver/helpers/correlation_utils.py
@@ -58,11 +58,74 @@ def find_los_echo_from_mag(
         mag,
         peaks_before=0,
         peaks_after=1,
-        min_rel_height=0.3,
+        min_rel_height=0.1,
+        repetition_period_samples=repetition_period_samples,
+    )
+    echo_indices = filter_echo_indices_by_noise_prominence(
+        mag,
+        los_idx=los_idx,
+        echo_indices=echo_indices,
         repetition_period_samples=repetition_period_samples,
     )
     echo_idx = echo_indices[0] if echo_indices else None
     return los_idx, echo_idx
+
+
+def filter_echo_indices_by_noise_prominence(
+    mag: np.ndarray,
+    *,
+    los_idx: int | None,
+    echo_indices: list[int],
+    repetition_period_samples: int | None = None,
+    noise_sigma_factor: float = 4.0,
+) -> list[int]:
+    """Keep echo peaks that stand out from local background noise.
+
+    The filtering does not depend on LOS peak height. Instead it compares each
+    candidate echo against a robust local baseline (median) and local noise
+    spread (MAD-scaled sigma estimate).
+    """
+    if mag.size == 0 or not echo_indices:
+        return []
+
+    los_idx_int = int(los_idx) if los_idx is not None else None
+    cleaned_indices = sorted(
+        {
+            int(idx)
+            for idx in echo_indices
+            if 0 <= int(idx) < mag.size and (los_idx_int is None or int(idx) > los_idx_int)
+        }
+    )
+    if not cleaned_indices:
+        return []
+
+    if repetition_period_samples is not None and repetition_period_samples > 1:
+        half_window = max(8, int(round(float(repetition_period_samples) / 8.0)))
+    else:
+        half_window = max(8, mag.size // 40)
+
+    min_points = 5
+    filtered: list[int] = []
+    for idx in cleaned_indices:
+        left = max(0, idx - half_window)
+        right = min(mag.size, idx + half_window + 1)
+        local = np.asarray(mag[left:right], dtype=float)
+        if local.size < min_points:
+            continue
+        local_baseline = float(np.median(local))
+        mad = float(np.median(np.abs(local - local_baseline)))
+        noise_sigma = 1.4826 * mad
+
+        prominence = float(mag[idx]) - local_baseline
+        if prominence <= 0.0:
+            continue
+        if noise_sigma <= 1e-12:
+            if prominence > 0.0:
+                filtered.append(int(idx))
+            continue
+        if prominence >= max(0.0, float(noise_sigma_factor)) * noise_sigma:
+            filtered.append(int(idx))
+    return filtered
 
 
 def classify_peak_group(


### PR DESCRIPTION
### Motivation
- Echo detection currently used LOS-relative amplitude thresholds which can miss echoes when the LOS peak is very large, so detection should instead use how prominent a candidate is versus local background noise.

### Description
- Added `filter_echo_indices_by_noise_prominence(...)` to `transceiver/helpers/correlation_utils.py` which keeps echo candidates that exceed a robust local baseline (median) by a MAD-scaled sigma threshold.
- Integrated the new prominence filter into `find_los_echo_from_mag(...)` and applied it when classifying visible cross-correlation peaks in `transceiver/__main__.py` so echoes are evaluated against local noise rather than LOS height.
- Lowered the min relative height used for initial grouping in `find_los_echo_from_mag(...)` and added/adjusted unit tests in `tests/test_correlation_utils.py` to reflect the new behavior and to cover non-prominent-noise rejection.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_correlation_utils.py` which completed successfully (`17 passed`).
- Attempted `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py::test_crosscorr_normalization_keeps_los_and_echo_indices_stable` but collection failed in this environment with an unrelated import-time `TypeError: __mro_entries__ must return a tuple` during `transceiver.__main__` import, so that single cross-file test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e902962a088321a448f6a73b991707)