### PR TITLE
Show only ellipse intersections for multi-selected mission results

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -172,7 +172,7 @@ def test_draw_selected_echo_overlay_uses_live_measurement_position() -> None:
     assert calls[0]["measurement_position"] == (7.0, -2.0)
 
 
-def test_draw_selected_echo_overlay_renders_all_selected_results() -> None:
+def test_draw_selected_echo_overlay_renders_intersections_for_multi_selection() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._selected_result_index = 0
     window._selected_result_indices = (0, 1)
@@ -193,13 +193,17 @@ def test_draw_selected_echo_overlay_renders_all_selected_results() -> None:
         MeasurementPoint(id="p0", name="P0", x=50.0, y=50.0, yaw=0.0),
         MeasurementPoint(id="p1", name="P1", x=60.0, y=60.0, yaw=0.0),
     ]
-    calls: list[dict[str, object]] = []
-    window._draw_echo_ellipse_for_overlay = lambda **kwargs: calls.append(kwargs)
+    ellipse_calls: list[dict[str, object]] = []
+    intersection_calls: list[list[list[tuple[float, float]]]] = []
+    window._draw_echo_ellipse_for_overlay = lambda **kwargs: ellipse_calls.append(kwargs)
+    window._build_echo_overlay_preview_points = lambda **kwargs: ([0.0, 0.0, 5.0, 5.0, 0.0, 0.0], 2)
+    window._draw_echo_overlay_intersection_points = lambda ellipses: intersection_calls.append(ellipses)
 
     window._draw_selected_echo_overlay()
 
-    assert len(calls) == 2
-    assert {call["measurement_position"] for call in calls} == {(7.0, -2.0), (8.0, -1.0)}
+    assert len(ellipse_calls) == 0
+    assert len(intersection_calls) == 1
+    assert len(intersection_calls[0]) == 2
 
 
 def test_selected_record_overlay_point_prefers_live_yaw() -> None:
@@ -949,3 +953,16 @@ def test_manual_measurement_point_context_falls_back_to_selected_active_start_po
     assert context is not None
     assert context.point_index == 1
     assert context.point.id == "p2"
+
+
+def test_polyline_intersection_points_finds_crossing() -> None:
+    from transceiver.mission_workflow_ui import _polyline_intersection_points
+
+    first = [(0.0, 0.0), (10.0, 10.0)]
+    second = [(0.0, 10.0), (10.0, 0.0)]
+
+    intersections = _polyline_intersection_points(first, second)
+
+    assert len(intersections) == 1
+    assert intersections[0][0] == 5.0
+    assert intersections[0][1] == 5.0

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -64,6 +64,56 @@ LIVE_ECHO_SAMPLING_REDUCED = (16, 24, 32)
 
 
 
+
+
+def _segment_intersection(
+    p1: tuple[float, float],
+    p2: tuple[float, float],
+    q1: tuple[float, float],
+    q2: tuple[float, float],
+    *,
+    epsilon: float = 1e-9,
+) -> tuple[float, float] | None:
+    r_x = p2[0] - p1[0]
+    r_y = p2[1] - p1[1]
+    s_x = q2[0] - q1[0]
+    s_y = q2[1] - q1[1]
+    denom = r_x * s_y - r_y * s_x
+    if abs(denom) <= epsilon:
+        return None
+    qmp_x = q1[0] - p1[0]
+    qmp_y = q1[1] - p1[1]
+    t = (qmp_x * s_y - qmp_y * s_x) / denom
+    u = (qmp_x * r_y - qmp_y * r_x) / denom
+    if -epsilon <= t <= 1.0 + epsilon and -epsilon <= u <= 1.0 + epsilon:
+        return (p1[0] + t * r_x, p1[1] + t * r_y)
+    return None
+
+
+def _polyline_intersection_points(
+    first: list[tuple[float, float]],
+    second: list[tuple[float, float]],
+    *,
+    min_distance_px: float = 3.0,
+) -> list[tuple[float, float]]:
+    if len(first) < 2 or len(second) < 2:
+        return []
+    min_distance_squared = max(0.5, min_distance_px) ** 2
+    intersections: list[tuple[float, float]] = []
+    for idx in range(len(first) - 1):
+        p1 = first[idx]
+        p2 = first[idx + 1]
+        for jdx in range(len(second) - 1):
+            q1 = second[jdx]
+            q2 = second[jdx + 1]
+            intersection = _segment_intersection(p1, p2, q1, q2)
+            if intersection is None:
+                continue
+            if any((intersection[0]-x)**2 + (intersection[1]-y)**2 <= min_distance_squared for x,y in intersections):
+                continue
+            intersections.append(intersection)
+    return intersections
+
 def _load_json_dict(path: Path) -> dict[str, Any]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -1802,7 +1852,33 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         rx_position = self._rx_antenna_global_position
         if rx_position is None:
             return
