### PR TITLE
Lower echo peak threshold and avoid plateau maxima in cross-correlation peak detection

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -141,7 +141,7 @@ USE_SHARED_MEMORY = False
 SHM_SIZE_THRESHOLD_BYTES = 25 * 1024 * 1024  # 25 MB
 XCORR_EXTRA_PEAKS_BEFORE = 4
 XCORR_EXTRA_PEAKS_AFTER = 4
-XCORR_EXTRA_PEAK_MIN_REL_HEIGHT = 0.1
+XCORR_ECHO_PEAK_MIN_REL_HEIGHT = 0.0
 XCORR_LOS_PEAK_MIN_REL_HEIGHT = 0.3
 XCORR_EXTRA_PEAK_COLORS = (
     "#FFB300",
@@ -170,7 +170,7 @@ def _classify_visible_xcorr_peaks(
     repetition_period_samples: int,
     peaks_before: int = XCORR_EXTRA_PEAKS_BEFORE,
     peaks_after: int = XCORR_EXTRA_PEAKS_AFTER,
-    min_rel_height: float = XCORR_EXTRA_PEAK_MIN_REL_HEIGHT,
+    min_rel_height: float = XCORR_ECHO_PEAK_MIN_REL_HEIGHT,
     los_min_rel_height: float = XCORR_LOS_PEAK_MIN_REL_HEIGHT,
 ) -> tuple[int | None, int | None, list[int]]:
     """Return (highest_idx, los_idx, echo_indices) from visible local maxima."""

--- a/transceiver/helpers/correlation_utils.py
+++ b/transceiver/helpers/correlation_utils.py
@@ -58,7 +58,7 @@ def find_los_echo_from_mag(
         mag,
         peaks_before=0,
         peaks_after=1,
-        min_rel_height=0.1,
+        min_rel_height=0.0,
         repetition_period_samples=repetition_period_samples,
     )
     echo_indices = filter_echo_indices_by_noise_prominence(
@@ -261,6 +261,7 @@ def find_local_maxima_around_peak_from_mag(
         if (
             mag[i] >= mag[i - 1]
             and mag[i] >= mag[i + 1]
+            and (mag[i] > mag[i - 1] or mag[i] > mag[i + 1])
             and mag[i] >= min_height
         )
     ]


### PR DESCRIPTION
### Motivation

- Make echo detection more permissive by lowering the minimum relative height threshold for extra/echo peaks. 
- Prevent flat-plateau points being classified as local maxima in cross-correlation peak finding.

### Description

- Renamed and changed the default constant `XCORR_EXTRA_PEAK_MIN_REL_HEIGHT` to `XCORR_ECHO_PEAK_MIN_REL_HEIGHT` and set it to `0.0` in `transceiver/__main__.py`.
- Updated `_classify_visible_xcorr_peaks` to use the new `XCORR_ECHO_PEAK_MIN_REL_HEIGHT` default.
- Changed the default `min_rel_height` from `0.1` to `0.0` in `find_los_echo_from_mag` in `transceiver/helpers/correlation_utils.py` to match the relaxed echo threshold.
- Tightened local maxima detection by requiring that a candidate maximum be strictly greater than at least one neighbor, which filters out flat plateau points in `find_local_maxima_around_peak_from_mag`.

### Testing

- Ran the project's unit test suite with `pytest` against the modified modules and all tests passed.
- Ran static checks/linting and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9043f2c3483219635c4f64145b7cc)