### PR TITLE
Decouple live marker redraw from echo preview throttling

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -454,6 +454,58 @@ def test_compute_bistatic_echo_ellipse_axes_rejects_negative_delta() -> None:
     assert _compute_bistatic_echo_ellipse_axes(distance_rx_to_point=10.0, echo_distance_m=-0.1) is None
 
 
+def test_request_live_redraw_marker_only_updates_even_if_live_preview_disabled() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.live_preview_enabled_var = SimpleNamespace(get=lambda: False)
+    window._live_marker_redraw_pending = False
+    window._live_marker_redraw_job = None
+    marker_draw_calls: list[str] = []
+    window._draw_live_marker = lambda: marker_draw_calls.append("drawn")
+    window.after = lambda _delay, callback: (callback(), None)[1]
+
+    window.request_live_redraw(include_echo=False)
+
+    assert marker_draw_calls == ["drawn"]
+    assert window._live_marker_redraw_pending is False
+    assert window._live_marker_redraw_job is None
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_position"),
+    [
+        (
+            {"type": "pose_stream", "event": {"type": "position_update", "position": {"x": 1.0, "y": 2.0}}},
+            {"x": 1.0, "y": 2.0},
+        ),
+        (
+            {"type": "navigation", "event": {"type": "position_update", "position": {"x": -4.0, "y": 7.5}}},
+            {"x": -4.0, "y": 7.5},
+        ),
+    ],
+)
+def test_handle_executor_runtime_event_position_update_requests_marker_redraw_when_live_preview_disabled(
+    payload: dict[str, object],
+    expected_position: dict[str, float],
+) -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.live_preview_enabled_var = SimpleNamespace(get=lambda: False)
+    applied_positions: list[dict[str, object]] = []
+    marker_redraw_requests: list[str] = []
+    live_redraw_requests: list[str] = []
+    label_updates: list[str] = []
+    window._apply_live_position_update = lambda position: applied_positions.append(position)
+    window.request_live_marker_redraw = lambda: marker_redraw_requests.append("marker")
+    window.request_live_redraw = lambda: live_redraw_requests.append("echo")
+    window._update_live_label = lambda: label_updates.append("label")
+
+    window._handle_executor_runtime_event(payload)
+
+    assert applied_positions == [expected_position]
+    assert marker_redraw_requests == ["marker"]
+    assert live_redraw_requests == ["echo"]
+    assert label_updates == ["label"]
+
+
 class _FakeAdapter:
     def __init__(self, events):
         self.config = object()

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -469,6 +469,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._live_position_received_at: float | None = None
         self._live_redraw_pending = False
         self._live_redraw_job: str | None = None
+        self._live_marker_redraw_pending = False
+        self._live_marker_redraw_job: str | None = None
         self._last_live_redraw_ts: float | None = None
         self._live_position_at_measurement_start: dict[str, Any] | None = None
         self._measurement_start_live_position_event = threading.Event()
@@ -3169,7 +3171,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             pass
         self._live_label_ticker_job = None
 
-    def request_live_redraw(self) -> None:
+    def request_live_redraw(self, *, include_echo: bool = True) -> None:
+        if not include_echo:
+            self.request_live_marker_redraw()
+            return
         if self._live_redraw_pending or not bool(self.live_preview_enabled_var.get()):
             return
         delay_ms = 0
@@ -3190,15 +3195,35 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._draw_live_overlay_layer()
         self._last_live_redraw_ts = time.time()
 
+    def request_live_marker_redraw(self) -> None:
+        if self._live_marker_redraw_pending:
+            return
+        self._live_marker_redraw_pending = True
+        self._live_marker_redraw_job = self.after(0, self._run_live_marker_redraw)
+
+    def _run_live_marker_redraw(self) -> None:
+        self._live_marker_redraw_job = None
+        self._live_marker_redraw_pending = False
+        self._draw_live_marker()
+
     def _cancel_live_redraw(self) -> None:
         self._live_redraw_pending = False
         if self._live_redraw_job is None:
+            pass
+        else:
+            try:
+                self.after_cancel(self._live_redraw_job)
+            except Exception:
+                pass
+            self._live_redraw_job = None
+        self._live_marker_redraw_pending = False
+        if self._live_marker_redraw_job is None:
             return
         try:
-            self.after_cancel(self._live_redraw_job)
+            self.after_cancel(self._live_marker_redraw_job)
         except Exception:
             pass
-        self._live_redraw_job = None
+        self._live_marker_redraw_job = None
 
     def _review_measurement(self, *, point_context, output_file: str) -> dict[str, object]:  # type: ignore[no-untyped-def]
         manual_review_enabled = bool(self.manual_review_enabled_var.get())
@@ -3649,6 +3674,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 if event.get("type") != "position_update":
                     return
                 self._apply_live_position_update(event.get("position"))
+                self.request_live_marker_redraw()
                 self.request_live_redraw()
                 self._update_live_label()
                 return
@@ -3660,6 +3686,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             event_type = str(event.get("type") or "")
             if event_type == "position_update":
                 self._apply_live_position_update(event.get("position"))
+                self.request_live_marker_redraw()
                 self.request_live_redraw()
                 self._update_live_label()
                 return


### PR DESCRIPTION
### Motivation
- Ensure the live position marker is updated even when the heavy live preview (echo overlays) is disabled, so pose-only streams still reflect marker movement.
- Avoid applying the FPS throttling used for echo overlays to the cheap marker redraw path.

### Description
- Added marker redraw scheduling state (`_live_marker_redraw_pending`, `_live_marker_redraw_job`) and a dedicated API `request_live_marker_redraw()` with `_run_live_marker_redraw()` to draw only the marker.
- Extended `request_live_redraw()` with parameter `include_echo: bool` so callers can request marker-only redraws via `include_echo=False`; the existing FPS throttling remains for the echo overlay path.
- Updated `_handle_executor_runtime_event()` so every `position_update` (both `navigation` and `pose_stream`) triggers a marker redraw regardless of the `live_preview_enabled_var` state.
- Enhanced `_cancel_live_redraw()` to also cancel any scheduled marker redraw jobs.
- Added/updated tests in `tests/test_mission_workflow_ui.py` to cover the marker-only redraw path and the `position_update` behavior when live preview is disabled.

### Testing
- Ran `pytest -q tests/test_mission_workflow_ui.py` which initially failed during collection when `PYTHONPATH` was not set (ModuleNotFoundError for `transceiver`).
- Re-ran with `PYTHONPATH=.` using `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` and got `60 passed` (all tests in that file passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb6fc8dfdc8321bf7c3ffeb906ed0d)