### PR TITLE
Persist result-table position and distance in mission run logs

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3148,6 +3148,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             )
 
         def _persist(payload: dict[str, Any]) -> None:
+            self._attach_result_table_snapshot(payload)
             self.after(0, self._on_record, payload)
 
         self._sync_live_pose_stream_state()
@@ -4007,8 +4008,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         )
 
     def _on_record(self, payload: dict[str, Any]) -> None:
-        payload["live_position_at_measurement"] = self._live_position_at_measurement_start
-        self._live_position_at_measurement_start = None
+        self._attach_result_table_snapshot(payload)
         self._records.append(payload)
         meas = payload.get("measurement", {})
         result = meas.get("result", {}) if isinstance(meas.get("result"), dict) else {}
@@ -4037,6 +4037,15 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             ),
         )
         self._update_live_label()
+
+    def _attach_result_table_snapshot(self, payload: dict[str, Any]) -> None:
+        if "live_position_at_measurement" not in payload:
+            payload["live_position_at_measurement"] = self._live_position_at_measurement_start
+            self._live_position_at_measurement_start = None
+        payload["result_table"] = {
+            "position": self._format_live_position_for_table(payload),
+            "abstand": self._format_live_distance_to_rx_for_table(payload),
+        }
 
     @staticmethod
     def _compose_table_outcome(payload: dict[str, Any], error_text: str) -> str:


### PR DESCRIPTION
### Motivation
- The UI displayed the result-table columns `Position` and `Abstand` but those values were not recorded in per-point run logs, causing logs to lack the exact table snapshot shown to the operator.
- Run logs should mirror the UI context so saved point payloads include the same human-readable position/distance values as the results table.

### Description
- Add helper method `_attach_result_table_snapshot(payload: dict[str, Any])` which ensures `live_position_at_measurement` is preserved if present and attaches `result_table.position` and `result_table.abstand` computed from UI formatting helpers.
- Call `_attach_result_table_snapshot` from the run `persist` callback and from `_on_record` so both persisted JSON point-logs and the UI table receive the same snapshot.
- The helper avoids overwriting an existing `live_position_at_measurement` and uses the existing `_format_live_position_for_table` and `_format_live_distance_to_rx_for_table` functions to produce stored strings.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "format_live_position_for_table or format_live_distance_to_rx_for_table"` which returned `2 passed, 63 deselected`.
- An initial collection attempt without `PYTHONPATH` produced `ModuleNotFoundError: No module named 'transceiver'`, so tests were executed with `PYTHONPATH=.` to load the package successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8b371caa8832182fe5b09dcd18416)