### PR TITLE
Capture live pose and lidar reference after RX measurement

### DIFF
--- a/tests/test_mission_measurement_service.py
+++ b/tests/test_mission_measurement_service.py
@@ -101,9 +101,33 @@ def test_trigger_waits_for_receive_and_runs_review_after_success() -> None:
     elapsed = time.perf_counter() - started
 
     assert elapsed >= 0.045
-    assert status_events == [("measurement", "running"), ("measurement", "succeeded")]
+    assert status_events == [
+        ("measurement", "running"),
+        ("measurement", "measurement_complete"),
+        ("measurement", "succeeded"),
+    ]
     assert timestamps["review_called"] >= timestamps["receive_end"]
     assert payload["file_ref"].endswith(".bin")
+
+
+def test_trigger_runs_lidar_reference_after_receive() -> None:
+    call_order: list[str] = []
+
+    class _OrderedApp:
+        def receive_for_mission(self, *, output_file: str, point_context=None):
+            call_order.append("receive")
+            return {"ok": True, "output_file": output_file}
+
+    service = MissionRxMeasurementService(
+        app=_OrderedApp(),
+        on_status=lambda *_args: None,
+        collect_lidar_reference=lambda _output_file: call_order.append("lidar_reference") or {"topic": "/scan"},
+    )
+
+    payload = service.trigger(_point_context())
+
+    assert call_order == ["receive", "lidar_reference"]
+    assert payload.get("lidar_reference", {}).get("topic") == "/scan"
 
 
 def test_trigger_skips_lidar_reference_when_disabled() -> None:

--- a/transceiver/mission_measurement_service.py
+++ b/transceiver/mission_measurement_service.py
@@ -200,6 +200,26 @@ class MissionRxMeasurementService:
         output_file = mission_dir / filename
         lidar_reference_file = mission_dir / f"{output_file.stem}.lidar.scan.txt"
 
+        try:
+            result = self._app.receive_for_mission(
+                output_file=str(output_file),
+                point_context=point_context,
+            )
+        except Exception as exc:
+            self._on_status("measurement", "failed")
+            if self._on_operator_message is not None:
+                self._on_operator_message(f"RX-Fehler bei Punkt {point_context.global_index}: {exc}")
+            raise RuntimeError("measurement_failed") from exc
+
+        if not result.get("ok"):
+            self._on_status("measurement", "failed")
+            detail = str(result.get("error") or "Receive fehlgeschlagen")
+            if self._on_operator_message is not None:
+                self._on_operator_message(f"RX-Fehler bei Punkt {point_context.global_index}: {detail}")
+            raise RuntimeError("measurement_failed")
+
+        self._on_status("measurement", "measurement_complete")
+
         lidar_reference: dict[str, Any] | None = None
         if self._enable_lidar_reference:
             try:
@@ -225,24 +245,6 @@ class MissionRxMeasurementService:
                         f"LIDAR-Referenzmessung fehlgeschlagen bei Punkt {point_context.global_index}: {exc}"
                     )
                 raise RuntimeError("lidar_reference_failed") from exc
-
-        try:
-            result = self._app.receive_for_mission(
-                output_file=str(output_file),
-                point_context=point_context,
-            )
-        except Exception as exc:
-            self._on_status("measurement", "failed")
-            if self._on_operator_message is not None:
-                self._on_operator_message(f"RX-Fehler bei Punkt {point_context.global_index}: {exc}")
-            raise RuntimeError("measurement_failed") from exc
-
-        if not result.get("ok"):
-            self._on_status("measurement", "failed")
-            detail = str(result.get("error") or "Receive fehlgeschlagen")
-            if self._on_operator_message is not None:
-                self._on_operator_message(f"RX-Fehler bei Punkt {point_context.global_index}: {detail}")
-            raise RuntimeError("measurement_failed")
 
         file_ref = str(result.get("output_file") or output_file)
         review_payload: dict[str, Any] | None = None

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3680,7 +3680,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.stop_btn.configure(state="normal" if run_active or manual_measurement_active or nav2point_active else "disabled")
 
     def _on_stage_update(self, stage: str, status: str) -> None:
-        if stage == "measurement" and status == "running":
+        if stage == "measurement" and status == "measurement_complete":
             self._live_position_at_measurement_start = self._wait_for_valid_live_position_for_measurement_start()
         self.after(0, lambda: self._update_live_label(stage=stage, status=status))
 


### PR DESCRIPTION
### Motivation
- Live robot pose and LIDAR reference must be snapped only after the actual RX measurement because the robot can still oscillate before the capture. 
- Align mission sequencing so the UI records the live position and the reference scan after the RX receive has completed.

### Description
- In `MissionRxMeasurementService.trigger()` the RX capture (`_app.receive_for_mission`) is performed first, then the code emits a new status `("measurement", "measurement_complete")`, and only afterwards the LIDAR reference is collected. 
- The mission UI handler in `MissionWorkflowWindow._on_stage_update()` now snapshots the live pose on the `measurement_complete` stage instead of on `measurement/running` by calling `_wait_for_valid_live_position_for_measurement_start()` at that point. 
- Tests in `tests/test_mission_measurement_service.py` were updated to expect the new status sequence and a new test was added to assert that `collect_lidar_reference` runs after the receive call. 

### Testing
- Running `pytest -q tests/test_mission_measurement_service.py tests/test_mission_workflow_ui.py` without setting `PYTHONPATH` failed during collection with `ModuleNotFoundError: No module named 'transceiver'`. 
- Running `PYTHONPATH=. pytest -q tests/test_mission_measurement_service.py tests/test_mission_workflow_ui.py` succeeded with `71 passed` (all tests in those files passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb8bcf794483219a2224f06a3e9813)