### PR TITLE
Cache mission preview echo distances in continuous update path

### DIFF
--- a/tests/test_receive_for_mission_threading.py
+++ b/tests/test_receive_for_mission_threading.py
@@ -446,3 +446,70 @@ def test_review_measurement_for_mission_uses_persisted_tx_reference_without_sing
     np.testing.assert_allclose(captured_ctx_input["ref_data"], np.array([10.0 + 20.0j, 30.0 + 40.0j]))
     assert ui.tx_data.size == 2
     assert outcome["reason"] != "missing_tx_reference"
+
+
+def test_get_live_echo_distances_for_mission_preview_reads_cached_field_and_limits() -> None:
+    ui = object.__new__(TransceiverUI)
+    ui._cont_thread = types.SimpleNamespace(is_alive=lambda: True)
+    ui._last_continuous_payload = {
+        "mission_preview_echo_distances_m": [1.5, "3.0", float("nan"), -2.0, "bad", 4.5],
+    }
+    ui._get_crosscorr_reference = lambda: (_ for _ in ()).throw(RuntimeError("must not be called"))
+
+    result = TransceiverUI.get_live_echo_distances_for_mission_preview(ui, limit=2)
+
+    assert result == [1.5, 3.0]
+
+
+def test_get_live_echo_distances_for_mission_preview_handles_invalid_payloads_robustly() -> None:
+    ui = object.__new__(TransceiverUI)
+    ui._cont_thread = types.SimpleNamespace(is_alive=lambda: True)
+
+    ui._last_continuous_payload = None
+    assert TransceiverUI.get_live_echo_distances_for_mission_preview(ui) == []
+
+    ui._last_continuous_payload = {"mission_preview_echo_distances_m": "invalid"}
+    assert TransceiverUI.get_live_echo_distances_for_mission_preview(ui) == []
+
+    ui._last_continuous_payload = {"mission_preview_echo_distances_m": [1.5]}
+    ui._cont_thread = types.SimpleNamespace(is_alive=lambda: False)
+    assert TransceiverUI.get_live_echo_distances_for_mission_preview(ui) == []
+
+
+def test_render_continuous_payload_caches_mission_preview_distances_without_recompute() -> None:
+    ui = object.__new__(TransceiverUI)
+    ui.latest_fs = 1.0
+    ui._cont_rendered_frames = 0
+    ui._cont_runtime_config = {}
+    ui._rx_cont_pg_state = {}
+    ui.rx_xcorr_normalized_enable = types.SimpleNamespace(set=lambda _value: None)
+    ui.rx_interpolation_enable = types.SimpleNamespace(set=lambda _value: None)
+    ui.rx_interpolation_method = types.SimpleNamespace(set=lambda _value: None)
+    ui._set_rx_interpolation_factor_text = lambda _value: None
+    ui._rx_interpolation_factor_text = lambda: "2"
+    ui._on_rx_interpolation_toggle = lambda recompute=False: None
+    ui._update_rx_interpolation_status = lambda interpolation_applied=False: None
+    ui._display_rx_plots = lambda *_args, **_kwargs: None
+
+    calls = {"count": 0}
+
+    def _fake_compute(_payload):
+        calls["count"] += 1
+        return [2.25, 4.5]
+
+    ui._compute_mission_preview_echo_distances_from_payload = _fake_compute
+
+    payload = {
+        "plot_data": [1.0, 2.0, 3.0],
+        "plot_ref_data": [1.0, 0.0],
+        "fs": 2.0,
+        "frame_ts": 0.0,
+        "processing_ms": 0.0,
+        "interpolation_applied": False,
+    }
+
+    TransceiverUI._render_continuous_payload(ui, payload)
+    TransceiverUI._render_continuous_payload(ui, payload)
+
+    assert calls["count"] == 1
+    assert ui._last_continuous_payload["mission_preview_echo_distances_m"] == [2.25, 4.5]

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -7059,16 +7059,10 @@ class TransceiverUI(ctk.CTk):
         except Exception:
             return True
 
