### PR TITLE
Fix run-log export to always use current results table

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -4459,23 +4459,39 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._update_results_selection_diagnostics()
 
     def _export_logs(self) -> None:
-        if self._run_log_dir is None or not self._run_log_dir.exists():
+        if not self._records:
             messagebox.showinfo("Export", "Noch keine Run-Logs vorhanden.", parent=self)
             return
 
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        run_name = self._run_log_dir.name if self._run_log_dir is not None else f"run-logs-{timestamp}"
         destination = filedialog.asksaveasfilename(
             title="Run-Logs exportieren",
             parent=self,
             defaultextension=".zip",
-            initialfile=f"{self._run_log_dir.name}.zip",
+            initialfile=f"{run_name}.zip",
             filetypes=[("ZIP", "*.zip")],
         )
         if not destination:
             return
 
         with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-            for path in sorted(self._run_log_dir.glob("*.json")):
-                zf.write(path, arcname=path.name)
+            zf.writestr(
+                "run-summary.json",
+                json.dumps(
+                    {
+                        "exported_at": datetime.now().isoformat(timespec="seconds"),
+                        "record_count": len(self._records),
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                ),
+            )
+            for index, payload in enumerate(self._records, start=1):
+                zf.writestr(
+                    f"point-{index:03d}.json",
+                    json.dumps(payload, indent=2, ensure_ascii=False),
+                )
         messagebox.showinfo("Export", f"Exportiert nach:\n{destination}", parent=self)
 
     def _import_logs(self) -> None:


### PR DESCRIPTION
### Motivation
- The export dialog previously relied on `self._run_log_dir` existing and showed "Noch keine Run-Logs vorhanden." when no active run-directory was present even if the UI table contained persisted/imported records.
- The intent is to always export the current state of the results table so users can export persisted or imported entries without an active run directory.

### Description
- Change export precondition to check the in-memory results list `self._records` instead of `self._run_log_dir` existence.
- Use a timestamp-based fallback run name when `self._run_log_dir` is not set and use it for the suggested ZIP `initialfile`.
- Serialize the export into a ZIP containing a generated `run-summary.json` with `exported_at` and `record_count` and numbered `point-XXX.json` files for each entry from `self._records`.
- All JSON entries are written with `json.dumps(..., indent=2, ensure_ascii=False)` to preserve readable, UTF-8 encoded content.

### Testing
- `python -m py_compile transceiver/mission_workflow_ui.py` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9f3d0b3c08321880f1ce0506b2d78)