### PR TITLE
Fix manual echo drag slot resolution in review dialog

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -324,6 +324,52 @@ def test_review_manual_echo_click_updates_first_echo_distance() -> None:
     assert delays == [10, 30]
 
 
+
+
+def test_review_manual_echo_click_updates_nearest_echo_slot_not_always_first() -> None:
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0, 40.0], dtype=float)
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._selected_los_idx = 0
+    dialog._selected_echo_indices = [1, 3, 4]
+    dialog._base_echo_indices = [1, 3, 4]
+    dialog._render_plot = lambda: None
+    dialog._plot = None
+
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    MissionMeasurementReviewDialog._apply_manual_lag(dialog, "echo", 32.0)
+
+    assert dialog._selected_echo_indices == [1, 2, 4]
+    assert dialog._base_echo_indices == [1, 2, 4]
+    delays = MissionMeasurementReviewDialog.echo_delays.fget(dialog)
+    assert delays == [10, 20, 40]
+
+
+def test_review_manual_echo_preview_updates_nearest_echo_slot_and_base_indices() -> None:
+    dialog = types.SimpleNamespace()
+    dialog._lags = np.array([0.0, 10.0, 20.0, 30.0, 40.0], dtype=float)
+    dialog._manual_lags = {"los": None, "echo": None}
+    dialog._selected_los_idx = 0
+    dialog._selected_echo_indices = [1, 3, 4]
+    dialog._base_echo_indices = [1, 3, 4]
+    dialog._update_peak_label_positions = lambda: None
+    dialog._update_stats_label = lambda: None
+    dialog._plot = None
+
+    from transceiver.__main__ import MissionMeasurementReviewDialog
+
+    MissionMeasurementReviewDialog._preview_manual_lag(dialog, "echo", 39.0)
+
+    assert dialog._selected_echo_indices == [1, 3, 4]
+    assert dialog._base_echo_indices == [1, 3, 4]
+    MissionMeasurementReviewDialog._preview_manual_lag(dialog, "echo", 29.0)
+    assert dialog._selected_echo_indices == [1, 3, 4]
+    assert dialog._base_echo_indices == [1, 3, 4]
+    MissionMeasurementReviewDialog._preview_manual_lag(dialog, "echo", 19.0)
+    assert dialog._selected_echo_indices == [1, 2, 4]
+    assert dialog._base_echo_indices == [1, 2, 4]
+
 def test_review_drag_preview_updates_echo_distances_live() -> None:
     dialog = types.SimpleNamespace()
     dialog._lags = np.array([0.0, 10.0, 20.0, 30.0], dtype=float)

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1988,6 +1988,36 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             range_max = min(lag_max, center + fallback_half_window)
         return (range_min, range_max)
 
+    def _resolve_echo_marker_slot_for_lag(self, target_lag: float) -> int | None:
+        if not self._selected_echo_indices:
+            return None
+
+        max_lag_distance = 25.0
+        plot = getattr(self, "_plot", None)
+        view_box = plot.getViewBox() if plot is not None else None
+        if view_box is not None:
+            view_range = view_box.viewRange()
+            visible_x = view_range[0]
+            visible_width = max(0.0, float(visible_x[1]) - float(visible_x[0]))
+            max_lag_distance = float(np.clip(visible_width * 0.02, 2.0, 25.0))
+
+        marker_slot = _find_echo_marker_slot_near_lag(
+            self._lags,
+            self._selected_echo_indices,
+            float(target_lag),
+            max_lag_distance=max_lag_distance,
+        )
+        if marker_slot is not None:
+            return int(marker_slot)
+
+        nearest_slot = int(
+            min(
+                range(len(self._selected_echo_indices)),
+                key=lambda slot: abs(float(self._lags[int(self._selected_echo_indices[slot])]) - float(target_lag)),
+            )
+        )
+        return nearest_slot
+
     def _apply_manual_lag(self, kind: str, lag_value: float) -> None:
         if kind not in ("los", "echo"):
             return
@@ -2001,10 +2031,13 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             return
 
         if self._selected_echo_indices:
+            marker_slot = MissionMeasurementReviewDialog._resolve_echo_marker_slot_for_lag(self, float(lag_value))
+            if marker_slot is None:
+                return
             self._selected_echo_indices = _update_echo_indices_after_manual_drag(
                 self._lags,
                 self._selected_echo_indices,
-                0,
+                int(marker_slot),
                 float(lag_value),
             )
             self._base_echo_indices = [int(idx) for idx in self._selected_echo_indices]
@@ -2024,12 +2057,16 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
             return
 
         if self._selected_echo_indices:
+            marker_slot = MissionMeasurementReviewDialog._resolve_echo_marker_slot_for_lag(self, float(lag_value))
+            if marker_slot is None:
+                return
             self._selected_echo_indices = _update_echo_indices_after_manual_drag(
                 self._lags,
                 self._selected_echo_indices,
-                0,
+                int(marker_slot),
                 float(lag_value),
             )
+            self._base_echo_indices = [int(idx) for idx in self._selected_echo_indices]
             self._update_peak_label_positions()
             self._update_stats_label()
 


### PR DESCRIPTION
### Motivation
- Manuelle Echo-Verschiebungen im Review-Dialog haben bisher pauschal `marker_slot=0` verwendet, wodurch Verschiebungen späterer Echo-Marker falsch in `selected_echo_indices` landeten.
- `_base_echo_indices` wurde beim Preview nicht konsistent mit `selected_echo_indices` aktualisiert, so dass Confirm nicht die tatsächlich sichtbare Marker-Lage persistierte.
- Es sollte stattdessen die bestehende Nähe-Logik verwendet und ein definierter Fallback genutzt werden, statt blind Slot `0` zu wählen.

### Description
- Ergänzt `MissionMeasurementReviewDialog._resolve_echo_marker_slot_for_lag` welches zuerst `_find_echo_marker_slot_near_lag` mit dem sichtbarkeits-skalierten Threshold nutzt und falls nötig auf den lag-nächsten Marker fällt backt.
- Geändert `MissionMeasurementReviewDialog._apply_manual_lag` und `_preview_manual_lag` so dass sie das neue Resolver-API aufrufen und nicht mehr hart `0` als `marker_slot` verwenden.
- Sorgt dafür, dass `_base_echo_indices` zusammen mit `_selected_echo_indices` auch im Preview-Pfad aktualisiert wird, damit Confirm die sichtbare Lage speichert.
- Fügt zwei dialog-nahe Regressionstests in `tests/test_crosscorr_normalization.py` hinzu, die Verschiebungen späterer Echo-Marker und Preview-Verhalten prüfen (`selected_echo_indices`, `echo_delays` und `_base_echo_indices`).

### Testing
- Versucht `PYTHONPATH=. pytest -q tests/test_crosscorr_normalization.py -k 'manual_echo_click_updates_nearest_echo_slot_not_always_first or manual_echo_preview_updates_nearest_echo_slot_and_base_indices or review_manual_echo_click_updates_first_echo_distance'` wurde ausgeführt but test collection failed with an import-related error; initial run failed with `ModuleNotFoundError` and the subsequent run (with `PYTHONPATH=.`) failed during collection with `TypeError: __mro_entries__ must return a tuple` from `transceiver.__main__`.
- Die Änderungen sind committed and the new tests are present, but automated test collection fails in this environment and needs CI/run-environment investigation to proceed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8d5174a148321baabdb6c08b8d279)