### PR TITLE
Fix map preview world-coordinate conversion call

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1877,7 +1877,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         max_value = 0.0
         for py in range(0, canvas_height, step_px):
             for px in range(0, canvas_width, step_px):
-                world_pos = self._preview_canvas_to_world(px + (step_px / 2.0), py + (step_px / 2.0))
+                world_pos = self._preview_pixel_to_world(preview_x=px + (step_px / 2.0), preview_y=py + (step_px / 2.0))
                 if world_pos is None:
                     continue
                 world_x, world_y = world_pos


### PR DESCRIPTION
### Motivation
- Fix an `AttributeError` thrown while rendering the multi-selection echo probability overlay by using the correct preview-pixel-to-world conversion helper so preview grid sample points are converted to world coordinates.

### Description
- Replace the non-existent `_preview_canvas_to_world` call with the existing `_preview_pixel_to_world(preview_x=..., preview_y=...)` in `transceiver/mission_workflow_ui.py` (around line 1880).

### Testing
- Ran `python -m py_compile transceiver/mission_workflow_ui.py` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8a47d23a4832191d18aff9e024a92)