### PR TITLE
Fix non-clickable Review action in mission workflow results table

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -338,6 +338,20 @@ class _TreeviewSelectionStub:
         self._indices: dict[str, int] = {}
         self._region = "cell"
         self._row_id = ""
+        self._column_id = ""
+        self._columns = (
+            "measurement_idx",
+            "idx",
+            "live_position",
+            "live_distance_to_rx_m",
+            "echo_1_m",
+            "echo_2_m",
+            "echo_3_m",
+            "echo_4_m",
+            "echo_5_m",
+            "review_action",
+            "status",
+        )
 
     def selection(self) -> tuple[str, ...]:
         return self._selected
@@ -348,8 +362,16 @@ class _TreeviewSelectionStub:
     def identify_row(self, _y: int) -> str:
         return self._row_id
 
+    def identify_column(self, _x: int) -> str:
+        return self._column_id
+
     def identify(self, _kind: str, _x: int, _y: int) -> str:
         return self._region
+
+    def cget(self, key: str):
+        if key == "columns":
+            return self._columns
+        return None
 
 
 class _StringVarStub:
@@ -403,6 +425,22 @@ def test_on_results_table_click_on_empty_region_preserves_multiselect() -> None:
     assert window._selected_result_indices == (0, 1)
     assert window._selected_result_index == 0
     assert window.results_selection_diagnostics_var.value == "Auswahl: 2 Zeilen"
+
+
+def test_on_results_table_click_opens_review_in_review_column() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    table = _TreeviewSelectionStub()
+    table._row_id = "row-a"
+    table._column_id = "#10"
+    table._indices = {"row-a": 3}
+    window.results_table = table
+    opened_rows: list[int] = []
+    window._open_review_for_result_row = lambda row_index: opened_rows.append(row_index)
+
+    result = window._on_results_table_click(SimpleNamespace(x=5, y=5))
+
+    assert result == "break"
+    assert opened_rows == [3]
 
 
 def test_parse_lidar_scan_text_for_overlay_supports_inline_ranges() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1681,7 +1681,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         row_id = self.results_table.identify_row(event.y)
         identify_column = getattr(self.results_table, "identify_column", None)
         column_id = identify_column(event.x) if callable(identify_column) else ""
-        if row_id and column_id == "#9":
+        review_column_id = "#10"
+        try:
+            columns = tuple(self.results_table.cget("columns"))
+        except Exception:
+            columns = ()
+        if columns:
+            try:
+                review_column_id = f"#{columns.index('review_action') + 1}"
+            except ValueError:
+                pass
+        if row_id and column_id == review_column_id:
             row_index = self.results_table.index(row_id)
             self._open_review_for_result_row(row_index)
             return "break"


### PR DESCRIPTION
### Motivation
- Clicking the Review cell in the mission workflow results table did not open the review dialog because the click handler relied on a stale hard-coded column id.

### Description
- Compute the `review_action` column id dynamically in `_on_results_table_click` in `transceiver/mission_workflow_ui.py` by reading `self.results_table.cget("columns")` and mapping to the correct `#N` id with a safe fallback.
- Add defensive handling when `columns` or `identify_column` are not available to preserve previous behavior.
- Extend the test Treeview stub in `tests/test_mission_workflow_ui.py` to implement `identify_column` and `cget("columns")` so tests can simulate real Treeview behavior.
- Add a regression test `test_on_results_table_click_opens_review_in_review_column` that verifies a click in the Review column invokes `_open_review_for_result_row`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "results_table_click or results_table_select or results_table_allows_extended_multiselect_mode"` and the targeted tests passed with `4 passed, 64 deselected`.
- Running the same `pytest` command without `PYTHONPATH` in this environment raised a collection error (`ModuleNotFoundError: No module named 'transceiver'`), which is an import-path/environment issue and not caused by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8c9f449708321a023faede4b2a5aa)