### PR TITLE
Add "Navigation erneut versuchen" option for mission navigation failures

### DIFF
--- a/transceiver/measurement_run_executor.py
+++ b/transceiver/measurement_run_executor.py
@@ -133,7 +133,7 @@ class MeasurementRunExecutorConfig:
     reverse_point_order: bool = False
     enable_measurements: bool = True
     confirm_measurement_after_navigation_failure: (
-        Callable[[PointExecutionContext, TerminalNavigationState], bool] | None
+        Callable[[PointExecutionContext, TerminalNavigationState], bool | str] | None
     ) = None
 
 
@@ -383,7 +383,9 @@ class MeasurementRunExecutor:
                 }
             )
 
-        for attempt in range(1, attempts + 1):
+        attempt = 0
+        while attempt < attempts:
+            attempt += 1
             nav_state = self.navigator.navigate_to_point(
                 self._to_navigation_point(
                     point, rotate_heading_by_pi=self.config.reverse_point_order
@@ -415,16 +417,31 @@ class MeasurementRunExecutor:
         if nav_state != "succeeded":
             confirm_measurement = self.config.confirm_measurement_after_navigation_failure
             proceed_with_measurement = False
+            retry_navigation = False
             if (
                 not self._cancel_requested
                 and callable(confirm_measurement)
                 and nav_state is not None
             ):
                 try:
-                    proceed_with_measurement = bool(confirm_measurement(point_context, nav_state))
+                    decision = confirm_measurement(point_context, nav_state)
+                    retry_navigation = isinstance(decision, str) and decision == "retry_navigation"
+                    proceed_with_measurement = bool(decision) and not retry_navigation
                 except Exception:
                     proceed_with_measurement = False
-            if (
+                    retry_navigation = False
+            if not self._cancel_requested and retry_navigation:
+                nav_state = self.navigator.navigate_to_point(
+                    self._to_navigation_point(
+                        point, rotate_heading_by_pi=self.config.reverse_point_order
+                    ),
+                    timeout_s=self.config.goal_reached_timeout_s,
+                    on_navigation_event=_emit_navigation_event,
+                )
+                attempt += 1
+            if nav_state == "succeeded":
+                navigation_done_at = time.time()
+            elif (
                 not self._cancel_requested
                 and proceed_with_measurement
             ):

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3505,23 +3505,29 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         result_payload["detail"] = detail_text
         return result_payload
 
-    def _confirm_measurement_after_navigation_failure(self, point_context, navigation_state: str) -> bool:  # type: ignore[no-untyped-def]
+    def _confirm_measurement_after_navigation_failure(self, point_context, navigation_state: str) -> bool | str:  # type: ignore[no-untyped-def]
         decision_ready = threading.Event()
-        decision = {"continue": False}
+        decision = {"action": "skip"}
 
         def _ask_operator() -> None:
             detail = (
                 f"Navigation zu Punktindex {point_context.global_index} ist fehlgeschlagen "
                 f"({navigation_state}).\n\n"
-                "Soll die Messung an der aktuellen Position trotzdem durchgeführt werden?"
+                "Ja: Messung an aktueller Position durchführen\n"
+                "Nein: Messung überspringen\n"
+                "Abbrechen: Navigation erneut versuchen"
             )
-            decision["continue"] = bool(
-                messagebox.askyesno(
-                    "Navigation fehlgeschlagen",
-                    detail,
-                    parent=self,
-                )
+            response = messagebox.askyesnocancel(
+                "Navigation fehlgeschlagen",
+                detail,
+                parent=self,
             )
+            if response is None:
+                decision["action"] = "retry_navigation"
+            elif response:
+                decision["action"] = "measure"
+            else:
+                decision["action"] = "skip"
             decision_ready.set()
 
         try:
@@ -3529,15 +3535,22 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         except tk.TclError:
             return False
         decision_ready.wait()
-        if decision["continue"]:
+        action = decision["action"]
+        if action == "retry_navigation":
+            self._append_validation(
+                f"⚠️ Navigation zu Punktindex {point_context.global_index} fehlgeschlagen ({navigation_state}); Navigation wird erneut versucht."
+            )
+            return "retry_navigation"
+        if action == "measure":
             self._append_validation(
                 f"⚠️ Navigation zu Punktindex {point_context.global_index} fehlgeschlagen ({navigation_state}); Messung wird trotzdem ausgeführt."
             )
-        else:
-            self._append_validation(
-                f"⚠️ Navigation zu Punktindex {point_context.global_index} fehlgeschlagen ({navigation_state}); Messung wird übersprungen."
-            )
-        return bool(decision["continue"])
+            return True
+
+        self._append_validation(
+            f"⚠️ Navigation zu Punktindex {point_context.global_index} fehlgeschlagen ({navigation_state}); Messung wird übersprungen."
+        )
+        return False
 
     def _get_crosscorr_reference_for_mission(self) -> Any:
         get_reference = getattr(self.master, "_get_crosscorr_reference", None)


### PR DESCRIPTION
### Motivation
- When navigation to a mission point fails the operator needs an explicit option to retry navigation in addition to the existing "measure anyway" or "skip" choices. 
- The run executor must be able to handle a retry decision from the operator and perform one immediate additional navigation attempt before deciding whether to measure or skip.

### Description
- Updated the mission UI failure dialog in `transceiver/mission_workflow_ui.py` so `_confirm_measurement_after_navigation_failure` uses `messagebox.askyesnocancel` and returns `bool | str`, adding a third action `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8ab46a7bc8321bc65de7e4aa9e0de)