### PR TITLE
Stream map->base_footprint from `/tf` TFMessage and normalize frames in rosbridge pose transport

### DIFF
--- a/tests/test_navigation_adapter.py
+++ b/tests/test_navigation_adapter.py
@@ -581,10 +581,10 @@ def test_rosbridge_pose_stream_sends_subscribe_and_parses_pose(monkeypatch) -> N
             self._recv_calls += 1
             if self._recv_calls == 1:
                 return (
-                    '{"op":"publish","topic":"/base_footprint","msg":'
-                    '{"header":{"frame_id":"map","stamp":{"sec":10,"nanosec":500000000}},'
-                    '"pose":{"pose":{"position":{"x":1.25,"y":2.5},'
-                    '"orientation":{"x":0.0,"y":0.0,"z":0.7071068,"w":0.7071068}}}}}'
+                    '{"op":"publish","topic":"/tf","msg":'
+                    '{"transforms":[{"header":{"frame_id":"map","stamp":{"sec":10,"nanosec":500000000}},'
+                    '"child_frame_id":"base_footprint","transform":{"translation":{"x":1.25,"y":2.5},'
+                    '"rotation":{"x":0.0,"y":0.0,"z":0.7071068,"w":0.7071068}}}]}}'
                 )
             raise RuntimeError("disconnect")
 
@@ -630,7 +630,7 @@ def test_rosbridge_pose_stream_sends_subscribe_and_parses_pose(monkeypatch) -> N
     assert sent_messages
     subscribe = sent_messages[0]
     assert '"op": "subscribe"' in subscribe