-        for record in self._selected_record_payloads():
+        selected_records = self._selected_record_payloads()
+        if len(selected_records) <= 1:
+            for record in selected_records:
+                measurement_position = self._selected_record_measurement_position(record)
+                if measurement_position is None:
+                    continue
+                measurement = record.get("measurement")
+                if not isinstance(measurement, dict):
+                    continue
+                result = measurement.get("result")
+                if not isinstance(result, dict):
+                    continue
+                echo_distances = self._extract_echo_distances(result.get("echo_delays"), limit=len(ECHO_OVERLAY_COLORS))
+                if not echo_distances:
+                    continue
+                for echo_index, echo_distance in enumerate(echo_distances):
+                    color = ECHO_OVERLAY_COLORS[echo_index % len(ECHO_OVERLAY_COLORS)]
+                    self._draw_echo_ellipse_for_overlay(
+                        rx_position=rx_position,
+                        measurement_position=measurement_position,
+                        echo_distance_m=echo_distance,
+                        color=color,
+                    )
+            return
+
+        selected_ellipse_points: list[list[tuple[float, float]]] = []
+        for record in selected_records:
             measurement_position = self._selected_record_measurement_position(record)
             if measurement_position is None:
                 continue
@@ -1812,17 +1888,34 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             result = measurement.get("result")
             if not isinstance(result, dict):
                 continue
-            echo_distances = self._extract_echo_distances(result.get("echo_delays"), limit=len(ECHO_OVERLAY_COLORS))
+            echo_distances = self._extract_echo_distances(result.get("echo_delays"), limit=1)
             if not echo_distances:
                 continue
-            for echo_index, echo_distance in enumerate(echo_distances):
-                color = ECHO_OVERLAY_COLORS[echo_index % len(ECHO_OVERLAY_COLORS)]
-                self._draw_echo_ellipse_for_overlay(
-                    rx_position=rx_position,
-                    measurement_position=measurement_position,
-                    echo_distance_m=echo_distance,
-                    color=color,
-                )
+            preview_points, _ = self._build_echo_overlay_preview_points(
+                rx_position=rx_position,
+                measurement_position=measurement_position,
+                echo_distance_m=echo_distances[0],
+            )
+            if not preview_points or len(preview_points) < 4:
+                continue
+            paired_points = [(preview_points[idx], preview_points[idx + 1]) for idx in range(0, len(preview_points), 2)]
+            selected_ellipse_points.append(paired_points)
+
+        self._draw_echo_overlay_intersection_points(selected_ellipse_points)
+
+
+    def _draw_echo_overlay_intersection_points(self, ellipses: list[list[tuple[float, float]]]) -> None:
+        if len(ellipses) < 2:
+            return
+        canvas = self.map_preview_canvas
+        intersection_points: list[tuple[float, float]] = []
+        for first_idx in range(len(ellipses) - 1):
+            for second_idx in range(first_idx + 1, len(ellipses)):
+                intersection_points.extend(_polyline_intersection_points(ellipses[first_idx], ellipses[second_idx]))
+        if not intersection_points:
+            return
+        for px, py in intersection_points:
+            canvas.create_oval(px - 3, py - 3, px + 3, py + 3, fill="#FFD54F", outline="#3E2723", width=1)
 
     def _draw_live_echo_preview_overlay(self) -> None:
         if not bool(self.live_preview_enabled_var.get()):


### PR DESCRIPTION
### Motivation
- Reduce visual clutter on the map when multiple mission results are selected by showing only the intersection points of the theoretically visible bistatic ellipses instead of drawing all ellipses. 
- Preserve the existing behavior for single-selection so a single selected result still renders its full ellipse overlay.

### Description
- Added geometry helpers `_segment_intersection` and `_polyline_intersection_points` to compute segment/polyline intersections with simple de-duplication of nearby points. 
- Updated `_draw_selected_echo_overlay` to: render full ellipses for single-selected records, and for multi-selection build preview polylines for each ellipse and compute intersection points instead of drawing every ellipse. 
- Added `_draw_echo_overlay_intersection_points` to draw small markers for computed intersection points on the map. 
- Adjusted tests in `tests/test_mission_workflow_ui.py` to verify multi-selection now uses intersection rendering and added `test_polyline_intersection_points_finds_crossing` to validate the intersection math.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "selected_echo_overlay or polyline_intersection_points"`, which passed (`3 passed, 60 deselected`).
- Note: an initial `pytest -q tests/test_mission_workflow_ui.py -k "selected_echo_overlay or polyline_intersection_points"` invocation in this environment failed to collect tests due to `ModuleNotFoundError: No module named 'transceiver'` until `PYTHONPATH=.` was used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f89b1bc7c883218804ba7ae61a4a94)