### PR TITLE
Enable stopping nav2point goals via Stop button

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -755,6 +755,44 @@ def test_on_map_canvas_release_queues_nav2point_with_dragged_yaw() -> None:
     assert queued == [((4.0, -3.0), 1.2)]
 
 
+def test_stop_run_cancels_active_nav2point_goal() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    cancel_calls: list[str] = []
+    messages: list[str] = []
+    window._nav2point_thread = SimpleNamespace(is_alive=lambda: True)
+    window._executor = None
+    window._navigator = SimpleNamespace(cancel_current_goal=lambda: cancel_calls.append("cancel"))
+    window._append_validation = messages.append
+
+    window._stop_run()
+
+    assert cancel_calls == ["cancel"]
+    assert any("nav2point-Cancel" in message for message in messages)
+
+
+def test_refresh_stop_button_state_enables_stop_while_nav2point_runs() -> None:
+    class _DummyButton:
+        def __init__(self) -> None:
+            self.state = "disabled"
+
+        def configure(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+            if "state" in kwargs:
+                self.state = kwargs["state"]
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.stop_btn = _DummyButton()
+    window._run_thread = None
+    window._manual_measurement_thread = None
+    window._nav2point_thread = SimpleNamespace(is_alive=lambda: True)
+
+    window._refresh_stop_button_state()
+    assert window.stop_btn.state == "normal"
+
+    window._nav2point_thread = SimpleNamespace(is_alive=lambda: False)
+    window._refresh_stop_button_state()
+    assert window.stop_btn.state == "disabled"
+
+
 def test_review_measurement_auto_approves_when_manual_review_disabled() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window.manual_review_enabled_var = SimpleNamespace(get=lambda: False)

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -319,6 +319,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._executor: MeasurementRunExecutor | None = None
         self._navigator: _UiNavigator | None = None
         self._run_thread: threading.Thread | None = None
+        self._nav2point_thread: threading.Thread | None = None
         self._manual_measurement_thread: threading.Thread | None = None
         self._records: list[dict[str, Any]] = []
         self._run_started_at: float | None = None
@@ -1125,14 +1126,21 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if self._run_thread and self._run_thread.is_alive():
             self._append_validation("⚠️ nav2point ist während eines aktiven Runs deaktiviert.")
             return
+        if self._nav2point_thread and self._nav2point_thread.is_alive():
+            self._append_validation("⚠️ nav2point läuft bereits. Bitte aktuellen Zielpunkt zuerst stoppen oder abwarten.")
+            return
         target = self._navigation_point_from_world_position(world_position, yaw_radians=yaw_radians)
 
         def _worker() -> None:
-            navigator = self._ensure_navigator()
-            state = navigator.navigate_to_point(
-                target,
-                timeout_s=float(self._runtime_config.goal_reached_timeout_s),
-            )
+            state: TerminalNavigationState = "aborted"
+            try:
+                navigator = self._ensure_navigator()
+                state = navigator.navigate_to_point(
+                    target,
+                    timeout_s=float(self._runtime_config.goal_reached_timeout_s),
+                )
+            finally:
+                self.after(0, self._refresh_stop_button_state)
             if state == "succeeded":
                 self.after(
                     0,
@@ -1148,7 +1156,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 ),
             )
 
-        threading.Thread(target=_worker, daemon=True).start()
+        self._nav2point_thread = threading.Thread(target=_worker, daemon=True)
+        self._nav2point_thread.start()
+        self._refresh_stop_button_state()
 
     @staticmethod
     def _measurement_distance_m(
@@ -3633,6 +3643,14 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             messagebox.showwarning("Fortsetzen", str(exc), parent=self)
 
     def _stop_run(self) -> None:
+        if self._nav2point_thread and self._nav2point_thread.is_alive() and self._executor is None:
+            if self._navigator is None:
+                self._append_validation("⚠️ Stop angefordert, aber kein aktives nav2point-Ziel gefunden.")
+                self._refresh_stop_button_state()
+                return
+            self._navigator.cancel_current_goal()
+            self._append_validation("Stop angefordert: nav2point-Cancel wurde an die Navigation gesendet.")
+            return
         if not self._executor:
             return
         try:
@@ -3651,7 +3669,15 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             manual_measurement_btn.configure(state="disabled" if running else "normal")
         self.pause_btn.configure(state="normal" if running and not paused else "disabled")
         self.resume_btn.configure(state="normal" if running and paused else "disabled")
-        self.stop_btn.configure(state="normal" if running else "disabled")
+        self._refresh_stop_button_state()
+
+    def _refresh_stop_button_state(self) -> None:
+        run_active = bool(self._run_thread is not None and self._run_thread.is_alive())
+        manual_measurement_active = bool(
+            self._manual_measurement_thread is not None and self._manual_measurement_thread.is_alive()
+        )
+        nav2point_active = bool(self._nav2point_thread is not None and self._nav2point_thread.is_alive())
+        self.stop_btn.configure(state="normal" if run_active or manual_measurement_active or nav2point_active else "disabled")
 
     def _on_stage_update(self, stage: str, status: str) -> None:
         if stage == "measurement" and status == "running":


### PR DESCRIPTION
### Motivation
- Operators must be able to abort ad-hoc `nav2point` navigation using the same Stop control used for mission runs so they don't need a separate workflow to cancel a single goal.

### Description
- Track ad-hoc nav2point execution by adding a `_nav2point_thread` attribute and prevent concurrent nav2point starts in `_queue_nav2point`.
- Run `nav2point` in a dedicated thread and ensure the Stop button state is refreshed when the worker finishes by calling `self._refresh_stop_button_state()`.
- Route Stop presses to cancel an active nav2point when no run `executor` is present by calling `navigator.cancel_current_goal()` in `_stop_run`.
- Replace direct `stop_btn` toggles with a new `_refresh_stop_button_state()` which enables `Stop` if a run, manual measurement, or nav2point is active.
- Files changed: `transceiver/mission_workflow_ui.py` and tests updated in `tests/test_mission_workflow_ui.py` (added `test_stop_run_cancels_active_nav2point_goal` and `test_refresh_stop_button_state_enables_stop_while_nav2point_runs`).

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` and the updated test module passed locally with all tests succeeding (`62 passed`).
- Also ran a focused filter with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "nav2point or stop_run_cancels_active_nav2point_goal or refresh_stop_button_state_enables_stop_while_nav2point_runs"` which passed after ensuring `PYTHONPATH` was set (initial collection failed without `PYTHONPATH` but was resolved).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb88616c348321a549281185d999da)