### PR TITLE
Fix mission review x-range to keep LOS peak visible

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -471,3 +471,32 @@ def test_review_add_echo_marker_near_lag_ignores_existing_marker() -> None:
     assert dialog._selected_echo_indices == [1]
     assert dialog._base_echo_indices == [1]
     assert dialog._manual_lags["echo"] is None
+
+def test_review_focused_x_range_includes_all_selected_markers() -> None:
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([-250.0, -120.0, -20.0, 10.0, 40.0, 260.0], dtype=float)
+    dialog._selected_los_idx = 1
+    dialog._selected_echo_indices = [5]
+
+    x_range = MissionMeasurementReviewDialog._focused_x_range(dialog)
+
+    assert x_range is not None
+    assert x_range[0] <= -120.0
+    assert x_range[1] >= 260.0
+
+
+def test_review_focused_x_range_keeps_single_marker_visible_with_margin() -> None:
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([-100.0, -50.0, 0.0, 50.0, 100.0], dtype=float)
+    dialog._selected_los_idx = 2
+    dialog._selected_echo_indices = []
+
+    x_range = MissionMeasurementReviewDialog._focused_x_range(dialog)
+
+    assert x_range is not None
+    assert x_range[0] < 0.0
+    assert x_range[1] > 0.0

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1939,12 +1939,26 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
         if not focus_lags:
             return None
 
-        center = float(sum(focus_lags) / len(focus_lags))
         lag_min = float(np.min(self._lags))
         lag_max = float(np.max(self._lags))
-        max_half_window = max(10.0, (lag_max - lag_min) / 2.0)
-        zoom_half_window = float(np.clip(50.0, 10.0, max_half_window))
-        return (center - zoom_half_window, center + zoom_half_window)
+        selected_min = float(min(focus_lags))
+        selected_max = float(max(focus_lags))
+
+        if len(focus_lags) == 1:
+            selected_span = 0.0
+        else:
+            selected_span = selected_max - selected_min
+
+        margin = max(10.0, selected_span * 0.2)
+        range_min = max(lag_min, selected_min - margin)
+        range_max = min(lag_max, selected_max + margin)
+
+        if range_max <= range_min:
+            center = float(focus_lags[0])
+            fallback_half_window = max(10.0, (lag_max - lag_min) * 0.1)
+            range_min = max(lag_min, center - fallback_half_window)
+            range_max = min(lag_max, center + fallback_half_window)
+        return (range_min, range_max)
 
     def _apply_manual_lag(self, kind: str, lag_value: float) -> None:
         if kind not in ("los", "echo"):


### PR DESCRIPTION
### Motivation
- When reviewing mission measurements the LOS peak can lie outside the visible x-range forcing users to manually zoom out, so the focus range should be based on the actually selected LOS/echo markers instead of a fixed window around the center. 
- The change aims to keep selected markers (especially the LOS) visible while respecting available lag bounds and handling edge cases.

### Description
- Replaced the previous center+fixed-half-window logic in `MissionMeasurementReviewDialog._focused_x_range` with computation based on `selected_min`/`selected_max` of the selected LOS/echo lags, adding a dynamic `margin` and clamping to `(lag_min, lag_max)` in `transceiver/__main__.py`.
- Added a fallback half-window for degenerate or zero-width cases to ensure a sane range when clamping would otherwise produce an invalid interval.
- Added two unit tests in `tests/test_crosscorr_normalization.py` that assert the focused x-range includes widely separated LOS/echo markers and that a single selected marker receives a visible margin.

### Testing
- Ran `pytest -q tests/test_crosscorr_normalization.py -k "focused_x_range or review_manual_los_drag or review_manual_echo_click"` which failed during collection with `ModuleNotFoundError: No module named 'transceiver'` in the first environment attempt. 
- Re-ran with `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py -k "focused_x_range or review_manual_los_drag or review_manual_echo_click"` which failed during import/collection due to a Qt-related error: `TypeError: __mro_entries__ must return a tuple`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8a9846ed083219179ce2f4de1a2d2)