### PR TITLE
Apply approved review outcomes to measurement result and refresh UI

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1008,6 +1008,97 @@ def test_review_measurement_auto_approves_when_manual_review_disabled() -> None:
     }
 
 
+def test_open_review_for_result_row_applies_approved_review_and_persists() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._records = [
+        {
+            "global_index": 0,
+            "point_index": 0,
+            "error": "",
+            "measurement": {
+                "status": "succeeded",
+                "result": {
+                    "output_file": "dummy.bin",
+                    "echo_delays": [{"distance_m": 3.0}],
+                    "review": {},
+                },
+            },
+        }
+    ]
+    calls: list[str] = []
+    window._append_validation = lambda _msg: calls.append("validation")
+    window._persist_workflow_state = lambda: calls.append("persist")
+    window._update_results_selection_diagnostics = lambda: calls.append("refresh")
+    window._draw_map_preview = lambda: calls.append("draw")
+    window._format_live_position_for_table = lambda _payload: "-"
+    window._format_live_distance_to_rx_for_table = lambda _payload: "-"
+
+    class _DummyResultsTable:
+        def get_children(self):  # type: ignore[no-untyped-def]
+            return ("item-0",)
+
+        def item(self, _item_id, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(f"item:{len(kwargs.get('values', ())) }")
+
+    window.results_table = _DummyResultsTable()
+    window.master = SimpleNamespace(
+        review_measurement_for_mission=lambda **_kwargs: {
+            "approved": True,
+            "manual_lags": {"los": 11, "echo": 22},
+            "los_idx": 7,
+            "echo_indices": [4, 5],
+            "los_lag": 11,
+            "echo_lags": [22, 33],
+            "echo_delays": [{"echo_index": 1, "delta_lag": 22, "distance_m": 7.5}],
+        }
+    )
+
+    window._open_review_for_result_row(0)
+
+    result = window._records[0]["measurement"]["result"]
+    assert result["manual_lags"] == {"los": 11, "echo": 22}
+    assert result["los_idx"] == 7
+    assert result["echo_indices"] == [4, 5]
+    assert result["los_lag"] == 11
+    assert result["echo_lags"] == [22, 33]
+    assert result["echo_delays"] == [{"echo_index": 1, "delta_lag": 22, "distance_m": 7.5}]
+    assert result["review"]["echo_delays"] == result["echo_delays"]
+    assert "persist" in calls
+    assert "refresh" in calls
+    assert "draw" in calls
+
+
+def test_open_review_for_result_row_does_not_apply_unapproved_review() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._records = [
+        {
+            "global_index": 0,
+            "point_index": 0,
+            "measurement": {
+                "status": "succeeded",
+                "result": {
+                    "output_file": "dummy.bin",
+                    "echo_delays": [{"distance_m": 3.0}],
+                },
+            },
+        }
+    ]
+    messages: list[str] = []
+    window._append_validation = messages.append
+    window._persist_workflow_state = lambda: messages.append("persist")
+    window._update_results_selection_diagnostics = lambda: messages.append("refresh")
+    window._draw_map_preview = lambda: messages.append("draw")
+    window.results_table = SimpleNamespace(get_children=lambda: ())
+    window.master = SimpleNamespace(review_measurement_for_mission=lambda **_kwargs: {"approved": False})
+
+    window._open_review_for_result_row(0)
+
+    result = window._records[0]["measurement"]["result"]
+    assert result["echo_delays"] == [{"distance_m": 3.0}]
+    assert "persist" not in messages
+    assert any("nicht freigegeben" in message for message in messages)
+
+
 def test_confirm_measurement_after_navigation_failure_uses_point_index_in_prompt(monkeypatch) -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     messages: list[str] = []

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1732,13 +1732,50 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         point_label = f"Punktindex {self._format_one_based_index(record.get('global_index'))}"
         review_prefill = self._build_review_prefill_from_result(result_payload)
         try:
-            review_fn(
+            review_outcome = review_fn(
                 point_label=point_label,
                 output_file=output_file,
                 initial_review=review_prefill,
             )
         except Exception as exc:
             self._append_validation(f"⚠️ Review konnte nicht geöffnet werden: {exc}")
+            return
+        if not isinstance(review_outcome, dict):
+            return
+        if not bool(review_outcome.get("approved")):
+            self._append_validation("ℹ️ Review nicht freigegeben; Messresultat bleibt unverändert.")
+            return
+
+        for key in ("manual_lags", "los_idx", "echo_indices", "los_lag", "echo_lags", "echo_delays"):
+            if key in review_outcome:
+                result_payload[key] = review_outcome.get(key)
+
+        review_payload = result_payload.get("review")
+        if not isinstance(review_payload, dict):
+            review_payload = {}
+            result_payload["review"] = review_payload
+        for key in ("manual_lags", "los_idx", "echo_indices", "los_lag", "echo_lags", "echo_delays"):
+            if key in review_outcome:
+                review_payload[key] = review_outcome.get(key)
+
+        self._persist_workflow_state()
+        if 0 <= row_index < len(self.results_table.get_children()):
+            error_text = record.get("error") or ""
+            combined_status = self._compose_table_outcome(record, error_text)
+            self.results_table.item(
+                self.results_table.get_children()[row_index],
+                values=(
+                    self._format_one_based_index(record.get("global_index")),
+                    self._format_one_based_index(record.get("point_index")),
+                    self._format_live_position_for_table(record),
+                    self._format_live_distance_to_rx_for_table(record),
+                    *self._format_echo_distances_for_table(result_payload.get("echo_delays")),
+                    "Review",
+                    combined_status,
+                ),
+            )
+        self._update_results_selection_diagnostics()
+        self._draw_map_preview()
 
     @staticmethod
     def _build_review_prefill_from_result(result_payload: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
### Motivation
- Beim Öffnen einer Mess-Review sollen vom Review-Dialog bestätigte Änderungen in das gespeicherte Messresultat übernommen werden, damit manuelle Echo-/Lag-Korrekturen sofort sichtbar und persistent sind.
- Änderungen dürfen nur bei bestätigtem Review überschrieben werden; abgelehnte Reviews sollen das Resultat unangetastet lassen und eine kurze Statusmeldung liefern.
- Nach Übernahme muss der Workflow-Status persistiert und die Anzeige (Tabelle / Map-Preview / Overlay) aktualisiert werden, damit die neuen Echo-Werte direkt sichtbar sind.

### Description
- `_open_review_for_result_row` speichert jetzt den Rückgabewert von `review_fn(...)` in `review_outcome` und verarbeitet diesen weiter.  
- Wenn `review_outcome` ein `dict` ist und `approved == True`, werden die Felder `manual_lags`, `los_idx`, `echo_indices`, `los_lag`, `echo_lags`, `echo_delays` in `measurement.result` zurückgeschrieben.  
- Dieselben Felder werden zusätzlich in `measurement.result['review']` gespiegelt, falls `review` noch nicht vorhanden war, um die bestehende Result-/Review-Struktur beizubehalten.  
- Nach dem Update wird `self._persist_workflow_state()` aufgerufen und die entsprechende Tabellenzeile via `results_table.item(...)` neu gesetzt; anschließend werden `self._update_results_selection_diagnostics()` und `self._draw_map_preview()` ausgeführt, damit UI und Overlay aktualisiert werden.  
- Bei `approved == False` werden keine Felder überschrieben und eine kurze Info-Validation (`_append_validation`) ausgegeben.  
- Regressionstests ergänzt: `test_open_review_for_result_row_applies_approved_review_and_persists` und `test_open_review_for_result_row_does_not_apply_unapproved_review` in `tests/test_mission_workflow_ui.py`.

### Testing
- `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "open_review_for_result_row or review_measurement_auto_approves"` ausgeführt und die gezielten Tests liefen grün: `5 passed, 67 deselected`.
- Ein initialer `pytest`-Lauf ohne `PYTHONPATH=.` schlug in dieser Umgebung mit `ModuleNotFoundError: No module named 'transceiver'` fehl; das ist eine Umgebungs-/Import-Eigenheit und nicht auf die Änderungen im Code zurückzuführen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8d899a1188321b64df6ed0247876f)