### PR TITLE
Switch live mission position source from /amcl_pose to /base_footprint

### DIFF
--- a/tests/test_navigation_adapter.py
+++ b/tests/test_navigation_adapter.py
@@ -581,7 +581,7 @@ def test_rosbridge_pose_stream_sends_subscribe_and_parses_pose(monkeypatch) -> N
             self._recv_calls += 1
             if self._recv_calls == 1:
                 return (
-                    '{"op":"publish","topic":"/amcl_pose","msg":'
+                    '{"op":"publish","topic":"/base_footprint","msg":'
                     '{"header":{"frame_id":"map","stamp":{"sec":10,"nanosec":500000000}},'
                     '"pose":{"pose":{"position":{"x":1.25,"y":2.5},'
                     '"orientation":{"x":0.0,"y":0.0,"z":0.7071068,"w":0.7071068}}}}}'
@@ -630,7 +630,7 @@ def test_rosbridge_pose_stream_sends_subscribe_and_parses_pose(monkeypatch) -> N
     assert sent_messages
     subscribe = sent_messages[0]
     assert '"op": "subscribe"' in subscribe
-    assert '"topic": "/amcl_pose"' in subscribe
+    assert '"topic": "/base_footprint"' in subscribe
     updates = [
         payload["event"]["position"]
         for payload in events

--- a/transceiver/navigation_adapter.py
+++ b/transceiver/navigation_adapter.py
@@ -625,9 +625,9 @@ class NavigationAdapter:
 
 
 class RosbridgePoseStreamTransport:
-    """Continuously streams `/amcl_pose` updates via rosbridge through an SSH tunnel."""
+    """Continuously streams `/base_footprint` updates via rosbridge through an SSH tunnel."""
 
-    _POSE_TOPIC = "/amcl_pose"
+    _POSE_TOPIC = "/base_footprint"
     _POSE_TYPE = "geometry_msgs/msg/PoseWithCovarianceStamped"
     _DEFAULT_EXPECTED_FRAME_ID = "map"
     _READY_RETRY_INTERVAL_S = 0.15
@@ -920,7 +920,7 @@ class RosbridgePoseStreamTransport:
                                 "type": "pose_stream",
                                 "event": {
                                     "type": "stream_error",
-                                    "message": "amcl_pose rosbridge message is missing required pose fields",
+                                    "message": "base_footprint rosbridge message is missing required pose fields",
                                     "attempt": reconnect_attempt,
                                     "timestamp": time.time(),
                                 },
@@ -941,7 +941,7 @@ class RosbridgePoseStreamTransport:
                                 "event": {
                                     "type": "stream_error",
                                     "message": (
-                                        "unerwarteter /amcl_pose frame_id: "
+                                        "unerwarteter /base_footprint frame_id: "
                                         f"erwartet={expected_frame}, empfangen={received_frame}"
                                     ),
                                     "attempt": reconnect_attempt,


### PR DESCRIPTION
### Motivation
- The mission workflow must use `/base_footprint` as the live robot pose source instead of `/amcl_pose` for current deployments.

### Description
- Updated `RosbridgePoseStreamTransport` to subscribe to the `/base_footprint` topic and adjusted the class docstring and `_POSE_TOPIC` accordingly.
- Replaced references in transport error/diagnostic messages from `amcl_pose` to `base_footprint` for consistent logging.
- Updated unit tests in `tests/test_navigation_adapter.py` to publish and assert on `/base_footprint` instead of `/amcl_pose`.

### Testing
- Ran `pytest -q tests/test_navigation_adapter.py::test_rosbridge_pose_stream_sends_subscribe_and_parses_pose` which failed initially when invoked without `PYTHONPATH` due to import resolution, as expected (ModuleNotFoundError).
- Ran `PYTHONPATH=. pytest -q tests/test_navigation_adapter.py::test_rosbridge_pose_stream_sends_subscribe_and_parses_pose` which passed (`1 passed`).
- Ran `PYTHONPATH=. pytest -q tests/test_navigation_adapter.py -k rosbridge_pose_stream` which passed (`4 passed, 18 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb647a0df88321ac82fdf1e8cd603a)