### PR TITLE
Kein Blocking-Wait im Main-Thread bei Mission-Review

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -7415,7 +7415,6 @@ class TransceiverUI(ctk.CTk):
             "reason": REVIEW_REASON_OPERATOR_REJECTED,
             "detail": "Messung wurde vom Operator verworfen.",
         }
-        done = threading.Event()
 
         def _show_review() -> None:
             try:
@@ -7560,11 +7559,13 @@ class TransceiverUI(ctk.CTk):
                 outcome["approved"] = False
                 outcome["reason"] = REVIEW_REASON_REVIEW_EXCEPTION
                 outcome["detail"] = str(exc)
-            finally:
-                done.set()
+
+        if threading.current_thread() is threading.main_thread():
+            _show_review()
+            return outcome
 
         self._ui(_show_review)
-        done.wait()
+        self._call_in_main_thread_sync(lambda: None)
         return outcome
 
     def _reset_rx_buttons(self) -> None:


### PR DESCRIPTION
### Motivation
- Vermeiden, dass `review_measurement_for_mission` im GUI-Main-Thread auf ein `threading.Event` blockierend wartet und dadurch die Oberfläche einfriert.
- Sicherstellen, dass Aufrufe aus Worker-Threads weiterhin asynchron an die GUI dispatchen und modal bleiben.

### Description
- Entfernt das lokale `done = threading.Event()` und das gemeinsame `done.wait()` aus `review_measurement_for_mission` in `transceiver/__main__.py`.
- Fügt einen Main-Thread-Fast-Path hinzu: wenn `threading.current_thread() is threading.main_thread()` wird `_show_review()` direkt ausgeführt und das `outcome` sofort zurückgegeben.
- Beibehaltung des Worker-Thread-Pfads: `self._ui(_show_review)` dispatcht die GUI-Aktion und anschließend wird mit `self._call_in_main_thread_sync(lambda: None)` synchron sichergestellt, dass die GUI-Arbeit abgeschlossen ist.

### Testing
- Ran `python -m pytest -q tests/test_mission_workflow_ui.py` to validate behavior and regressions.
- Test result: 69 passed and 1 failed, where the failing test is `test_confirm_measurement_after_navigation_failure_uses_point_index_in_prompt` and appears unrelated to this change (Tkinter/messagebox test setup issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8d091daf08321a5344bf0bc46ac3c)