### PR TITLE
Support map→mid→base_footprint TF composition in rosbridge pose stream

### DIFF
--- a/tests/test_navigation_adapter.py
+++ b/tests/test_navigation_adapter.py
@@ -645,6 +645,76 @@ def test_rosbridge_pose_stream_sends_subscribe_and_parses_pose(monkeypatch) -> N
     assert abs(float(updates[0]["yaw"]) - 1.57079632679) < 1e-3
 
 
+def test_extract_pose_payload_accepts_two_hop_chain() -> None:
+    payload = RosbridgePoseStreamTransport._extract_pose_payload(
+        {
+            "msg": {
+                "transforms": [
+                    {
+                        "header": {
+                            "frame_id": "map",
+                            "stamp": {"sec": 20, "nanosec": 100000000},
+                        },
+                        "child_frame_id": "odom",
+                        "transform": {
+                            "translation": {"x": 1.0, "y": 2.0, "z": 0.0},
+                            "rotation": {
+                                "x": 0.0,
+                                "y": 0.0,
+                                "z": 0.7071068,
+                                "w": 0.7071068,
+                            },
+                        },
+                    },
+                    {
+                        "header": {
+                            "frame_id": "odom",
+                            "stamp": {"sec": 20, "nanosec": 300000000},
+                        },
+                        "child_frame_id": "base_footprint",
+                        "transform": {
+                            "translation": {"x": 1.0, "y": 0.0, "z": 0.0},
+                            "rotation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+                        },
+                    },
+                ]
+            }
+        },
+        expected_frame_id="map",
+    )
+
+    assert payload is not None
+    assert abs(float(payload["x"]) - 1.0) < 1e-6
+    assert abs(float(payload["y"]) - 3.0) < 1e-6
+    assert abs(float(payload["yaw"]) - 1.57079632679) < 1e-3
+    assert abs(float(payload["timestamp"]) - 20.3) < 1e-6
+
+
+def test_extract_pose_payload_returns_none_when_chain_is_incomplete() -> None:
+    payload = RosbridgePoseStreamTransport._extract_pose_payload(
+        {
+            "msg": {
+                "transforms": [
+                    {
+                        "header": {
+                            "frame_id": "map",
+                            "stamp": {"sec": 20, "nanosec": 100000000},
+                        },
+                        "child_frame_id": "odom",
+                        "transform": {
+                            "translation": {"x": 1.0, "y": 2.0, "z": 0.0},
+                            "rotation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+                        },
+                    }
+                ]
+            }
+        },
+        expected_frame_id="map",
+    )
+
+    assert payload is None
+
+
 def test_rosbridge_pose_stream_reconnects_after_disconnect(monkeypatch) -> None:
     import sys
     import types

--- a/transceiver/navigation_adapter.py
+++ b/transceiver/navigation_adapter.py
@@ -680,6 +680,52 @@ class RosbridgePoseStreamTransport:
         cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
         return float(math.atan2(siny_cosp, cosy_cosp))
 
+    @staticmethod
+    def _quat_multiply(
+        q1: tuple[float, float, float, float],
+        q2: tuple[float, float, float, float],
+    ) -> tuple[float, float, float, float]:
+        x1, y1, z1, w1 = q1
+        x2, y2, z2, w2 = q2
+        return (
+            (w1 * x2) + (x1 * w2) + (y1 * z2) - (z1 * y2),
+            (w1 * y2) - (x1 * z2) + (y1 * w2) + (z1 * x2),
+            (w1 * z2) + (x1 * y2) - (y1 * x2) + (z1 * w2),
+            (w1 * w2) - (x1 * x2) - (y1 * y2) - (z1 * z2),
+        )
+
+    @staticmethod
+    def _rotate_vector_by_quaternion(
+        x: float,
+        y: float,
+        z: float,
+        q: tuple[float, float, float, float],
+    ) -> tuple[float, float, float]:
+        qx, qy, qz, qw = q
+        vx, vy, vz = x, y, z
+        ux = (qy * vz) - (qz * vy)
+        uy = (qz * vx) - (qx * vz)
+        uz = (qx * vy) - (qy * vx)
+        uux = (qy * uz) - (qz * uy)
+        uuy = (qz * ux) - (qx * uz)
+        uuz = (qx * uy) - (qy * ux)
+        return (
+            vx + 2.0 * ((qw * ux) + uux),
+            vy + 2.0 * ((qw * uy) + uuy),
+            vz + 2.0 * ((qw * uz) + uuz),
+        )
+
+    @staticmethod
+    def _extract_timestamp(stamp: Any) -> float:
+        if isinstance(stamp, dict):
+            try:
+                sec = int(stamp.get("sec", 0))
+                nanosec = int(stamp.get("nanosec", 0))
+                return float(sec) + float(nanosec) / 1_000_000_000.0
+            except (TypeError, ValueError):
+                return time.time()
+        return time.time()
+
     @classmethod
     def _normalize_frame_id(cls, value: Any) -> str | None:
         if not isinstance(value, str):
@@ -704,6 +750,15 @@ class RosbridgePoseStreamTransport:
         expected_parent_frame = cls._normalize_frame_id(expected_frame_id) or "map"
         expected_child_frame = cls._POSE_CHILD_FRAME_ID
 
+        edge_lookup: dict[
+            tuple[str, str],
+            tuple[
+                tuple[float, float, float],
+                tuple[float, float, float, float],
+                float,
+            ],
+        ] = {}
+
         for transform_entry in transforms:
             if not isinstance(transform_entry, dict):
                 continue
@@ -714,7 +769,7 @@ class RosbridgePoseStreamTransport:
 
             parent_frame = cls._normalize_frame_id(header.get("frame_id"))
             child_frame = cls._normalize_frame_id(transform_entry.get("child_frame_id"))
-            if parent_frame != expected_parent_frame or child_frame != expected_child_frame:
+            if parent_frame is None or child_frame is None:
                 continue
 
             translation = transform.get("translation")
@@ -723,8 +778,9 @@ class RosbridgePoseStreamTransport:
                 continue
 
             try:
-                px = float(translation["x"])
-                py = float(translation["y"])
+                tx = float(translation["x"])
+                ty = float(translation["y"])
+                tz = float(translation.get("z", 0.0))
                 qx = float(rotation.get("x", 0.0))
                 qy = float(rotation.get("y", 0.0))
                 qz = float(rotation.get("z", 0.0))
@@ -732,16 +788,15 @@ class RosbridgePoseStreamTransport:
             except (TypeError, ValueError, KeyError):
                 continue
 
-            stamp = header.get("stamp")
-            timestamp = time.time()
-            if isinstance(stamp, dict):
-                try:
-                    sec = int(stamp.get("sec", 0))
-                    nanosec = int(stamp.get("nanosec", 0))
-                    timestamp = float(sec) + float(nanosec) / 1_000_000_000.0
-                except (TypeError, ValueError):
-                    timestamp = time.time()
+            edge_lookup[(parent_frame, child_frame)] = (
+                (tx, ty, tz),
+                (qx, qy, qz, qw),
+                cls._extract_timestamp(header.get("stamp")),
+            )
 
+        direct = edge_lookup.get((expected_parent_frame, expected_child_frame))
+        if direct is not None:
+            (px, py, _pz), (qx, qy, qz, qw), timestamp = direct
             return {
                 "x": px,
                 "y": py,
@@ -750,6 +805,29 @@ class RosbridgePoseStreamTransport:
                 "timestamp": timestamp,
                 "yaw": cls._extract_yaw(x=qx, y=qy, z=qz, w=qw),
             }
+
+        for (parent_frame, mid_frame), first_edge in edge_lookup.items():
+            if parent_frame != expected_parent_frame:
+                continue
+            second_edge = edge_lookup.get((mid_frame, expected_child_frame))
+            if second_edge is None:
+                continue
+
+            (t1x, t1y, t1z), q1, ts1 = first_edge
+            (t2x, t2y, t2z), q2, ts2 = second_edge
+            rt2x, rt2y, _rt2z = cls._rotate_vector_by_quaternion(t2x, t2y, t2z, q1)
+            px = t1x + rt2x
+            py = t1y + rt2y
+            qx, qy, qz, qw = cls._quat_multiply(q1, q2)
+            return {
+                "x": px,
+                "y": py,
+                "frame_id": expected_parent_frame,
+                "child_frame_id": expected_child_frame,
+                "timestamp": max(ts1, ts2),
+                "yaw": cls._extract_yaw(x=qx, y=qy, z=qz, w=qw),
+            }
+
         return None
 
     def _stop_ssh_tunnel(self) -> None:
@@ -947,8 +1025,8 @@ class RosbridgePoseStreamTransport:
                                 "event": {
                                     "type": "stream_error",
                                     "message": (
-                                        "tf rosbridge message misses map->base_footprint transform "
-                                        f"(expected parent frame: {expected_frame})"
+                                        "tf rosbridge message misses expected transform path "
+                                        f"({expected_frame}->base_footprint directly or via one intermediate frame)"
                                     ),
                                     "attempt": reconnect_attempt,
                                     "timestamp": time.time(),


### PR DESCRIPTION
### Motivation
- Die Pose-Extraktion aus rosbridge-`/tf`-Nachrichten soll nicht nur direkte `map->base_footprint`-Transforms akzeptieren, sondern auch eine zweistufige Kette `map->mid->base_footprint`, wenn der direkte Transform fehlt.

### Description
- `RosbridgePoseStreamTransport._extract_pose_payload` baut jetzt zunächst ein Kanten-Lookup aus allen gültigen `msg.transforms` und priorisiert weiterhin den direkten Pfad `(expected_parent_frame -> base_footprint)` gegenüber der Kettenauflösung.
- Es wurden Quaternion- und Vektor-Hilfsfunktionen (`_quat_multiply`, `_rotate_vector_by_quaternion`) sowie `
_extract_timestamp` ergänzt, um Translation/Rotation korrekt zu verketten und Timestamps zu extrahieren.
- Bei gefundener zweistufiger Kette werden die Translation des zweiten Transforms durch die erste Rotation gedreht, die beiden Translationen addiert, die Quaternions multipliziert und als Timestamp das neuere der beiden Stamps verwendet.
- Die Fehlermeldung in `_run_loop` wurde präzisiert, so dass klar ist, dass entweder ein direkter Transform oder ein Ein-Zwischenframe-Pfad (`expected_frame->base_footprint` direkt oder via einem Zwischenframe) erwartet wurde.

### Testing
- Neue Tests wurden ergänzt: vorhandener direkter-Transform-Fall bleibt erhalten, ein neuer Erfolgsfall für `map->odom->base_footprint`, und ein Negativfall für unvollständige Kette; diese Tests sind in `tests/test_navigation_adapter.py` enthalten.
- Testlauf mit gesetztem Importpfad wurde durchgeführt und erfolgreich: `PYTHONPATH=. pytest -q tests/test_navigation_adapter.py` zeigte `24 passed` (ohne `PYTHONPATH` schlug die Sammlung wegen `ModuleNotFoundError: No module named 'transceiver'` fehl).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb697244908321b20ee678c0f64501)