### PR TITLE
Optimize live overlay rendering with persistent canvas item IDs

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -453,7 +453,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._map_preview_offset: tuple[float, float] = (0.0, 0.0)
         self._map_canvas_image_id: int | None = None
         self._map_marker_ids: list[int] = []
-        self._live_overlay_item_ids: list[int] = []
+        self._live_overlay_items: dict[str, Any] = {
+            "echo_slots": {},
+            "marker": None,
+            "heading": None,
+        }
         self._static_map_layer_signature: tuple[Any, ...] | None = None
         self._map_image_size: tuple[int, int] | None = None
         self._live_position: dict[str, Any] | None = None
@@ -814,7 +818,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._map_preview_offset = (0.0, 0.0)
         self._map_canvas_image_id = None
         self._map_marker_ids = []
-        self._live_overlay_item_ids = []
+        self._live_overlay_items = {
+            "echo_slots": {},
+            "marker": None,
+            "heading": None,
+        }
         self._static_map_layer_signature = None
         self._map_image_size = None
         self._live_position = None
@@ -1268,7 +1276,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _render_map_placeholder(self, text: str) -> None:
         self.map_preview_canvas.delete("all")
-        self._live_overlay_item_ids = []
+        self._live_overlay_items = {
+            "echo_slots": {},
+            "marker": None,
+            "heading": None,
+        }
         self._static_map_layer_signature = None
         self.map_preview_canvas.create_text(
             20,
@@ -1328,7 +1340,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._map_preview_offset = (offset_x, offset_y)
 
         self.map_preview_canvas.delete("all")
-        self._live_overlay_item_ids = []
+        self._live_overlay_items = {
+            "echo_slots": {},
+            "marker": None,
+            "heading": None,
+        }
         self._map_canvas_image_id = self.map_preview_canvas.create_image(offset_x, offset_y, anchor="nw", image=preview)
         self._draw_mission_markers()
         self._draw_pending_nav2point_marker()
@@ -1339,19 +1355,34 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._draw_selected_lidar_reference_overlay()
 
     def _draw_live_overlay_layer(self) -> None:
-        self._clear_live_overlay_layer()
+        if not bool(self.live_preview_enabled_var.get()):
+            self._clear_live_overlay_layer()
+            return
         self._draw_live_echo_preview_overlay()
         self._draw_live_marker()
 
     def _clear_live_overlay_layer(self) -> None:
-        if not self._live_overlay_item_ids:
-            return
-        for item_id in self._live_overlay_item_ids:
+        overlay_items = self._live_overlay_items
+        echo_slots = overlay_items.get("echo_slots", {})
+        item_ids: list[int] = [
+            item_id
+            for item_id in (
+                *echo_slots.values(),
+                overlay_items.get("marker"),
+                overlay_items.get("heading"),
+            )
+            if isinstance(item_id, int)
+        ]
+        for item_id in item_ids:
             try:
                 self.map_preview_canvas.delete(item_id)
             except tk.TclError:
                 pass
-        self._live_overlay_item_ids = []
+        self._live_overlay_items = {
+            "echo_slots": {},
+            "marker": None,
+            "heading": None,
+        }
 
     def _draw_rx_antenna_marker(self) -> None:
         position = self._rx_antenna_global_position
@@ -1632,34 +1663,78 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 )
 
     def _draw_live_echo_preview_overlay(self) -> None:
-        if not bool(self.live_preview_enabled_var.get()):
-            return
         rx_position = self._rx_antenna_global_position
         if rx_position is None:
+            self._clear_live_echo_preview_overlay()
             return
         live_position = self._copy_valid_live_position()
         if live_position is None:
+            self._clear_live_echo_preview_overlay()
             return
         x_value = live_position.get("x")
         y_value = live_position.get("y")
         if not isinstance(x_value, (int, float)) or not isinstance(y_value, (int, float)):
+            self._clear_live_echo_preview_overlay()
             return
         measurement_position = (float(x_value), float(y_value))
         if not math.isfinite(measurement_position[0]) or not math.isfinite(measurement_position[1]):
+            self._clear_live_echo_preview_overlay()
             return
         echo_distances = self._get_live_preview_echo_distances(limit=len(ECHO_OVERLAY_COLORS))
         if not echo_distances:
+            self._clear_live_echo_preview_overlay()
             return
+        overlay_items = self._live_overlay_items
+        echo_slot_ids = overlay_items.get("echo_slots")
+        if not isinstance(echo_slot_ids, dict):
+            echo_slot_ids = {}
+            overlay_items["echo_slots"] = echo_slot_ids
+        active_slot_names: set[str] = set()
         for echo_index, echo_distance in enumerate(echo_distances):
