### PR TITLE
Add map/RX metadata to run logs and validate mismatches on import

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -128,6 +128,20 @@ def test_format_live_distance_to_rx_for_table_uses_live_position_coordinates() -
     assert distance == "5"
 
 
+def test_current_map_name_prefers_map_config_filename() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._selected_map_config_file = "/tmp/maps/demo_map.yaml"
+    window._selected_map_config = None
+
+    assert window._current_map_name() == "demo_map.yaml"
+
+
+def test_positions_differ_detects_deviation_and_none_values() -> None:
+    assert MissionWorkflowWindow._positions_differ((1.0, 2.0), (1.0, 2.0)) is False
+    assert MissionWorkflowWindow._positions_differ((1.0, 2.0), (1.0, 2.001)) is True
+    assert MissionWorkflowWindow._positions_differ(None, (1.0, 2.0)) is True
+
+
 def test_format_live_distance_to_rx_for_table_returns_dash_without_live_position() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._rx_antenna_global_position = (1.0, 2.0)

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -4042,10 +4042,33 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if "live_position_at_measurement" not in payload:
             payload["live_position_at_measurement"] = self._live_position_at_measurement_start
             self._live_position_at_measurement_start = None
+        payload["map_name"] = self._current_map_name()
+        payload["rx_antenna_global_position"] = self._serialize_rx_antenna_global_position()
         payload["result_table"] = {
             "position": self._format_live_position_for_table(payload),
             "abstand": self._format_live_distance_to_rx_for_table(payload),
         }
+
+    def _current_map_name(self) -> str | None:
+        map_config_file = self._selected_map_config_file
+        if isinstance(map_config_file, str) and map_config_file.strip():
+            return Path(map_config_file).name
+        if self._selected_map_config is None:
+            return None
+        return Path(self._selected_map_config.image).name
+
+    @staticmethod
+    def _positions_differ(
+        left: tuple[float, float] | None,
+        right: tuple[float, float] | None,
+        *,
+        tolerance: float = 1e-6,
+    ) -> bool:
+        if left is None and right is None:
+            return False
+        if left is None or right is None:
+            return True
+        return not (math.isclose(left[0], right[0], abs_tol=tolerance) and math.isclose(left[1], right[1], abs_tol=tolerance))
 
     @staticmethod
     def _compose_table_outcome(payload: dict[str, Any], error_text: str) -> str:
@@ -4297,6 +4320,50 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not imported_records:
             messagebox.showerror("Import", "Keine gültigen Punkt-Logs gefunden.", parent=self)
             return
+
+        imported_map_name = next(
+            (
+                str(payload.get("map_name")).strip()
+                for payload in imported_records
+                if isinstance(payload.get("map_name"), str) and str(payload.get("map_name")).strip()
+            ),
+            "",
+        )
+        current_map_name = self._current_map_name() or ""
+        if imported_map_name and current_map_name and imported_map_name != current_map_name:
+            messagebox.showwarning(
+                "Import",
+                (
+                    "Abweichender Map-Name im Import erkannt.\n"
+                    f"Import: {imported_map_name}\n"
+                    f"Aktuell: {current_map_name}"
+                ),
+                parent=self,
+            )
+
+        imported_rx_position = next(
+            (
+                parsed
+                for payload in imported_records
+                for parsed in [self._parse_rx_antenna_global_position(payload.get("rx_antenna_global_position"))]
+                if parsed is not None
+            ),
+            None,
+        )
+        if self._positions_differ(imported_rx_position, self._rx_antenna_global_position):
+            update_rx_position = messagebox.askyesno(
+                "Import",
+                (
+                    "RX-Position aus Import weicht von der aktuellen Position ab.\n"
+                    "Soll die RX-Position auf den Importwert aktualisiert werden?"
+                ),
+                parent=self,
+            )
+            if update_rx_position and imported_rx_position is not None:
+                self._set_rx_antenna_position(
+                    x=imported_rx_position[0],
+                    y=imported_rx_position[1],
+                )
 
         self.results_table.delete(*self.results_table.get_children())
         self._records = []


### PR DESCRIPTION
### Motivation
- Persist per-point context about which map and RX antenna position produced a run so imports can be cross-checked and operators can be informed of mismatches.
- Prompt the operator to accept RX position updates when imported run data contains a different RX position.

### Description
- Enrich per-point run payloads in `_attach_result_table_snapshot` with `map_name` and `rx_antenna_global_position` before they are persisted. 
- Add helper ` _current_map_name` to derive the active map file name and `_positions_differ` to compare RX positions with a small tolerance. 
- During `_import_logs` inspect imported records and show a warning when the imported `map_name` differs from the currently selected map, and prompt the operator via `messagebox.askyesno` to update the UI RX position when imported RX coordinates differ. 
- Add unit tests `test_current_map_name_prefers_map_config_filename` and `test_positions_differ_detects_deviation_and_none_values` to validate the new helpers.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k 'current_map_name or positions_differ'`, which passed (2 tests).
- Ran the full `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py`, which showed 66 passed and 1 failing GUI-related test (`test_confirm_measurement_after_navigation_failure_uses_point_index_in_prompt`) due to tkinter/messagebox interaction in the headless test environment; behavior unrelated to the new helper logic.
- An initial run without `PYTHONPATH` failed to import the package, so tests were executed with `PYTHONPATH=.` as shown above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8b57fe0c883219889fd5224d74f18)