### PR TITLE
Lower default noise sigma factor for echo filtering (4.0 -> 2.0)

### DIFF
--- a/transceiver/helpers/correlation_utils.py
+++ b/transceiver/helpers/correlation_utils.py
@@ -77,7 +77,7 @@ def filter_echo_indices_by_noise_prominence(
     los_idx: int | None,
     echo_indices: list[int],
     repetition_period_samples: int | None = None,
-    noise_sigma_factor: float = 4.0,
+    noise_sigma_factor: float = 2.0,
 ) -> list[int]:
     """Keep echo peaks that stand out from local background noise.
 


### PR DESCRIPTION
### Motivation
- Make echo detection more permissive by reducing the default threshold for noise prominence so weaker echoes that are above local noise are retained (`noise_sigma_factor` default changed). 

### Description
- Change default of `noise_sigma_factor` in `filter_echo_indices_by_noise_prominence` from `4.0` to `2.0` to lower the required multiple of local noise for an echo to be kept. 

### Testing
- Ran unit tests with `pytest` focusing on the transceiver helpers and correlation utilities; the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9072183988321b8edcfe48bb85c04)