### PR TITLE
Preserve mission result list across log imports

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1362,3 +1362,30 @@ def test_manual_measurement_point_context_falls_back_to_selected_active_start_po
     assert context is not None
     assert context.point_index == 1
     assert context.point.id == "p2"
+
+def test_import_logs_appends_records_without_clearing_existing_results(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+    import zipfile
+
+    payload = {"measurement": {"status": "ok", "result": {}}, "map_name": "map-a"}
+    archive = tmp_path / "import.zip"
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("point-0001.json", json.dumps(payload))
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._rx_antenna_global_position = None
+    window._current_map_name = lambda: "map-a"
+    window._append_validation = lambda _msg: None
+
+    imported: list[dict[str, object]] = []
+    window._on_record = lambda record: imported.append(record)
+
+    cleared = {"called": False}
+    window._clear_results_table = lambda: cleared.__setitem__("called", True)
+
+    monkeypatch.setattr("transceiver.mission_workflow_ui.filedialog.askopenfilename", lambda **_kwargs: str(archive))
+
+    window._import_logs()
+
+    assert cleared["called"] is False
+    assert imported == [payload]

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -4545,7 +4545,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                     y=imported_rx_position[1],
                 )
 
-        self._clear_results_table()
         for payload in imported_records:
             self._on_record(payload)
 


### PR DESCRIPTION
### Motivation
- Importing run logs used to clear the current result list which lost historical run results; imports should append to the existing results so history is preserved (run start already intentionally keeps results). 

### Description
- Remove the call to `_clear_results_table()` inside `_import_logs()` so each imported payload is fed to `_on_record()` and appended to the existing results. 
- Add test `test_import_logs_appends_records_without_clearing_existing_results` in `tests/test_mission_workflow_ui.py` to assert that `_import_logs()` does not call `_clear_results_table()` and that imported payloads are passed to `_on_record()`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "import_logs_appends_records_without_clearing_existing_results"` and it passed (`1 passed, 75 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9e92084908321963eaccc9da2802b)