### PR TITLE
Propagate interpolation metadata through re-review normalization and persistence

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1101,6 +1101,49 @@ def test_open_review_for_result_row_derives_echo_delays_from_echo_lags() -> None
     assert result["echo_delays"] == [{"echo_index": 0, "delta_lag": 15.0, "distance_m": 22.5}]
 
 
+
+
+def test_open_review_for_result_row_scales_rereview_echo_delays_with_interpolation() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._records = [
+        {
+            "global_index": 0,
+            "point_index": 0,
+            "error": "",
+            "measurement": {
+                "status": "succeeded",
+                "result": {
+                    "output_file": "dummy.bin",
+                    "review": {},
+                },
+            },
+        }
+    ]
+    window._append_validation = lambda _msg: None
+    window._persist_workflow_state = lambda: None
+    window._update_results_selection_diagnostics = lambda: None
+    window._draw_map_preview = lambda: None
+    window._format_live_position_for_table = lambda _payload: "-"
+    window._format_live_distance_to_rx_for_table = lambda _payload: "-"
+    window.results_table = SimpleNamespace(get_children=lambda: (), item=lambda *_args, **_kwargs: None)
+    window.master = SimpleNamespace(
+        review_measurement_for_mission=lambda **_kwargs: {
+            "approved": True,
+            "los_lag": 100,
+            "echo_lags": [112],
+            "interpolation_enabled": True,
+            "interpolation_factor": 4,
+        }
+    )
+
+    window._open_review_for_result_row(0)
+
+    result = window._records[0]["measurement"]["result"]
+    assert result["echo_delays"] == [{"echo_index": 0, "delta_lag": 3.0, "distance_m": 4.5}]
+    assert result["interpolation_enabled"] is True
+    assert result["interpolation_factor"] == 4
+    assert result["review"]["echo_delays"] == result["echo_delays"]
+
 def test_open_review_for_result_row_applies_approved_review_and_persists() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._records = [

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1751,7 +1751,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if normalized_echo_delays:
             review_outcome["echo_delays"] = normalized_echo_delays
 
-        for key in ("manual_lags", "los_idx", "echo_indices", "los_lag", "echo_lags", "echo_delays"):
+        for key in (
+            "manual_lags",
+            "los_idx",
+            "echo_indices",
+            "los_lag",
+            "echo_lags",
+            "echo_delays",
+            "interpolation_enabled",
+            "interpolation_factor",
+        ):
             if key in review_outcome:
                 result_payload[key] = review_outcome.get(key)
 
@@ -1759,7 +1768,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not isinstance(review_payload, dict):
             review_payload = {}
             result_payload["review"] = review_payload
-        for key in ("manual_lags", "los_idx", "echo_indices", "los_lag", "echo_lags", "echo_delays"):
+        for key in (
+            "manual_lags",
+            "los_idx",
+            "echo_indices",
+            "los_lag",
+            "echo_lags",
+            "echo_delays",
+            "interpolation_enabled",
+            "interpolation_factor",
+        ):
             if key in review_outcome:
                 review_payload[key] = review_outcome.get(key)
 
@@ -1793,6 +1811,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             echo_indices=[] if has_structured_echo_delays else review_outcome.get("echo_indices"),
             echo_lags=[] if has_structured_echo_delays else review_outcome.get("echo_lags"),
             los_lag=review_outcome.get("los_lag"),
+            interpolation_enabled=review_outcome.get("interpolation_enabled"),
+            interpolation_factor=review_outcome.get("interpolation_factor"),
         )
 
     @staticmethod
@@ -1815,6 +1835,21 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                     parsed_manual[key] = int(round(float(value)))
             if parsed_manual:
                 prefill["manual_lags"] = parsed_manual
+        interpolation_enabled = result_payload.get("interpolation_enabled")
+        if interpolation_enabled is None:
+            review_payload = result_payload.get("review")
+            if isinstance(review_payload, dict):
+                interpolation_enabled = review_payload.get("interpolation_enabled")
+        if interpolation_enabled is not None:
+            prefill["interpolation_enabled"] = bool(interpolation_enabled)
+
+        interpolation_factor = result_payload.get("interpolation_factor")
+        if interpolation_factor is None:
+            review_payload = result_payload.get("review")
+            if isinstance(review_payload, dict):
+                interpolation_factor = review_payload.get("interpolation_factor")
+        if interpolation_factor is not None:
+            prefill["interpolation_factor"] = interpolation_factor
         return prefill
 
     def _on_results_table_select(self, _event: tk.Event) -> None:


### PR DESCRIPTION
### Motivation
- Ensure re-review normalization applies the same interpolation semantics as the initial review path so scaled delays are computed correctly.
- Preserve `interpolation_enabled` and `interpolation_factor` when applying an approved re-review so subsequent re-reviews or consumers see consistent metadata.
- Keep handling of both structured `echo_delays` (dict entries) and unstructured inputs (`echo_lags`/`echo_indices`) consistent in the re-review path.

### Description
- Forward `interpolation_enabled` and `interpolation_factor` from the re-review outcome into `MissionWorkflowWindow._normalize_review_echo_delays(...)`, which now passes them to `_coerce_echo_delay_entries(...)`.
- Persist `interpolation_enabled` and `interpolation_factor` into the top-level result payload and the nested `result["review"]` when an approved re-review is applied.
- Extend `_build_review_prefill_from_result(...)` to include interpolation metadata taken from the existing `result` or its nested `review` so the review dialog is prefilled correctly on re-review.
- Add a unit test `test_open_review_for_result_row_scales_rereview_echo_delays_with_interpolation` that simulates a re-review with `interpolation_enabled=True` and `interpolation_factor>1` and asserts delays are scaled and metadata is preserved.

### Testing
- Running `pytest -q tests/test_mission_workflow_ui.py -k "normalizes_review_echo_delays_for_table_and_payload or derives_echo_delays_from_echo_lags or scales_rereview_echo_delays_with_interpolation"` without `PYTHONPATH` failed during collection due to import path, which is an environment issue not related to the change.
- Running `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "normalizes_review_echo_delays_for_table_and_payload or derives_echo_delays_from_echo_lags or scales_rereview_echo_delays_with_interpolation"` executed the three targeted tests and they all passed (`3 passed, 72 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8dd6195f48321ab44e5c359a702e0)