### PR TITLE
Persist approved manual mission review results into results table

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -504,6 +504,59 @@ def test_open_review_for_result_row_uses_rx_output_file_fallback() -> None:
     assert messages == []
 
 
+def test_open_review_for_result_row_persists_manual_review_result_to_table() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    messages: list[str] = []
+    window._records = [
+        {
+            "global_index": 0,
+            "measurement": {
+                "result": {
+                    "output_file": "signals/rx/mission/run/point-0000.bin",
+                    "echo_delays": [{"distance_m": 11.0}],
+                }
+            },
+        }
+    ]
+
+    class _RowTable:
+        def __init__(self) -> None:
+            self.values = ("1", "1", "-", "-", "11", "-", "-", "-", "-", "succeeded")
+
+        def get_children(self):
+            return ("row-0",)
+
+        def item(self, row_id, option=None, **kwargs):
+            assert row_id == "row-0"
+            if kwargs and "values" in kwargs:
+                self.values = kwargs["values"]
+                return None
+            if option == "values":
+                return self.values
+            return {"values": self.values}
+
+    window.results_table = _RowTable()
+    window._append_validation = messages.append
+    window._draw_map_preview = lambda: None
+    window.master = SimpleNamespace(
+        review_measurement_for_mission=lambda **_kwargs: {
+            "approved": True,
+            "echo_delays": [{"distance_m": 77.0}],
+            "echo_lags": [123],
+            "los_lag": 100,
+        }
+    )
+
+    window._open_review_for_result_row(0)
+
+    result_payload = window._records[0]["measurement"]["result"]
+    assert result_payload["echo_lags"] == [123]
+    assert result_payload["los_lag"] == 100
+    assert result_payload["echo_delays"] == [{"distance_m": 77.0}]
+    assert window.results_table.values[4] == "77"
+    assert messages == []
+
+
 def test_parse_lidar_scan_text_for_overlay_supports_inline_ranges() -> None:
     parsed = MissionWorkflowWindow._parse_lidar_scan_text_for_overlay(
         "angle_min: -1.57\nangle_increment: 0.1\nranges: [1.0, 2.5, inf, nan]\n"

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1732,13 +1732,41 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         point_label = f"Punktindex {self._format_one_based_index(record.get('global_index'))}"
         review_prefill = self._build_review_prefill_from_result(result_payload)
         try:
-            review_fn(
+            review_result = review_fn(
                 point_label=point_label,
                 output_file=output_file,
                 initial_review=review_prefill,
             )
+            if isinstance(review_result, dict) and bool(review_result.get("approved")):
+                self._apply_manual_review_result(row_index=row_index, result_payload=result_payload, review_result=review_result)
         except Exception as exc:
             self._append_validation(f"⚠️ Review konnte nicht geöffnet werden: {exc}")
+
+    def _apply_manual_review_result(
+        self,
+        *,
+        row_index: int,
+        result_payload: dict[str, Any],
+        review_result: dict[str, Any],
+    ) -> None:
+        for key in ("manual_lags", "los_idx", "echo_indices", "los_lag", "echo_lags"):
+            if key in review_result:
+                result_payload[key] = review_result.get(key)
+        if "echo_delays" in review_result:
+            result_payload["echo_delays"] = review_result.get("echo_delays")
+
+        row_ids = self.results_table.get_children()
+        if row_index < 0 or row_index >= len(row_ids):
+            return
+        row_id = row_ids[row_index]
+        current_values = list(self.results_table.item(row_id, "values"))
+        if len(current_values) < 10:
+            return
+        echo_distances = self._format_echo_distances_for_table(result_payload.get("echo_delays"))
+        for idx, value in enumerate(echo_distances):
+            current_values[4 + idx] = value
+        self.results_table.item(row_id, values=tuple(current_values))
+        self._draw_map_preview()
 
     @staticmethod
     def _build_review_prefill_from_result(result_payload: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
### Motivation
- The mission review dialog produced an approved manual review payload but the UI ignored the returned result and left the stored measurement payload and results table showing the original auto-detect values.
- Users expect that confirming edits in the review dialog updates both the stored measurement record and the visible table row immediately so manual corrections are reflected in the run log.

### Description
- Capture the `review_measurement_for_mission(...)` return value in `_open_review_for_result_row` and, when `approved`, apply it by calling a new `_apply_manual_review_result` helper.
- Implement `_apply_manual_review_result` to persist keys (`manual_lags`, `los_idx`, `echo_indices`, `los_lag`, `echo_lags`, `echo_delays`) into the `result_payload` and update the corresponding results-table row's echo columns, then redraw the map preview.
- Add a regression test `test_open_review_for_result_row_persists_manual_review_result_to_table` in `tests/test_mission_workflow_ui.py` that verifies the payload is updated and the table cell for the echo distance is changed to the reviewed value.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py::test_open_review_for_result_row_persists_manual_review_result_to_table tests/test_mission_workflow_ui.py::test_open_review_for_result_row_uses_rx_output_file_fallback` and both tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8d4512f448321989813dcbb005e5d)