### PR TITLE
Suppress nearby echo candidates in correlation utils

### DIFF
--- a/tests/test_correlation_utils.py
+++ b/tests/test_correlation_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from transceiver.helpers.correlation_utils import (
+    _suppress_nearby_candidates,
     classify_peak_group,
     classify_peak_group_from_mag,
     filter_peak_indices_to_period_group,
@@ -76,6 +77,30 @@ def test_local_maxima_do_not_include_adjacent_lower_group_when_period_known() ->
     assert group_b_center in maxima
     assert all(abs(idx - group_b_center) <= period / 2 for idx in maxima)
     assert all(abs(idx - group_a_center) > period / 2 for idx in maxima)
+
+
+def test_suppress_nearby_candidates_keeps_strongest_per_cluster() -> None:
+    mag = np.zeros(30, dtype=float)
+    mag[10] = 0.6
+    mag[11] = 0.9
+    mag[20] = 0.7
+    mag[22] = 0.8
+
+    kept = _suppress_nearby_candidates([10, 11, 20, 22], mag, min_distance=2)
+
+    assert kept == [11, 22]
+
+
+def test_find_los_echo_from_mag_suppresses_echo_candidates_that_are_too_close() -> None:
+    mag = np.zeros(220, dtype=float)
+    mag[90] = 1.0
+    mag[130] = 0.75
+    mag[132] = 0.72
+
+    los_idx, echo_idx = find_los_echo_from_mag(mag)
+
+    assert los_idx == 90
+    assert echo_idx == 130
 
 
 def test_local_maxima_with_repetition_period_only_scans_center_window() -> None:

--- a/transceiver/helpers/correlation_utils.py
+++ b/transceiver/helpers/correlation_utils.py
@@ -1,6 +1,33 @@
 import numpy as np
 
 
+def _suppress_nearby_candidates(
+    indices: list[int],
+    mag: np.ndarray,
+    min_distance: int,
+) -> list[int]:
+    """Merge nearby candidate peaks and keep only the strongest per cluster."""
+    if not indices:
+        return []
+
+    min_distance = max(0, int(min_distance))
+    sorted_indices = sorted(
+        {int(idx) for idx in indices if 0 <= int(idx) < mag.size}
+    )
+    if not sorted_indices:
+        return []
+
+    clusters: list[list[int]] = [[sorted_indices[0]]]
+    for idx in sorted_indices[1:]:
+        if idx - clusters[-1][-1] <= min_distance:
+            clusters[-1].append(idx)
+        else:
+            clusters.append([idx])
+
+    kept = [int(max(cluster, key=lambda j: float(mag[j]))) for cluster in clusters]
+    return sorted(kept)
+
+
 def _peak_search_bounds(
     mag: np.ndarray,
     *,
@@ -229,6 +256,11 @@ def find_los_echo_from_mag(
         los_idx=los_idx,
         echo_indices=echo_indices,
         repetition_period_samples=repetition_period_samples,
+    )
+    echo_indices = _suppress_nearby_candidates(
+        echo_indices,
+        mag,
+        min_distance=2,
     )
     echo_idx = echo_indices[0] if echo_indices else None
     return los_idx, echo_idx


### PR DESCRIPTION
### Motivation
- Reduce unstable echo selection when multiple candidate peaks are very close together by merging nearby candidates and keeping only the strongest per cluster.

### Description
- Added helper `_suppress_nearby_candidates(indices, mag, min_distance)` to `transceiver/helpers/correlation_utils.py` to cluster nearby candidate indices and retain the candidate with highest magnitude in each cluster.
- Integrated the suppression step into `find_los_echo_from_mag` after `filter_echo_indices_by_noise_prominence` so closely spaced echo candidates no longer produce duplicate/unstable echo picks.
- Added unit tests in `tests/test_correlation_utils.py` for the helper behavior and an integration test that verifies closely spaced echo peaks are suppressed.

### Testing
- Ran `pytest -q tests/test_correlation_utils.py` which initially failed import due to missing `PYTHONPATH` configuration during collection.
- Re-ran with `PYTHONPATH=. pytest -q tests/test_correlation_utils.py` and all tests in that file passed (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f89a9295f8832196c6693c6b366495)