-    def get_live_echo_distances_for_mission_preview(self, *, limit: int = 5) -> list[float]:
-        if limit <= 0:
-            return []
-        payload = getattr(self, "_last_continuous_payload", None)
-        if not isinstance(payload, dict):
-            return []
-        cont_thread = getattr(self, "_cont_thread", None)
-        if cont_thread is None or not cont_thread.is_alive():
-            return []
-
+    def _compute_mission_preview_echo_distances_from_payload(
+        self,
+        payload: dict[str, object],
+    ) -> list[float]:
         raw_data = payload.get("plot_data")
         data = np.asarray(raw_data) if raw_data is not None else np.array([], dtype=np.complex64)
         if data.size == 0:
@@ -7076,31 +7070,23 @@ class TransceiverUI(ctk.CTk):
 
         ref_data = np.asarray(payload.get("plot_ref_data", np.array([], dtype=np.complex64)))
         if ref_data.size == 0:
-            ref_candidate = None
-            get_reference = getattr(self, "_get_crosscorr_reference", None)
-            if callable(get_reference):
-                try:
-                    reference_payload = get_reference()
-                except Exception:
-                    reference_payload = None
-                if isinstance(reference_payload, tuple) and reference_payload:
-                    ref_candidate = reference_payload[0]
-                else:
-                    ref_candidate = reference_payload
-            if ref_candidate is None:
-                return []
-            ref_data = np.asarray(ref_candidate)
-        if ref_data.size == 0:
             return []
 
+        normalize_enabled = payload.get("normalize_enabled")
+        if normalize_enabled is None:
+            normalize_enabled = payload.get("xcorr_normalized_enabled")
+        if normalize_enabled is None:
+            normalize_enabled = (
+                bool(getattr(self, "rx_xcorr_normalized_enable", None).get())
+                if hasattr(getattr(self, "rx_xcorr_normalized_enable", None), "get")
+                else False
+            )
         try:
             reduced_data, reduced_ref, lag_step = _reduce_pair(np.asarray(data), np.asarray(ref_data))
             ctx = _build_crosscorr_ctx(
                 reduced_data,
                 reduced_ref,
-                normalize=bool(getattr(self, "rx_xcorr_normalized_enable", None).get())
-                if hasattr(getattr(self, "rx_xcorr_normalized_enable", None), "get")
-                else False,
+                normalize=bool(normalize_enabled),
                 lag_step=lag_step,
             )
         except Exception:
@@ -7122,7 +7108,7 @@ class TransceiverUI(ctk.CTk):
             return []
 
         interpolation_factor = 1.0
-        if bool(getattr(self, "_latest_rx_data_interpolated", False)):
+        if bool(payload.get("interpolation_applied", getattr(self, "_latest_rx_data_interpolated", False))):
             try:
                 interpolation_factor = float(self._rx_effective_interpolation_factor())
             except Exception:
@@ -7132,8 +7118,6 @@ class TransceiverUI(ctk.CTk):
 
         distances_m: list[float] = []
         for idx in echo_indices:
-            if len(distances_m) >= limit:
-                break
             try:
                 echo_lag = float(lags[int(idx)])
             except Exception:
@@ -7142,6 +7126,54 @@ class TransceiverUI(ctk.CTk):
             if not np.isfinite(delay_samples) or delay_samples <= 0.0:
                 continue
             distances_m.append(float(delay_samples * 1.5))
