### PR TITLE
Keep mission workflow result list across new runs

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3305,7 +3305,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._append_validation("ℹ️ Testlauf aktiv: Wegpunkte werden ohne Messung angefahren.")
         start_point_index = self._selected_start_point_index()
 
-        self._clear_results_table()
+        # Ergebnisliste absichtlich nicht automatisch löschen:
+        # Historische Run-Ergebnisse sollen im Workflow persistent bleiben
+        # und nur über "Ergebnisliste leeren" entfernt werden.
         self._run_started_at = time.time()
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
         self._run_log_dir = Path("signals") / "mission-runs" / ts


### PR DESCRIPTION
### Motivation
- Preserve historical run results in the mission workflow UI so previous measurement entries remain visible until explicitly removed via the "Ergebnisliste leeren" action.

### Description
- Remove the automatic `self._clear_results_table()` call from `_start_run` in `transceiver/mission_workflow_ui.py` and add a comment explaining that the results list is intentionally persistent.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui_state.py` which passed (`11 passed`), and an environment-level run of `pytest -q tests/test_mission_workflow_ui_state.py tests/test_mission_workflow_ui.py` failed during collection due to missing `PYTHONPATH` import errors in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9e88b4f048321a0993588208aff19)