### PR TITLE
Prefill mission review dialog from saved LOS/echo points

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -464,6 +464,7 @@ def test_open_review_for_result_row_uses_file_ref_fallback() -> None:
         {
             "point_label": "Punktindex 1",
             "output_file": "signals/rx/mission/run/point-0000.bin",
+            "initial_review": {},
         }
     ]
     assert messages == []
@@ -476,7 +477,14 @@ def test_open_review_for_result_row_uses_rx_output_file_fallback() -> None:
     window._records = [
         {
             "global_index": 1,
-            "measurement": {"result": {"rx": {"output_file": "signals/rx/mission/run/point-0001.bin"}}},
+            "measurement": {
+                "result": {
+                    "rx": {"output_file": "signals/rx/mission/run/point-0001.bin"},
+                    "los_lag": 11,
+                    "echo_lags": [22.2, 35],
+                    "manual_lags": {"los": 11, "echo": 35},
+                }
+            },
         }
     ]
     window.master = SimpleNamespace(
@@ -490,6 +498,7 @@ def test_open_review_for_result_row_uses_rx_output_file_fallback() -> None:
         {
             "point_label": "Punktindex 2",
             "output_file": "signals/rx/mission/run/point-0001.bin",
+            "initial_review": {"los_lag": 11, "echo_lags": [22, 35], "manual_lags": {"los": 11, "echo": 35}},
         }
     ]
     assert messages == []

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -7408,6 +7408,7 @@ class TransceiverUI(ctk.CTk):
         point_label: str,
         output_file: str,
         auto_approve: bool = False,
+        initial_review: dict[str, object] | None = None,
     ) -> dict[str, object]:
         """Open a blocking cross-correlation review dialog for one mission point."""
         outcome: dict[str, object] = {
@@ -7453,6 +7454,20 @@ class TransceiverUI(ctk.CTk):
                 mag = np.asarray(ctx.get("mag", np.array([], dtype=float)))
                 los_idx = ctx.get("los_idx")
                 echo_indices = [int(idx) for idx in list(ctx.get("echo_indices", []))]
+                if isinstance(initial_review, dict) and lags.size:
+                    prefill_los_lag = initial_review.get("los_lag")
+                    if isinstance(prefill_los_lag, (int, float)):
+                        los_idx = int(np.argmin(np.abs(lags - float(prefill_los_lag))))
+                    prefill_echo_lags = initial_review.get("echo_lags")
+                    if isinstance(prefill_echo_lags, list):
+                        prefilled_echo_indices = []
+                        for value in prefill_echo_lags:
+                            if isinstance(value, (int, float)):
+                                prefilled_echo_indices.append(
+                                    int(np.argmin(np.abs(lags - float(value))))
+                                )
+                        if prefilled_echo_indices:
+                            echo_indices = prefilled_echo_indices
                 if lags.size == 0 or mag.size == 0 or los_idx is None:
                     detail = "Crosscorrelation enthält keine auswertbaren Peaks (LOS fehlt)."
                     messagebox.showerror("Mission Review", detail)

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1730,10 +1730,37 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._append_validation("⚠️ Review kann nicht geöffnet werden: Review-Funktion nicht verfügbar.")
             return
         point_label = f"Punktindex {self._format_one_based_index(record.get('global_index'))}"
+        review_prefill = self._build_review_prefill_from_result(result_payload)
         try:
-            review_fn(point_label=point_label, output_file=output_file)
+            review_fn(
+                point_label=point_label,
+                output_file=output_file,
+                initial_review=review_prefill,
+            )
         except Exception as exc:
             self._append_validation(f"⚠️ Review konnte nicht geöffnet werden: {exc}")
+
+    @staticmethod
+    def _build_review_prefill_from_result(result_payload: dict[str, Any]) -> dict[str, Any]:
+        prefill: dict[str, Any] = {}
+        los_lag = result_payload.get("los_lag")
+        if isinstance(los_lag, (int, float)):
+            prefill["los_lag"] = int(round(float(los_lag)))
+        echo_lags = result_payload.get("echo_lags")
+        if isinstance(echo_lags, (list, tuple)):
+            parsed_echo_lags = [int(round(float(value))) for value in echo_lags if isinstance(value, (int, float))]
+            if parsed_echo_lags:
+                prefill["echo_lags"] = parsed_echo_lags
+        manual_lags = result_payload.get("manual_lags")
+        if isinstance(manual_lags, dict):
+            parsed_manual: dict[str, int] = {}
+            for key in ("los", "echo"):
+                value = manual_lags.get(key)
+                if isinstance(value, (int, float)):
+                    parsed_manual[key] = int(round(float(value)))
+            if parsed_manual:
+                prefill["manual_lags"] = parsed_manual
+        return prefill
 
     def _on_results_table_select(self, _event: tk.Event) -> None:
         selected = self.results_table.selection()


### PR DESCRIPTION
### Motivation
- Beim Öffnen des Review-Dialogs aus einer Ergebniszeile sollen bereits gespeicherte LOS-/Echo-Punkte sichtbar und editierbar sein, statt dass ausschließlich eine Neudetektion (Auto-Detect) verwendet wird. 
- Das Ziel ist, gespeicherte `los_lag`/`echo_lags`/`manual_lags` aus dem Ergebnispayload in den Review-Dialog vorzubefüllen, damit Änderungen möglich sind und der Nutzer speichern oder ohne Speichern schließen kann.

### Description
- `MissionWorkflowWindow._open_review_for_result_row` wurde geändert, um ein `initial_review`-Dict zu bauen und an `review_measurement_for_mission` weiterzureichen.  
- Neue Hilfsfunktion `MissionWorkflowWindow._build_review_prefill_from_result` extrahiert und normalisiert `los_lag`, `echo_lags` und `manual_lags` aus dem Result-Payload (Rundung und Typprüfung).  
- `review_measurement_for_mission` in `transceiver/__main__.py` akzeptiert nun optional `initial_review` und mappt bei Vorhandensein die übergebenen Lags auf die nächstgelegenen Lag-Indizes (`lags`) im aktuellen Crosscorr-Context, sodass der Dialog mit bereits selektierten Peaks startet.  
- Tests in `tests/test_mission_workflow_ui.py` wurden aktualisiert, um zu überprüfen, dass `initial_review` korrekt weitergereicht und normalisiert wird (inkl. Rundung von Fließkommawerten).  

### Testing
- Einzelne UI-Tests wurden lokal ausgeführt mit `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "open_review_for_result_row"` und ergaben `2 passed, 68 deselected`.
- Ein initialer `pytest`-Aufruf ohne `PYTHONPATH` schlug wegen Importkonfiguration fehl (`ModuleNotFoundError: No module named 'transceiver'`), was durch Setzen von `PYTHONPATH=.` behoben wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8cfe3278083219e5c432796c954c5)