-    assert '"topic": "/base_footprint"' in subscribe
+    assert '"topic": "/tf"' in subscribe
     updates = [
         payload["event"]["position"]
         for payload in events
@@ -640,6 +640,7 @@ def test_rosbridge_pose_stream_sends_subscribe_and_parses_pose(monkeypatch) -> N
     assert updates[0]["x"] == 1.25
     assert updates[0]["y"] == 2.5
     assert updates[0]["frame_id"] == "map"
+    assert updates[0]["child_frame_id"] == "base_footprint"
     assert abs(float(updates[0]["timestamp"]) - 10.5) < 1e-6
     assert abs(float(updates[0]["yaw"]) - 1.57079632679) < 1e-3
 

--- a/transceiver/navigation_adapter.py
+++ b/transceiver/navigation_adapter.py
@@ -625,10 +625,11 @@ class NavigationAdapter:
 
 
 class RosbridgePoseStreamTransport:
-    """Continuously streams `/base_footprint` updates via rosbridge through an SSH tunnel."""
+    """Streams `map -> base_footprint` pose updates from `/tf` via rosbridge."""
 
-    _POSE_TOPIC = "/base_footprint"
-    _POSE_TYPE = "geometry_msgs/msg/PoseWithCovarianceStamped"
+    _POSE_TOPIC = "/tf"
+    _POSE_TYPE = "tf2_msgs/msg/TFMessage"
+    _POSE_CHILD_FRAME_ID = "base_footprint"
     _DEFAULT_EXPECTED_FRAME_ID = "map"
     _READY_RETRY_INTERVAL_S = 0.15
 
@@ -680,50 +681,76 @@ class RosbridgePoseStreamTransport:
         return float(math.atan2(siny_cosp, cosy_cosp))
 
     @classmethod
-    def _extract_pose_payload(cls, rosbridge_msg: dict[str, Any]) -> dict[str, Any] | None:
+    def _normalize_frame_id(cls, value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().lstrip("/")
+        return normalized or None
+
+    @classmethod
+    def _extract_pose_payload(
+        cls,
+        rosbridge_msg: dict[str, Any],
+        *,
+        expected_frame_id: str,
+    ) -> dict[str, Any] | None:
         msg = rosbridge_msg.get("msg")
         if not isinstance(msg, dict):
             return None
-        header = msg.get("header")
-        pose_cov = msg.get("pose")
-        if not isinstance(header, dict) or not isinstance(pose_cov, dict):
-            return None
-        pose = pose_cov.get("pose")
-        if not isinstance(pose, dict):
-            return None
-        position = pose.get("position")
-        orientation = pose.get("orientation")
-        if not isinstance(position, dict) or not isinstance(orientation, dict):
-            return None
-        try:
-            px = float(position["x"])
-            py = float(position["y"])
-            qx = float(orientation.get("x", 0.0))
-            qy = float(orientation.get("y", 0.0))
-            qz = float(orientation.get("z", 0.0))
-            qw = float(orientation.get("w", 1.0))
-        except (TypeError, ValueError, KeyError):
+        transforms = msg.get("transforms")
+        if not isinstance(transforms, list):
             return None
 
-        frame_id_raw = header.get("frame_id")
-        frame_id = frame_id_raw if isinstance(frame_id_raw, str) and frame_id_raw.strip() else "map"
-        stamp = header.get("stamp")
-        timestamp = time.time()
-        if isinstance(stamp, dict):
+        expected_parent_frame = cls._normalize_frame_id(expected_frame_id) or "map"
+        expected_child_frame = cls._POSE_CHILD_FRAME_ID
+
+        for transform_entry in transforms:
+            if not isinstance(transform_entry, dict):
+                continue
+            header = transform_entry.get("header")
+            transform = transform_entry.get("transform")
+            if not isinstance(header, dict) or not isinstance(transform, dict):
+                continue
+
+            parent_frame = cls._normalize_frame_id(header.get("frame_id"))
+            child_frame = cls._normalize_frame_id(transform_entry.get("child_frame_id"))
+            if parent_frame != expected_parent_frame or child_frame != expected_child_frame:
+                continue
+
+            translation = transform.get("translation")
+            rotation = transform.get("rotation")
+            if not isinstance(translation, dict) or not isinstance(rotation, dict):
+                continue
+
             try:
-                sec = int(stamp.get("sec", 0))
-                nanosec = int(stamp.get("nanosec", 0))
-                timestamp = float(sec) + float(nanosec) / 1_000_000_000.0
-            except (TypeError, ValueError):
-                timestamp = time.time()
+                px = float(translation["x"])
+                py = float(translation["y"])
+                qx = float(rotation.get("x", 0.0))
+                qy = float(rotation.get("y", 0.0))
+                qz = float(rotation.get("z", 0.0))
+                qw = float(rotation.get("w", 1.0))
+            except (TypeError, ValueError, KeyError):
+                continue
 
-        return {
-            "x": px,
-            "y": py,
-            "frame_id": frame_id,
-            "timestamp": timestamp,
-            "yaw": cls._extract_yaw(x=qx, y=qy, z=qz, w=qw),
-        }
+            stamp = header.get("stamp")
+            timestamp = time.time()
+            if isinstance(stamp, dict):
+                try:
+                    sec = int(stamp.get("sec", 0))
+                    nanosec = int(stamp.get("nanosec", 0))
+                    timestamp = float(sec) + float(nanosec) / 1_000_000_000.0
+                except (TypeError, ValueError):
+                    timestamp = time.time()
+
+            return {
+                "x": px,
+                "y": py,
+                "frame_id": expected_parent_frame,
+                "child_frame_id": expected_child_frame,
+                "timestamp": timestamp,
+                "yaw": cls._extract_yaw(x=qx, y=qy, z=qz, w=qw),
+            }
+        return None
 
     def _stop_ssh_tunnel(self) -> None:
         with self._lock:
@@ -813,7 +840,6 @@ class RosbridgePoseStreamTransport:
         reconnect_attempt = 0
         while not self._stop_event.is_set():
             reconnect_attempt += 1
-            frame_mismatch_reported = False
             disconnect_reason = ""
             try:
                 local_port = self._reserve_local_port()
@@ -913,42 +939,23 @@ class RosbridgePoseStreamTransport:
                         continue
                     if decoded.get("op") != "publish" or decoded.get("topic") != self._POSE_TOPIC:
                         continue
-                    payload = self._extract_pose_payload(decoded)
+                    payload = self._extract_pose_payload(decoded, expected_frame_id=expected_frame)
                     if payload is None:
                         on_event(
                             {
                                 "type": "pose_stream",
                                 "event": {
                                     "type": "stream_error",
-                                    "message": "base_footprint rosbridge message is missing required pose fields",
-                                    "attempt": reconnect_attempt,
-                                    "timestamp": time.time(),
-                                },
-                            }
-                        )
-                        continue
-                    received_frame = payload.get("frame_id")
-                    if (
-                        not frame_mismatch_reported
-                        and isinstance(received_frame, str)
-                        and received_frame.strip()
-                        and received_frame != expected_frame
-                    ):
-                        frame_mismatch_reported = True
-                        on_event(
-                            {
-                                "type": "pose_stream",
-                                "event": {
-                                    "type": "stream_error",
                                     "message": (
-                                        "unerwarteter /base_footprint frame_id: "
-                                        f"erwartet={expected_frame}, empfangen={received_frame}"
+                                        "tf rosbridge message misses map->base_footprint transform "
+                                        f"(expected parent frame: {expected_frame})"
                                     ),
                                     "attempt": reconnect_attempt,
                                     "timestamp": time.time(),
                                 },
                             }
                         )
+                        continue
                     on_event(
                         {
                             "type": "pose_stream",


### PR DESCRIPTION
### Motivation

- Adapt the rosbridge pose streaming to consume `TFMessage` updates on `/tf` and extract the `map -> base_footprint` transform instead of relying on a `/base_footprint` `PoseWithCovarianceStamped` topic.
- Make frame ID handling more robust by normalizing and validating parent/child frame names and by tolerating varied timestamp formats in incoming messages.

### Description

- Change constants to use `'/tf'` and `tf2_msgs/msg/TFMessage` and add `_POSE_CHILD_FRAME_ID = 'base_footprint'` while updating the class docstring to reflect the new behavior.
- Add `_normalize_frame_id` to consistently normalize and validate frame id strings and update `_extract_pose_payload` to accept `expected_frame_id` and to parse the `transforms` array from `TFMessage`, filtering for the expected parent frame and the `base_footprint` child frame before extracting translation, rotation, timestamp, and yaw.
- Update the run loop to call `_extract_pose_payload` with the expected frame, change the rosbridge subscription topic to `'/tf'`, and adjust stream error messages and handling when the expected transform is not present.
- Update unit tests to expect `/tf` subscription and to assert the presence of `child_frame_id` in parsed position updates.

### Testing

- Ran the modified unit tests in `tests/test_navigation_adapter.py`, including `test_rosbridge_pose_stream_sends_subscribe_and_parses_pose`, and they passed.
- Executed the related reconnection test `test_rosbridge_pose_stream_reconnects_after_disconnect` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb66dc8d4c8321b1a3ae32a7657eaf)