### PR TITLE
Persist mission workflow results on window close

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -4447,6 +4447,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._navigator.stop_pose_stream()
             self._navigator = None
         self._live_pose_stream_active = False
+        self._persist_workflow_state()
         self.destroy()
 
 


### PR DESCRIPTION
### Motivation
- Beim Schließen des Mission-Workflow-Fensters gingen zuvor aufgezeichnete Ergebnispunkte verloren, weil der Workflow-Status nicht vor dem Zerstören des Toplevel-Fensters persistiert wurde.

### Description
- In `transceiver/mission_workflow_ui.py` wurde in `MissionWorkflowWindow._on_window_close` ein Aufruf zu `_persist_workflow_state()` vor `destroy()` ergänzt, sodass `self._records` in die gespeicherte `records`-Liste geschrieben werden.

### Testing
- `python -m py_compile transceiver/mission_workflow_ui.py` wurde erfolgreich ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9ea5bf7d88321a5b9a94298b779ef)