### PR TITLE
Ensure mission Stop cancels active Nav2 goal even without known goal ID

### DIFF
--- a/tests/test_navigation_adapter.py
+++ b/tests/test_navigation_adapter.py
@@ -426,6 +426,60 @@ def test_cancel_current_goal_uses_server_side_cancel_before_signals(monkeypatch)
     assert process.sent_signals == [signal.SIGINT]
 
 
+def test_cancel_current_goal_calls_cancel_service_when_goal_id_missing(monkeypatch) -> None:
+    calls: list[tuple[str, object]] = []
+
+    class _Process:
+        def __init__(self) -> None:
+            self.sent_signals: list[int] = []
+
+        def poll(self):
+            return None
+
+        def send_signal(self, sig: int) -> None:
+            self.sent_signals.append(sig)
+            calls.append(("signal", sig))
+
+        def wait(self, timeout: float) -> int:
+            raise TimeoutError("still running")
+
+        def terminate(self) -> None:
+            calls.append(("terminate", None))
+
+        def kill(self) -> None:
+            calls.append(("kill", None))
+
+    def _fake_run(cmd, **kwargs):
+        calls.append(("server_cancel", cmd))
+
+        class _Done:
+            returncode = 0
+
+        return _Done()
+
+    monkeypatch.setattr("transceiver.navigation_adapter.subprocess.run", _fake_run)
+
+    transport = Ros2CliNavigationTransport()
+    process = _Process()
+    transport._last_process = process
+    transport._last_config = NavigationAdapterConfig(
+        robot_host="robot@10.0.0.2",
+        ros2_namespace="robot1",
+        remote_ros_setup="/opt/ros/jazzy/setup.bash",
+    )
+    transport._last_goal_id = None
+
+    transport.cancel_current_goal()
+
+    assert calls[0][0] == "server_cancel"
+    cancel_cmd = " ".join(str(part) for part in calls[0][1])
+    assert "service call" in cancel_cmd
+    assert "/robot1/navigate_to_pose/_action/cancel_goal" in cancel_cmd
+    assert "action_msgs/srv/CancelGoal" in cancel_cmd
+    assert "uuid" in cancel_cmd
+    assert process.sent_signals == [signal.SIGINT]
+
+
 def test_send_goal_maps_dead_transport_to_connection_error_even_after_accept(monkeypatch) -> None:
     class _Stream:
         def __init__(self, lines: list[str], rest: str = "") -> None:

--- a/transceiver/navigation_adapter.py
+++ b/transceiver/navigation_adapter.py
@@ -372,11 +372,10 @@ class Ros2CliNavigationTransport:
 
     def _cancel_on_server(self) -> None:
         config = self._last_config
-        goal_id = self._last_goal_id
-        if config is None or not goal_id:
+        if config is None:
             return
         try:
-            cancel_cmd = self._build_cancel_command(config=config, goal_id=goal_id)
+            cancel_cmd = self._build_cancel_command(config=config, goal_id=self._last_goal_id)
             subprocess.run(
                 cancel_cmd,
                 capture_output=True,
@@ -404,19 +403,14 @@ class Ros2CliNavigationTransport:
         cls,
         *,
         config: NavigationAdapterConfig,
-        goal_id: str,
+        goal_id: str | None,
     ) -> list[str]:
         resolved_action = cls._resolve_action_name(
             namespace=config.ros2_namespace,
             action_name=config.ros2_action_name,
         )
-        return cls._build_remote_ssh_command(
-            robot_host=config.robot_host,
-            connect_timeout_s=config.goal_acceptance_timeout_s,
-            remote_ros_env_cmd=config.remote_ros_env_cmd.strip(),
-            remote_ros_setup=config.remote_ros_setup.strip(),
-            fastdds_profiles_file="",
-            remote_command=" ".join(
+        if goal_id:
+            remote_command = " ".join(
                 [
                     "ros2",
                     "action",
@@ -425,7 +419,29 @@ class Ros2CliNavigationTransport:
                     "--goal-id",
                     shlex.quote(goal_id),
                 ]
-            ),
+            )
+        else:
+            cancel_service_name = f"{resolved_action}/_action/cancel_goal"
+            cancel_all_payload = (
+                '{"goal_info":{"goal_id":{"uuid":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"stamp":{"sec":0,"nanosec":0}}}'
+            )
+            remote_command = " ".join(
+                [
+                    "ros2",
+                    "service",
+                    "call",
+                    shlex.quote(cancel_service_name),
+                    "action_msgs/srv/CancelGoal",
+                    shlex.quote(cancel_all_payload),
+                ]
+            )
+        return cls._build_remote_ssh_command(
+            robot_host=config.robot_host,
+            connect_timeout_s=config.goal_acceptance_timeout_s,
+            remote_ros_env_cmd=config.remote_ros_env_cmd.strip(),
+            remote_ros_setup=config.remote_ros_setup.strip(),
+            fastdds_profiles_file="",
+            remote_command=remote_command,
             diagnostics_label=f"cancel_action={resolved_action}",
         )
 


### PR DESCRIPTION
### Motivation
- Pressing Stop during a mission should cancel an active Nav2 navigation on the robot even when no parsable goal id is available from the CLI output.
- Some runs produce no known `goal_id`, so attempting only `ros2 action cancel --goal-id` can fail to stop the robot.

### Description
- Update `Ros2CliNavigationTransport._cancel_on_server` to attempt a server-side cancel whenever runtime config is present, not only when a `goal_id` is known, by delegating to `_build_cancel_command` with `self._last_goal_id`.
- Extend `_build_cancel_command` to support two paths: use `ros2 action cancel <action> --goal-id <id>` when `goal_id` is provided, and fall back to calling the nav2 cancel service with `ros2 service call <action>/_action/cancel_goal action_msgs/srv/CancelGoal <zero-uuid-payload>` when `goal_id` is missing.
- Keep the existing local-process fallback (send `SIGINT`, then `terminate()`, then `kill()`) unchanged so the transport still tries graceful termination if server cancel does not immediately stop the CLI process.
- Add a unit test `test_cancel_current_goal_calls_cancel_service_when_goal_id_missing` in `tests/test_navigation_adapter.py` that verifies a service-call is constructed and invoked when `_last_goal_id` is `None`.

### Testing
- Ran `pytest -q tests/test_navigation_adapter.py` without `PYTHONPATH` initially which failed in this environment with `ModuleNotFoundError: No module named 'transceiver'` due to test import path setup issue.
- Ran `PYTHONPATH=. pytest -q tests/test_navigation_adapter.py` which executed the file and reported `25 passed` (all tests in that file passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb7a78c5288321ae830e1be343511d)