### PR TITLE
Normalize mission re-review echo delays before UI updates

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1008,6 +1008,99 @@ def test_review_measurement_auto_approves_when_manual_review_disabled() -> None:
     }
 
 
+def test_open_review_for_result_row_normalizes_review_echo_delays_for_table_and_payload() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._records = [
+        {
+            "global_index": 0,
+            "point_index": 0,
+            "error": "",
+            "measurement": {
+                "status": "succeeded",
+                "result": {
+                    "output_file": "dummy.bin",
+                    "echo_delays": [{"distance_m": 3.0}],
+                    "review": {},
+                },
+            },
+        }
+    ]
+    calls: list[str] = []
+    observed_values: list[object] = []
+    window._append_validation = lambda _msg: calls.append("validation")
+    window._persist_workflow_state = lambda: calls.append("persist")
+    window._update_results_selection_diagnostics = lambda: calls.append("refresh")
+    window._draw_map_preview = lambda: calls.append("draw")
+    window._format_live_position_for_table = lambda _payload: "-"
+    window._format_live_distance_to_rx_for_table = lambda _payload: "-"
+
+    class _DummyResultsTable:
+        def get_children(self):  # type: ignore[no-untyped-def]
+            return ("item-0",)
+
+        def item(self, _item_id, **kwargs):  # type: ignore[no-untyped-def]
+            values = kwargs.get("values", ())
+            observed_values.append(values)
+            calls.append(f"item:{len(values)}")
+
+    window.results_table = _DummyResultsTable()
+    window.master = SimpleNamespace(
+        review_measurement_for_mission=lambda **_kwargs: {
+            "approved": True,
+            "los_lag": 10,
+            "echo_indices": [3],
+            "echo_lags": [22],
+            "echo_delays": [12],
+        }
+    )
+
+    window._open_review_for_result_row(0)
+
+    result = window._records[0]["measurement"]["result"]
+    assert result["echo_delays"] == [{"echo_index": 3, "delta_lag": 12.0, "distance_m": 18.0}]
+    assert result["review"]["echo_delays"] == result["echo_delays"]
+    assert observed_values
+    assert observed_values[0][4] == "18"
+    assert "persist" in calls
+
+
+def test_open_review_for_result_row_derives_echo_delays_from_echo_lags() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._records = [
+        {
+            "global_index": 0,
+            "point_index": 0,
+            "error": "",
+            "measurement": {
+                "status": "succeeded",
+                "result": {
+                    "output_file": "dummy.bin",
+                    "review": {},
+                },
+            },
+        }
+    ]
+    window._append_validation = lambda _msg: None
+    window._persist_workflow_state = lambda: None
+    window._update_results_selection_diagnostics = lambda: None
+    window._draw_map_preview = lambda: None
+    window._format_live_position_for_table = lambda _payload: "-"
+    window._format_live_distance_to_rx_for_table = lambda _payload: "-"
+    window.results_table = SimpleNamespace(get_children=lambda: (), item=lambda *_args, **_kwargs: None)
+    window.master = SimpleNamespace(
+        review_measurement_for_mission=lambda **_kwargs: {
+            "approved": True,
+            "los_lag": 10,
+            "echo_lags": [25],
+        }
+    )
+
+    window._open_review_for_result_row(0)
+
+    result = window._records[0]["measurement"]["result"]
+    assert result["echo_delays"] == [{"echo_index": 0, "delta_lag": 15.0, "distance_m": 22.5}]
+
+
 def test_open_review_for_result_row_applies_approved_review_and_persists() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._records = [

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -29,6 +29,7 @@ from .measurement_run_executor import (
 )
 from .mission_measurement_service import (
     MissionRxMeasurementService,
+    _coerce_echo_delay_entries,
     REVIEW_REASON_OPERATOR_REJECTED,
     REVIEW_REASON_REVIEW_EXCEPTION,
     REVIEW_REASON_REVIEW_UNAVAILABLE,
@@ -1746,6 +1747,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._append_validation("ℹ️ Review nicht freigegeben; Messresultat bleibt unverändert.")
             return
 
+        normalized_echo_delays = self._normalize_review_echo_delays(review_outcome)
+        if normalized_echo_delays:
+            review_outcome["echo_delays"] = normalized_echo_delays
+
         for key in ("manual_lags", "los_idx", "echo_indices", "los_lag", "echo_lags", "echo_delays"):
             if key in review_outcome:
                 result_payload[key] = review_outcome.get(key)
@@ -1776,6 +1781,19 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             )
         self._update_results_selection_diagnostics()
         self._draw_map_preview()
+
+    @staticmethod
+    def _normalize_review_echo_delays(review_outcome: dict[str, Any]) -> list[dict[str, Any]]:
+        raw_echo_delays = review_outcome.get("echo_delays")
+        has_structured_echo_delays = isinstance(raw_echo_delays, list) and any(
+            isinstance(entry, dict) for entry in raw_echo_delays
+        )
+        return _coerce_echo_delay_entries(
+            echo_delays=raw_echo_delays,
+            echo_indices=[] if has_structured_echo_delays else review_outcome.get("echo_indices"),
+            echo_lags=[] if has_structured_echo_delays else review_outcome.get("echo_lags"),
+            los_lag=review_outcome.get("los_lag"),
+        )
 
     @staticmethod
     def _build_review_prefill_from_result(result_payload: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
### Motivation
- Re-review payloads could contain echo delay data in various shapes which caused inconsistent UI table rendering and payload storage.
- The goal is to ensure `echo_delays` are coerced to the same canonical schema used during initial measurement review so tables and persisted payloads remain consistent.

### Description
- Normalize `review_outcome` echo data early in `MissionWorkflowWindow._open_review_for_result_row` using a new helper that wraps the existing `_coerce_echo_delay_entries` logic. 
- Add `MissionWorkflowWindow._normalize_review_echo_delays(...)` to choose whether to treat provided `echo_delays` as already-structured or derive them from `echo_indices`/`echo_lags`/`los_lag` and return a list of dicts with `delta_lag`/`distance_m`.
- Apply normalized `echo_delays` back into `review_outcome` before copying values into `result_payload` and `review_payload`, and update the table row afterwards so `_format_echo_distances_for_table(...)` sees canonical data.
- Add regression tests in `tests/test_mission_workflow_ui.py` for non-normalized `echo_delays`, for reviews that only return `echo_lags`, and ensure existing approved-review behavior remains unchanged.

### Testing
- Ran the focused test subset with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k 'open_review_for_result_row or format_echo_distances_for_table'`. 
- All targeted tests passed: `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8daf1c7188321998292f682345049)