### PR TITLE
Preserve near-LOS shoulder peaks in echo detection

### DIFF
--- a/tests/test_correlation_utils.py
+++ b/tests/test_correlation_utils.py
@@ -55,6 +55,24 @@ def test_local_maxima_keep_visible_echoes_for_lower_secondary_peak() -> None:
     assert maxima == [80, 120]
 
 
+def test_local_maxima_keeps_near_los_shoulder_even_below_rel_height_threshold() -> None:
+    mag = np.zeros(200, dtype=float)
+    mag[100] = 1.0
+    mag[103] = 0.08
+    mag[140] = 0.5
+    cc = mag.astype(np.complex128)
+
+    maxima = find_local_maxima_around_peak(
+        cc,
+        center_idx=100,
+        peaks_before=0,
+        peaks_after=2,
+        min_rel_height=0.1,
+    )
+
+    assert maxima == [100, 103, 140]
+
+
 def test_local_maxima_do_not_include_adjacent_lower_group_when_period_known() -> None:
     n = 1200
     group_a_center = 420

--- a/transceiver/helpers/correlation_utils.py
+++ b/transceiver/helpers/correlation_utils.py
@@ -105,7 +105,12 @@ def filter_echo_indices_by_noise_prominence(
     noise_sigma = 1.4826 * global_mad
 
     filtered: list[int] = []
+    los_mag = float(mag[los_idx_int]) if los_idx_int is not None and 0 <= los_idx_int < mag.size else None
     for idx in cleaned_indices:
+        if los_idx_int is not None and los_mag is not None:
+            los_distance = int(idx) - int(los_idx_int)
+            if 0 < los_distance <= 8 and float(mag[idx]) < 0.08 * los_mag:
+                continue
         prominence = float(mag[idx]) - global_baseline
         if prominence <= 0.0:
             continue
@@ -199,7 +204,15 @@ def find_local_maxima_around_peak_from_mag(
     min_rel_height: float = 0.1,
     repetition_period_samples: int | None = None,
 ) -> list[int]:
-    """Return local maxima indices around a center peak (before + after)."""
+    """Return local maxima indices around a center peak (before + after).
+
+    Notes
+    -----
+    Besides the configured relative-height threshold, we always keep the
+    nearest local maximum on each side of ``center_idx`` (if present). This
+    preserves shoulders directly around the LOS peak and avoids dropping
+    near-LOS candidates when ``min_rel_height`` is strict.
+    """
     if mag.size < 3:
         return []
     if center_idx is None:
@@ -245,21 +258,49 @@ def find_local_maxima_around_peak_from_mag(
                     right_bound = idx
                     break
 
-    local_maxima = [
+    local_maxima_all = [
         i
         for i in range(max(1, left_bound), min(mag.size - 1, right_bound + 1))
         if (
             mag[i] >= mag[i - 1]
             and mag[i] >= mag[i + 1]
             and (mag[i] > mag[i - 1] or mag[i] > mag[i + 1])
-            and mag[i] >= min_height
         )
     ]
-    if not local_maxima:
+    if not local_maxima_all:
         return []
 
+    local_maxima = [
+        i
+        for i in local_maxima_all
+        if mag[i] >= min_height
+    ]
+
+    before_all = [i for i in local_maxima_all if i < center_idx]
+    after_all = [i for i in local_maxima_all if i > center_idx]
     before = [i for i in local_maxima if i < center_idx]
     after = [i for i in local_maxima if i > center_idx]
+
+    nearest_before = before_all[-1] if before_all else None
+    nearest_after = after_all[0] if after_all else None
+    shoulder_max_distance = 8
+    shoulder_min_rel_height = 0.08 * center_mag
+    if (
+        nearest_before is not None
+        and nearest_before not in before
+        and (center_idx - nearest_before) <= shoulder_max_distance
+        and float(mag[nearest_before]) >= shoulder_min_rel_height
+    ):
+        before.append(nearest_before)
+        before.sort()
+    if (
+        nearest_after is not None
+        and nearest_after not in after
+        and (nearest_after - center_idx) <= shoulder_max_distance
+        and float(mag[nearest_after]) >= shoulder_min_rel_height
+    ):
+        after.append(nearest_after)
+        after.sort()
 
     before_count = max(0, int(peaks_before))
     after_count = max(0, int(peaks_after))


### PR DESCRIPTION
### Motivation
- Ensure that small "shoulder" peaks directly adjacent to the LOS peak are not skipped by strict relative-height filtering so near-LOS echoes are detected reliably. 
- Avoid introducing spurious echo markers by limiting shoulder retention to a short neighborhood and requiring a minimum relative amplitude. 
- Reduce false-positive echoes from tiny near-LOS artifacts by extending the noise-based echo filtering logic.

### Description
- Updated `find_local_maxima_around_peak_from_mag` to always consider the nearest local maximum on each side of `center_idx` and keep it even if it falls below `min_rel_height`, with retention constrained by a short distance (`<= 8` samples) and a minimum relative-height threshold (now `0.08 * LOS magnitude`).
- Changed the local maxima collection to first build the full set of local maxima (`local_maxima_all`) and then apply the relative-height filter while still allowing nearest-neighbor shoulders to be added back when they meet the proximity and relative-amplitude checks.
- Extended `filter_echo_indices_by_noise_prominence` to ignore very small candidates that are within 8 samples of the LOS and below ~8% of the LOS magnitude to avoid treating tiny near-LOS artifacts as echoes.
- Added a regression test `test_local_maxima_keeps_near_los_shoulder_even_below_rel_height_threshold` in `tests/test_correlation_utils.py` to cover the shoulder-preservation behavior.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_correlation_utils.py` which executed the correlation-utils tests and resulted in `18 passed`.
- Ran `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py` which aborted during collection in this environment with `TypeError: __mro_entries__ must return a tuple` originating from importing `transceiver/__main__.py`, so that suite could not be completed here.
- All modified unit tests that target the changed behavior passed locally where collected (`tests/test_correlation_utils.py` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb9083ca7883218ea9e78ef8e63d93)