### PR TITLE
Lower echo prominence threshold to 1× baseline noise

### DIFF
--- a/transceiver/helpers/correlation_utils.py
+++ b/transceiver/helpers/correlation_utils.py
@@ -77,7 +77,7 @@ def filter_echo_indices_by_noise_prominence(
     los_idx: int | None,
     echo_indices: list[int],
     repetition_period_samples: int | None = None,
-    noise_sigma_factor: float = 2.0,
+    noise_sigma_factor: float = 1.0,
 ) -> list[int]:
     """Keep echo peaks that stand out from global background noise.
 


### PR DESCRIPTION
### Motivation
- Reduce the strictness of echo filtering so candidate echoes that are only 1× above the MAD-scaled noise baseline are retained instead of requiring a 2× factor.

### Description
- Change the default `noise_sigma_factor` from `2.0` to `1.0` in `filter_echo_indices_by_noise_prominence` in `transceiver/helpers/correlation_utils.py`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_correlation_utils.py` which passed all tests (`17 passed`), noting that a plain `pytest` run failed during collection without `PYTHONPATH` due to module import path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9145e5d7c8321b3ff98701e23569e)