### PR TITLE
Restore mission workflow focus after mission measurement review closes

### DIFF
--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -7565,6 +7565,11 @@ class TransceiverUI(ctk.CTk):
                     outcome.get("detail", ""),
                 )
                 dialog_result = dialog.exec()
+                workflow_window = getattr(self, "_mission_workflow_window", None)
+                if workflow_window is not None and workflow_window.winfo_exists():
+                    workflow_window.deiconify()
+                    workflow_window.lift()
+                    workflow_window.after_idle(workflow_window.focus_force)
                 logging.info(
                     "Mission review dialog finished: point_label=%s result=%s confirmed=%s reason=%s detail=%s",
                     point_label,


### PR DESCRIPTION
### Motivation
- Ensure the Mission Workflow window is restored and receives focus after the Mission Measurement Review dialog closes so the workflow is visible even if another application window had taken the foreground.

### Description
- After `dialog.exec()` returns in `TransceiverUI.review_measurement_for_mission`, the code retrieves `self._mission_workflow_window` and, if it exists, calls `deiconify()`, `lift()`, and schedules `focus_force` via `after_idle` to restore and focus the workflow window.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui_state.py` and the suite passed (`11 passed`), with an initial collection error resolved by setting `PYTHONPATH=.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9e61157e48321bbf005e500adc9bf)