### PR TITLE
Fix syntax error in navigation adapter cancel command builder

### DIFF
--- a/transceiver/navigation_adapter.py
+++ b/transceiver/navigation_adapter.py
@@ -489,12 +489,6 @@ class Ros2CliNavigationTransport:
             namespace=config.ros2_namespace,
             action_name=config.ros2_action_name,
         )
-        return cls._build_remote_ssh_command(
-            robot_host=config.robot_host,
-            connect_timeout_s=config.goal_acceptance_timeout_s,
-            remote_ros_env_cmd=config.remote_ros_env_cmd.strip(),
-            remote_ros_setup=config.remote_ros_setup.strip(),
-            fastdds_profiles_file=config.fastdds_profiles_file.strip(),
         if goal_id:
             remote_command = " ".join(
                 [
@@ -1422,4 +1416,3 @@ class RosbridgePoseStreamTransport:
 
 
 Ros2CliPoseStreamTransport = RosbridgePoseStreamTransport
-


### PR DESCRIPTION
### Motivation
- Importing the package failed with a `SyntaxError` due to an unclosed parenthesis caused by an accidental early `return` inside `_build_cancel_command`, preventing the module from being imported. 

### Description
- Removed the stray early `return` so `_build_cancel_command` now constructs `remote_command` first based on `goal_id` and then returns a single call to `_build_remote_ssh_command` with that `remote_command`. 
- The final `_build_remote_ssh_command` invocation includes `remote_command` and a `diagnostics_label` of `cancel_action={resolved_action}` and sets `fastdds_profiles_file` to an explicit empty string. 

### Testing
- `python -m py_compile transceiver/navigation_adapter.py` was run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb872d35848321807a8d9dbc332bcb)