### PR TITLE
Fix review action when mission result lacks top-level output_file

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -443,6 +443,58 @@ def test_on_results_table_click_opens_review_in_review_column() -> None:
     assert opened_rows == [3]
 
 
+def test_open_review_for_result_row_uses_file_ref_fallback() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    calls: list[dict[str, str]] = []
+    messages: list[str] = []
+    window._records = [
+        {
+            "global_index": 0,
+            "measurement": {"result": {"file_ref": "signals/rx/mission/run/point-0000.bin"}},
+        }
+    ]
+    window.master = SimpleNamespace(
+        review_measurement_for_mission=lambda **kwargs: calls.append(kwargs)
+    )
+    window._append_validation = messages.append
+
+    window._open_review_for_result_row(0)
+
+    assert calls == [
+        {
+            "point_label": "Punktindex 1",
+            "output_file": "signals/rx/mission/run/point-0000.bin",
+        }
+    ]
+    assert messages == []
+
+
+def test_open_review_for_result_row_uses_rx_output_file_fallback() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    calls: list[dict[str, str]] = []
+    messages: list[str] = []
+    window._records = [
+        {
+            "global_index": 1,
+            "measurement": {"result": {"rx": {"output_file": "signals/rx/mission/run/point-0001.bin"}}},
+        }
+    ]
+    window.master = SimpleNamespace(
+        review_measurement_for_mission=lambda **kwargs: calls.append(kwargs)
+    )
+    window._append_validation = messages.append
+
+    window._open_review_for_result_row(0)
+
+    assert calls == [
+        {
+            "point_label": "Punktindex 2",
+            "output_file": "signals/rx/mission/run/point-0001.bin",
+        }
+    ]
+    assert messages == []
+
+
 def test_parse_lidar_scan_text_for_overlay_supports_inline_ranges() -> None:
     parsed = MissionWorkflowWindow._parse_lidar_scan_text_for_overlay(
         "angle_min: -1.57\nangle_increment: 0.1\nranges: [1.0, 2.5, inf, nan]\n"

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1716,6 +1716,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not isinstance(result_payload, dict):
             return
         output_file = result_payload.get("output_file")
+        if (not isinstance(output_file, str) or not output_file.strip()) and isinstance(result_payload.get("file_ref"), str):
+            output_file = result_payload.get("file_ref")
+        if not isinstance(output_file, str) or not output_file.strip():
+            rx_payload = result_payload.get("rx")
+            if isinstance(rx_payload, dict):
+                output_file = rx_payload.get("output_file")
         if not isinstance(output_file, str) or not output_file.strip():
             self._append_validation("⚠️ Review kann nicht geöffnet werden: output_file fehlt.")
             return


### PR DESCRIPTION
### Motivation
- The mission workflow Review action showed the persistent warning `⚠️ Review kann nicht geöffnet werden: output_file fehlt.` for records whose measurement file path was stored under alternative keys instead of `measurement.result.output_file`.
- The UI must open the review reliably regardless of slight payload shape differences produced by different measurement/serialization code paths.

### Description
- Update `_open_review_for_result_row` in `transceiver/mission_workflow_ui.py` to try fallbacks when `measurement.result.output_file` is missing by checking `measurement.result.file_ref` and then `measurement.result.rx.output_file` before returning the missing-file warning.
- Add two regression tests to `tests/test_mission_workflow_ui.py` that verify the review call uses `file_ref` and `rx.output_file` as fallbacks respectively.
- Keep existing behavior of reporting a validation message when no usable output path is found or when the review function is unavailable.

### Testing
- Ran unit tests for the changed cases with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "open_review_for_result_row or on_results_table_click_opens_review_in_review_column"` and all relevant tests passed (`3 passed`).
- Running the same `pytest` command without setting `PYTHONPATH` initially failed during collection due to `ModuleNotFoundError: No module named 'transceiver'`, which is an environment setup issue and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8cc3176a883218dbf92ab4f0c44b3)