### PR TITLE
Remove LOS min_rel_height gating for echo peaks in _classify_visible_xcorr_peaks

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -53,6 +53,7 @@ sys.modules.setdefault("uhd", types.ModuleType("uhd"))
 from transceiver.__main__ import (
     TransceiverUI,
     _build_crosscorr_ctx,
+    _classify_visible_xcorr_peaks,
     _find_echo_marker_slot_near_lag,
     _format_echo_delay_display,
     _format_rx_stats_rows,
@@ -79,6 +80,25 @@ def test_crosscorr_normalization_sets_peak_to_one_for_nonempty_signal() -> None:
     assert mag.size > 0
     assert np.isfinite(mag).all()
     assert np.isclose(np.max(mag), 1.0)
+
+
+def test_classify_visible_xcorr_peaks_keeps_echoes_with_stricter_los_threshold() -> None:
+    mag = np.zeros(180, dtype=float)
+    mag[90] = 1.0
+    mag[110] = 0.25
+
+    highest_idx, los_idx, echo_indices = _classify_visible_xcorr_peaks(
+        mag,
+        repetition_period_samples=200,
+        peaks_before=0,
+        peaks_after=1,
+        min_rel_height=0.0,
+        los_min_rel_height=0.3,
+    )
+
+    assert highest_idx == 90
+    assert los_idx == 90
+    assert echo_indices == [110]
 
 
 def test_crosscorr_normalization_applies_to_comparison_trace_mag2() -> None:

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -181,7 +181,7 @@ def _classify_visible_xcorr_peaks(
         min_rel_height=min_rel_height,
         repetition_period_samples=repetition_period_samples,
     )
-    _los_highest_idx, los_idx, los_echo_indices, _los_group_indices = _classify_peak_group_from_mag(
+    _los_highest_idx, los_idx, _los_echo_indices, _los_group_indices = _classify_peak_group_from_mag(
         mag,
         peaks_before=peaks_before,
         peaks_after=peaks_after,
@@ -193,7 +193,7 @@ def _classify_visible_xcorr_peaks(
     los_echo_indices = _filter_echo_indices_by_noise_prominence(
         mag,
         los_idx=los_idx,
-        echo_indices=(los_echo_indices if los_idx is not None else visible_echo_indices),
+        echo_indices=visible_echo_indices,
         repetition_period_samples=repetition_period_samples,
     )
     return highest_idx, los_idx, los_echo_indices


### PR DESCRIPTION
### Motivation
- Die LOS-Schwelle `los_min_rel_height` sollte nur die Auswahl des LOS-Peaks beeinflussen, nicht das Entfernen von Echo-Peaks, damit schwächere, aber rauscharte Echo-Peaks weiterhin als Echo-Kandidaten betrachtet werden.

### Description
- Ändere `_classify_visible_xcorr_peaks` so, dass Echo-Kandidaten aus der normalen Sichtbarkeitsklassifikation (`min_rel_height`) übernommen und danach per Rausch-Prominenz gefiltert werden, statt Echo-Kandidaten aus der strengeren `los_min_rel_height`-Passage zu verwenden (Datei: `transceiver/__main__.py`).
- Füge einen Regressionstest `test_classify_visible_xcorr_peaks_keeps_echoes_with_stricter_los_threshold` hinzu, der sicherstellt, dass ein Echo mit Höhe `0.25` erhalten bleibt wenn `los_min_rel_height=0.3` (Datei: `tests/test_crosscorr_normalization.py`).

### Testing
- Erfolgreich: `python -m py_compile transceiver/__main__.py tests/test_crosscorr_normalization.py` lief ohne Syntaxfehler.
- Teilweise: Der neue Test `test_classify_visible_xcorr_peaks_keeps_echoes_with_stricter_los_threshold` wurde lokal ausgeführt via `pytest`, Sammlungs-/Importlauf schlägt in dieser Umgebung fehl wegen eines `TypeError: __mro_entries__ must return a tuple` beim Laden des `pyqtgraph`-Stubs; das ist ein Umgebungs-/stub-Problem, nicht die Logik der Änderung.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e91688bd68832194f2afb0b06ec8f2)