+        return distances_m
+
+    def _mission_preview_echo_payload_key(self, payload: dict[str, object]) -> tuple[object, ...]:
+        return (
+            id(payload.get("plot_data")),
+            id(payload.get("plot_ref_data")),
+            payload.get("fs"),
+            payload.get("normalize_enabled", payload.get("xcorr_normalized_enabled")),
+            payload.get("interpolation_applied"),
+        )
+
+    def _get_or_compute_mission_preview_echo_distances(
+        self,
+        payload: dict[str, object],
+    ) -> list[float]:
+        payload_key = self._mission_preview_echo_payload_key(payload)
+        if payload_key == getattr(self, "_mission_preview_echo_cache_key", None):
+            cached = getattr(self, "_mission_preview_echo_cache_values", None)
+            if isinstance(cached, list):
+                return list(cached)
+        distances_m = self._compute_mission_preview_echo_distances_from_payload(payload)
+        self._mission_preview_echo_cache_key = payload_key
+        self._mission_preview_echo_cache_values = list(distances_m)
+        return distances_m
+
+    def get_live_echo_distances_for_mission_preview(self, *, limit: int = 5) -> list[float]:
+        if limit <= 0:
+            return []
+        payload = getattr(self, "_last_continuous_payload", None)
+        if not isinstance(payload, dict):
+            return []
+        cont_thread = getattr(self, "_cont_thread", None)
+        if cont_thread is None or not cont_thread.is_alive():
+            return []
+        values = payload.get("mission_preview_echo_distances_m")
+        if not isinstance(values, list):
+            return []
+        distances_m: list[float] = []
+        for value in values:
+            if len(distances_m) >= limit:
+                break
+            try:
+                as_float = float(value)
+            except (TypeError, ValueError):
+                continue
+            if not np.isfinite(as_float) or as_float <= 0.0:
+                continue
+            distances_m.append(as_float)
         return distances_m
 
     def _build_receive_arg_list(self, *, output_file: str | None = None) -> tuple[list[str], int, float]:
@@ -8742,14 +8774,18 @@ class TransceiverUI(ctk.CTk):
             interpolation_applied=bool(self._latest_rx_data_interpolated)
         )
 
-        self._last_continuous_payload = dict(payload)
+        payload_with_preview = dict(payload)
+        payload_with_preview["mission_preview_echo_distances_m"] = (
+            self._get_or_compute_mission_preview_echo_distances(payload_with_preview)
+        )
+        self._last_continuous_payload = payload_with_preview
         self._display_rx_plots(
             plot_data,
             fs,
             reset_manual=False,
             target_tab='Continuous',
             source='continuous_preprocessed',
-            preprocessed_payload=payload,
+            preprocessed_payload=payload_with_preview,
         )
 
         if hasattr(self, 'rx_aoa_label'):


### PR DESCRIPTION
### Motivation
- Reduce latency in the UI draw path by moving the expensive echo-distance computation out of the live getter and into the continuous-update/render path.
- Expose a ready-to-read field `mission_preview_echo_distances_m` on the continuous payload so callers can obtain distances quickly without recomputation.
- Prevent the costly fallback reference lookup (`_get_crosscorr_reference`) from running in the UI draw/getter path and avoid redundant recalculation for identical payloads.

### Description
- Added `_compute_mission_preview_echo_distances_from_payload(payload)` to compute distances from `plot_data` and `plot_ref_data` using the existing cross-correlation helpers.
- Added `_get_or_compute_mission_preview_echo_distances()` and `_mission_preview_echo_payload_key()` to cache results per-payload and avoid recompute on repeated renders, and call this from `_render_continuous_payload()` to attach `mission_preview_echo_distances_m` to the payload.
- Reworked `get_live_echo_distances_for_mission_preview()` to be a fast getter that only reads, validates and truncates `mission_preview_echo_distances_m` (applies `limit`) and no longer performs the expensive `_get_crosscorr_reference()` fallback.
- Added tests in `tests/test_receive_for_mission_threading.py` covering: reading the cached field with limits, robustness against invalid/empty payloads, and ensuring no recompute on repeated `_render_continuous_payload()` calls.

### Testing
- `python -m compileall transceiver/__main__.py tests/test_receive_for_mission_threading.py` succeeded.
- `PYTHONPATH=. pytest -q tests/test_receive_for_mission_threading.py -k "mission_preview or render_continuous_payload_caches"` was executed and failed during test collection with `TypeError: __mro_entries__ must return a tuple` due to UI/import stubbing in the test environment; this is an environment/import issue rather than the new logic itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e926f56a4c83219cbe759a0491fe95)