### PR TITLE
Erkenne Echo-Schultern bei der Peak-Gruppierung

### DIFF
--- a/tests/test_correlation_utils.py
+++ b/tests/test_correlation_utils.py
@@ -55,6 +55,23 @@ def test_local_maxima_keep_visible_echoes_for_lower_secondary_peak() -> None:
     assert maxima == [80, 120]
 
 
+def test_local_maxima_treats_shoulder_as_echo_candidate_when_no_clear_peak() -> None:
+    mag = np.zeros(220, dtype=float)
+    mag[100] = 1.0
+    mag[101:150] = np.linspace(0.82, 0.18, 49, dtype=float)
+    cc = mag.astype(np.complex128)
+
+    maxima = find_local_maxima_around_peak(
+        cc,
+        center_idx=100,
+        peaks_before=0,
+        peaks_after=1,
+        min_rel_height=0.1,
+    )
+
+    assert maxima == [100, 101]
+
+
 def test_local_maxima_do_not_include_adjacent_lower_group_when_period_known() -> None:
     n = 1200
     group_a_center = 420

--- a/transceiver/helpers/correlation_utils.py
+++ b/transceiver/helpers/correlation_utils.py
@@ -263,8 +263,27 @@ def find_local_maxima_around_peak_from_mag(
 
     before_count = max(0, int(peaks_before))
     after_count = max(0, int(peaks_after))
-    before_sel = before[-before_count:] if before_count > 0 else []
-    after_sel = after[:after_count] if after_count > 0 else []
+
+    if before_count > 0 and not before:
+        shoulder_idx = center_idx - 1
+        if shoulder_idx >= max(1, left_bound) and mag[shoulder_idx] >= min_height:
+            if shoulder_idx - 2 >= 0:
+                if mag[shoulder_idx] >= mag[shoulder_idx - 1] >= mag[shoulder_idx - 2]:
+                    before.append(int(shoulder_idx))
+            else:
+                before.append(int(shoulder_idx))
+
+    if after_count > 0 and not after:
+        shoulder_idx = center_idx + 1
+        if shoulder_idx <= min(mag.size - 2, right_bound) and mag[shoulder_idx] >= min_height:
+            if shoulder_idx + 2 < mag.size:
+                if mag[shoulder_idx] >= mag[shoulder_idx + 1] >= mag[shoulder_idx + 2]:
+                    after.append(int(shoulder_idx))
+            else:
+                after.append(int(shoulder_idx))
+
+    before_sel = sorted(before)[-before_count:] if before_count > 0 else []
+    after_sel = sorted(after)[:after_count] if after_count > 0 else []
     return before_sel + [center_idx] + after_sel
 
 


### PR DESCRIPTION
### Motivation
- Die Echo-Erkennung soll neben klaren lokalen Maxima auch monotone "Schultern" direkt neben dem LOS-Peak als Echo-Kandidaten berücksichtigen, damit schwächere, aber sichtbare Echo-Schultern nicht verloren gehen.

### Description
- Erweiterung von `find_local_maxima_around_peak_from_mag` in `transceiver/helpers/correlation_utils.py`, so dass wenn auf einer Seite keine klaren lokalen Maxima existieren und `peaks_before`/`peaks_after` > 0, die unmittelbare Nachbarstelle geprüft und bei Mindesthöhe sowie monotonem Verlauf als Schulter-Kandidat aufgenommen wird.
- Auswahl der Vor-/Nach-Partitionen wird danach sortiert und wie vorher auf die angeforderte Anzahl zugeschnitten; die Funktionalität für bekannte Repetitionsperioden bleibt unverändert.
- Neuer Regressionstest `test_local_maxima_treats_shoulder_as_echo_candidate_when_no_clear_peak` wurde zu `tests/test_correlation_utils.py` hinzugefügt, der das Schulter-Verhalten absichert.
- Geänderte Dateien: `transceiver/helpers/correlation_utils.py`, `tests/test_correlation_utils.py`.

### Testing
- `PYTHONPATH=. pytest -q tests/test_correlation_utils.py -k "shoulder or lower_secondary_peak"` wurde ausgeführt und hat bestanden (`2 passed, 16 deselected`).
- `PYTHONPATH=. pytest -q tests/test_correlation_utils.py` wurde ausgeführt und lieferte `17 passed, 1 failed`; der einzelne Fehlschlag ist `test_find_los_echo_from_mag_rejects_non_prominent_echo_in_noise`, der bereits in dieser Testumgebung auffällt und nicht durch die Schulter-Änderung eingeführt wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb8d50f45483219557b1d6e13b90b9)