### PR TITLE
Persist mission workflow result list across restarts

### DIFF
--- a/tests/test_mission_workflow_ui_state.py
+++ b/tests/test_mission_workflow_ui_state.py
@@ -178,3 +178,27 @@ def test_save_and_load_json_dict_preserves_manual_navigation_enabled_flag(tmp_pa
     loaded = _load_json_dict(state_file)
 
     assert loaded["manual_navigation_enabled"] is True
+
+
+def test_save_and_load_json_dict_preserves_mission_result_records(tmp_path) -> None:
+    state_file = tmp_path / "mission-workflow-state.json"
+    payload = {
+        "name": "scan-records",
+        "repeat": 1,
+        "start_point_index": 0,
+        "points": [{"id": "p001", "x": 0.0, "y": 0.0, "z": 0.0, "yaw": 0.0, "enabled": True}],
+        "records": [
+            {
+                "global_index": 0,
+                "point_index": 0,
+                "navigation": {"state": "succeeded"},
+                "measurement": {"status": "succeeded", "result": {"echo_delays": [1.2]}},
+                "result_table": {"position": "1.00 / 2.00", "abstand": "3.4"},
+            }
+        ],
+    }
+
+    _save_json_dict(state_file, payload)
+    loaded = _load_json_dict(state_file)
+
+    assert loaded["records"] == payload["records"]

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3115,6 +3115,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "reverse_point_order": bool(self.reverse_point_order_var.get()),
             "live_pose_stream_enabled": bool(self.live_pose_stream_enabled_var.get()),
             "live_preview_enabled": bool(self.live_preview_enabled_var.get()),
+            "records": self._records,
         }
 
     def _serialize_rx_antenna_global_position(self) -> dict[str, float] | None:
@@ -3217,6 +3218,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 f"Punkte pro Zyklus: {len(mission.points)} | Wiederholungen: {repeats} | Gesamtpunkte: {total_points}"
             )
             self._refresh_review_ready_indicator()
+            persisted_records = payload.get("records")
+            if isinstance(persisted_records, list):
+                self._clear_results_table()
+                for persisted_payload in persisted_records:
+                    if isinstance(persisted_payload, dict):
+                        self._on_record(dict(persisted_payload))
+                if persisted_records:
+                    self._append_validation(
+                        f"✅ Persistierte Ergebnisliste geladen: {len(self._records)} Messpunkte"
+                    )
         finally:
             self._is_restoring_workflow_state = False
 


### PR DESCRIPTION
### Motivation
- Ensure the mission workflow result list (table rows) is kept across application restarts so previously recorded measurement results are not lost.

### Description
- Include the current run `records` in the workflow state payload returned by `_build_workflow_state_payload` so they are serialized to `mission_workflow_state.json`.
- Restore persisted `records` in `_restore_workflow_state` by clearing the current results table and replaying saved payloads via `_on_record`, and append a validation message when records are restored.
- Add `test_save_and_load_json_dict_preserves_mission_result_records` in `tests/test_mission_workflow_ui_state.py` to verify `records` survive the save/load roundtrip.

### Testing
- Running `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui_state.py` succeeded with all tests passing (`12 passed`).
- An initial `pytest` run without `PYTHONPATH` failed collection due to import paths, after which the test run with `PYTHONPATH=.` passed as above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9e93114a88321ae00d46b02747d51)