+            slot_name = f"echo_{echo_index}"
+            active_slot_names.add(slot_name)
             color = ECHO_OVERLAY_COLORS[echo_index % len(ECHO_OVERLAY_COLORS)]
+            current_item_id = echo_slot_ids.get(slot_name)
             overlay_item_id = self._draw_echo_ellipse_for_overlay(
                 rx_position=rx_position,
                 measurement_position=measurement_position,
                 echo_distance_m=echo_distance,
                 color=color,
+                existing_item_id=current_item_id if isinstance(current_item_id, int) else None,
             )
             if overlay_item_id is not None:
-                self._live_overlay_item_ids.append(overlay_item_id)
+                echo_slot_ids[slot_name] = overlay_item_id
+            elif isinstance(current_item_id, int):
+                try:
+                    self.map_preview_canvas.delete(current_item_id)
+                except tk.TclError:
+                    pass
+                echo_slot_ids.pop(slot_name, None)
+        for slot_name in tuple(echo_slot_ids):
+            if slot_name in active_slot_names:
+                continue
+            stale_item_id = echo_slot_ids.pop(slot_name, None)
+            if not isinstance(stale_item_id, int):
+                continue
+            try:
+                self.map_preview_canvas.delete(stale_item_id)
+            except tk.TclError:
+                pass
+
+    def _clear_live_echo_preview_overlay(self) -> None:
+        overlay_items = self._live_overlay_items
+        echo_slot_ids = overlay_items.get("echo_slots")
+        if not isinstance(echo_slot_ids, dict):
+            overlay_items["echo_slots"] = {}
+            return
+        for item_id in echo_slot_ids.values():
+            if not isinstance(item_id, int):
+                continue
+            try:
+                self.map_preview_canvas.delete(item_id)
+            except tk.TclError:
+                pass
+        overlay_items["echo_slots"] = {}
 
     def _selected_record_point(self, record: dict[str, Any] | None) -> MeasurementPoint | None:
         if record is None:
@@ -1728,6 +1803,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         measurement_position: tuple[float, float],
         echo_distance_m: float,
         color: str,
+        existing_item_id: int | None = None,
     ) -> int | None:
         mission = self._mission
         original = self._map_image_original
@@ -1784,14 +1860,28 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if len(preview_points) < 6:
             return None
         line_width = max(1, int(round((echo_distance_m / resolution) * self._map_preview_scale[0] * 0.03)))
+        if isinstance(existing_item_id, int):
+            try:
+                self.map_preview_canvas.coords(existing_item_id, *preview_points)
+                self.map_preview_canvas.itemconfigure(
+                    existing_item_id,
+                    fill=color,
+                    width=line_width,
+                    smooth=True,
+                    dash=(4, 4),
+                    state=tk.NORMAL,
+                )
+                return existing_item_id
+            except tk.TclError:
+                pass
         return int(
             self.map_preview_canvas.create_line(
-            *preview_points,
-            fill=color,
-            width=line_width,
-            smooth=True,
-            dash=(4, 4),
-        )
+                *preview_points,
+                fill=color,
+                width=line_width,
+                smooth=True,
+                dash=(4, 4),
+            )
         )
 
     def _draw_selected_lidar_reference_overlay(self) -> None:
@@ -1975,6 +2065,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             or original is None
             or position is None
         ):
+            self._clear_live_marker_overlay()
             return
         expected_frame_id = self._expected_live_frame_id()
         received_frame_id = position.get("frame_id")
@@ -1983,10 +2074,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             and received_frame_id.strip()
             and received_frame_id != expected_frame_id
         ):
+            self._clear_live_marker_overlay()
             return
         x_value = position.get("x")
         y_value = position.get("y")
         if not isinstance(x_value, (int, float)) or not isinstance(y_value, (int, float)):
+            self._clear_live_marker_overlay()
             return
 
         scale_x, scale_y = self._map_preview_scale
@@ -1997,6 +2090,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             image_height=original.height(),
         )
         if map_pixel is None:
+            self._clear_live_marker_overlay()
             return
         if not self._is_pixel_inside_map(
             map_pixel[0],
@@ -2004,35 +2098,95 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             width=original.width(),
             height=original.height(),
         ):
+            self._clear_live_marker_overlay()
             return
         pixel_coordinates = (map_pixel[0] * scale_x + offset_x, map_pixel[1] * scale_y + offset_y)
         px, py = pixel_coordinates
         radius = 6
