### PR TITLE
Handle manual stop as cancel despite transient navigation transport errors

### DIFF
--- a/tests/test_measurement_run_executor.py
+++ b/tests/test_measurement_run_executor.py
@@ -289,7 +289,7 @@ def test_manual_stop_after_last_point_uses_completed_with_abort_substatus() -> N
     assert summaries[0]["abort_reason"] == "run_cancelled.manual_stop_after_completion"
 
 
-def test_manual_stop_without_cancel_confirmation_marks_failed() -> None:
+def test_manual_stop_with_transport_connection_error_still_marks_cancelled() -> None:
     class NoCancelConfirmationNavigator(FakeNavigator):
         def __init__(self) -> None:
             super().__init__(["connection_error"])
@@ -307,7 +307,7 @@ def test_manual_stop_without_cancel_confirmation_marks_failed() -> None:
     nav = NoCancelConfirmationNavigator()
     summaries: list[dict] = []
     executor = MeasurementRunExecutor(
-        mission=MeasurementMission(name="single", points=[_mission().points[0]], repeat=1),
+        mission=_mission(),
         navigator=nav,
         trigger_measurement=lambda _point: {"ok": True},
         persist_result=lambda _payload: None,
@@ -321,9 +321,9 @@ def test_manual_stop_without_cancel_confirmation_marks_failed() -> None:
     executor.stop()
     thread.join(timeout=2)
 
-    assert executor.state == "failed"
+    assert executor.state == "cancelled"
     assert nav.cancel_calls == 1
-    assert summaries[0]["abort_reason"] == "navigation_failed.connection_error"
+    assert summaries[0]["abort_reason"] == "run_cancelled.manual_stop"
 
 def test_invalid_transitions_raise() -> None:
     executor = MeasurementRunExecutor(

--- a/transceiver/measurement_run_executor.py
+++ b/transceiver/measurement_run_executor.py
@@ -396,7 +396,12 @@ class MeasurementRunExecutor:
 
         if self._cancel_requested and nav_state == "succeeded":
             nav_state = "canceled"
-        if self._cancel_requested and nav_state == "canceled":
+        if self._cancel_requested and nav_state != "succeeded":
+            # A manual stop was requested while navigation was active.
+            # Depending on timing/transport teardown we may observe "aborted",
+            # "timeout" or "connection_error" instead of an explicit cancel ack.
+            # Treat these as cancel-confirmed to keep stop semantics stable.
+            nav_state = "canceled"
             self._cancel_confirmed = True
 
         point_context = PointExecutionContext(


### PR DESCRIPTION
### Motivation
- Pressing Stop could lead to `navigation_failed.connection_error` (or other non-cancel terminal states) due to transport/teardown timing, which incorrectly marks a run as failed instead of cancelled.

### Description
- Normalize navigation outcomes to `canceled` when a manual stop was already requested by treating any non-`succeeded` result observed after a stop as a confirmed cancel in `MeasurementRunExecutor` (`transceiver/measurement_run_executor.py`).
- Set `_cancel_confirmed = True` in that path so the executor finalizes to the `cancelled` state and produces `run_cancelled.manual_stop` as abort reason.
- Update and rename the unit test to assert the new behavior and correct the test mission fixture usage in `tests/test_measurement_run_executor.py`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_measurement_run_executor.py` and all tests in that file passed (24 passed).
- Ran `PYTHONPATH=. pytest -q tests/test_measurement_run_executor_integration.py` which failed (5 failed) due to existing test-double signature incompatibilities for `on_navigation_event` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb83f27fe08321ae2563339489ead4)