### PR TITLE
Deselect mission results when clicking empty table space

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -717,6 +717,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         scroll.grid(row=0, column=1, sticky="ns")
         self.results_table.configure(yscrollcommand=scroll.set)
         self.results_table.bind("<<TreeviewSelect>>", self._on_results_table_select)
+        self.results_table.bind("<Button-1>", self._on_results_table_click, add="+")
 
         self._mission_points: list[MeasurementPoint] = []
         self.mission_name_var.trace_add("write", lambda *_args: self._persist_workflow_state())
@@ -1655,6 +1656,21 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         selected_index = self.points_table.index(selected[0])
         self._selected_point_index = selected_index if selected_index >= 0 else None
         self._draw_map_preview()
+
+
+    def _on_results_table_click(self, event: tk.Event) -> str | None:
+        row_id = self.results_table.identify_row(event.y)
+        if row_id:
+            return None
+        region = self.results_table.identify("region", event.x, event.y)
+        if region in {"heading", "separator"}:
+            return None
+        self.results_table.selection_remove(*self.results_table.selection())
+        self.results_table.focus("")
+        self._selected_result_index = None
+        self._selected_result_indices = ()
+        self._draw_map_preview()
+        return "break"
 
     def _on_results_table_select(self, _event: tk.Event) -> None:
         selected = self.results_table.selection()


### PR DESCRIPTION
### Motivation
- Improve UX in the Mission workflow so clicking an empty area of the results table clears any current selection (including multi-selection) and updates map overlays accordingly.
- Prevent accidental leftover selections when users click outside rows or in whitespace inside the results table.

### Description
- Bind a dedicated `<Button-1>` handler to the mission `results_table` to detect clicks that are not on a row. 
- Add `_on_results_table_click` which ignores clicks on rows, headers, and separators, and otherwise calls `selection_remove`, clears focus, resets `_selected_result_index` and `_selected_result_indices`, and triggers `_draw_map_preview()`.
- Leave the existing `<<TreeviewSelect>>` behavior intact so normal row selection and multi-selection continue to work.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py tests/test_mission_workflow_ui_state.py` and the suite succeeded with `73 passed`.
- An initial test run without `PYTHONPATH` failed during collection due to `ModuleNotFoundError`, and the subsequent run with `PYTHONPATH=.` was used to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f87fe7e8d48321b03ace4a2fd23306)