-        live_marker_id = self.map_preview_canvas.create_oval(
-            px - radius,
-            py - radius,
-            px + radius,
-            py + radius,
-            fill="#ff4d6d",
-            outline="#ffffff",
-            width=1,
-        )
-        self._live_overlay_item_ids.append(int(live_marker_id))
+        marker_id = self._live_overlay_items.get("marker")
+        if isinstance(marker_id, int):
+            try:
+                self.map_preview_canvas.coords(
+                    marker_id,
+                    px - radius,
+                    py - radius,
+                    px + radius,
+                    py + radius,
+                )
+                self.map_preview_canvas.itemconfigure(
+                    marker_id,
+                    fill="#ff4d6d",
+                    outline="#ffffff",
+                    width=1,
+                    state=tk.NORMAL,
+                )
+            except tk.TclError:
+                marker_id = None
+        if not isinstance(marker_id, int):
+            marker_id = int(
+                self.map_preview_canvas.create_oval(
+                    px - radius,
+                    py - radius,
+                    px + radius,
+                    py + radius,
+                    fill="#ff4d6d",
+                    outline="#ffffff",
+                    width=1,
+                )
+            )
+        self._live_overlay_items["marker"] = marker_id
         yaw_value = position.get("yaw")
         if isinstance(yaw_value, (int, float)):
             heading_length = 14
             end_x = px + math.cos(float(yaw_value)) * heading_length
             end_y = py - math.sin(float(yaw_value)) * heading_length
-            heading_id = self.map_preview_canvas.create_line(
-                px,
-                py,
-                end_x,
-                end_y,
-                fill="#ffccd5",
-                width=2,
-                arrow=tk.LAST,
-            )
-            self._live_overlay_item_ids.append(int(heading_id))
+            heading_id = self._live_overlay_items.get("heading")
+            if isinstance(heading_id, int):
+                try:
+                    self.map_preview_canvas.coords(heading_id, px, py, end_x, end_y)
+                    self.map_preview_canvas.itemconfigure(
+                        heading_id,
+                        fill="#ffccd5",
+                        width=2,
+                        arrow=tk.LAST,
+                        state=tk.NORMAL,
+                    )
+                except tk.TclError:
+                    heading_id = None
+            if not isinstance(heading_id, int):
+                heading_id = int(
+                    self.map_preview_canvas.create_line(
+                        px,
+                        py,
+                        end_x,
+                        end_y,
+                        fill="#ffccd5",
+                        width=2,
+                        arrow=tk.LAST,
+                    )
+                )
+            self._live_overlay_items["heading"] = heading_id
+            return
+        self._clear_live_heading_overlay()
+
+    def _clear_live_marker_overlay(self) -> None:
+        marker_id = self._live_overlay_items.get("marker")
+        if isinstance(marker_id, int):
+            try:
+                self.map_preview_canvas.delete(marker_id)
+            except tk.TclError:
+                pass
+        self._live_overlay_items["marker"] = None
+        self._clear_live_heading_overlay()
+
+    def _clear_live_heading_overlay(self) -> None:
+        heading_id = self._live_overlay_items.get("heading")
+        if isinstance(heading_id, int):
+            try:
+                self.map_preview_canvas.delete(heading_id)
+            except tk.TclError:
+                pass
+        self._live_overlay_items["heading"] = None
 
     def _highlight_marker(self, marker_id: int) -> None:
         self.map_preview_canvas.itemconfigure(


### PR DESCRIPTION
### Motivation
- Reduce flicker and CPU work by avoiding delete+recreate of live overlay canvas items and instead update them in-place.
- Make live overlay mapping stable per echo slot and for the live marker/heading so UI state persists across redraws and map refreshes.
- Keep robust behavior on UI state changes by preserving `tk.TclError` fallbacks when updating or deleting canvas items.

### Description
- Replaced `self._live_overlay_item_ids` list with a persistent mapping `self._live_overlay_items` containing `echo_slots`, `marker` and `heading` to track canonical item IDs.
- Updated `_draw_live_echo_preview_overlay` to assign stable slot names (`echo_0`, `echo_1`, ...) and reuse or update existing items via `canvas.coords(...)` and `canvas.itemconfigure(...)`, and to remove only stale slots.
- Added `existing_item_id` support to `_draw_echo_ellipse_for_overlay` so ellipses are updated in-place when possible and recreated on failure.
- Converted `_draw_live_marker` to reuse/update `marker` and `heading` IDs and added helper clear methods (`_clear_live_echo_preview_overlay`, `_clear_live_marker_overlay`, `_clear_live_heading_overlay`) while keeping `tk.TclError` try/except fallbacks.
- Modified `_draw_live_overlay_layer` to avoid blanket per-frame deletion and instead clear overlays only when live preview is disabled or when helpers determine items must be removed.

### Testing
- Ran `python -m py_compile transceiver/mission_workflow_ui.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e921ae95888321b50edf7472055d01)