### PR TITLE
Remove review column and open review on results row double-click

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -349,7 +349,6 @@ class _TreeviewSelectionStub:
             "echo_3_m",
             "echo_4_m",
             "echo_5_m",
-            "review_action",
             "status",
         )
 
@@ -427,17 +426,16 @@ def test_on_results_table_click_on_empty_region_preserves_multiselect() -> None:
     assert window.results_selection_diagnostics_var.value == "Auswahl: 2 Zeilen"
 
 
-def test_on_results_table_click_opens_review_in_review_column() -> None:
+def test_on_results_table_double_click_opens_review_for_row() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     table = _TreeviewSelectionStub()
     table._row_id = "row-a"
-    table._column_id = "#10"
     table._indices = {"row-a": 3}
     window.results_table = table
     opened_rows: list[int] = []
     window._open_review_for_result_row = lambda row_index: opened_rows.append(row_index)
 
-    result = window._on_results_table_click(SimpleNamespace(x=5, y=5))
+    result = window._on_results_table_double_click(SimpleNamespace(y=5))
 
     assert result == "break"
     assert opened_rows == [3]

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -688,7 +688,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "echo_3_m",
             "echo_4_m",
             "echo_5_m",
-            "review_action",
             "status",
         )
         self.results_table = ttk.Treeview(
@@ -709,7 +708,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "echo_3_m": f"{ECHO_HEADING_MARKERS[2]} E3",
             "echo_4_m": f"{ECHO_HEADING_MARKERS[3]} E4",
             "echo_5_m": f"{ECHO_HEADING_MARKERS[4]} E5",
-            "review_action": "Review",
             "status": "Status",
         }
         for key, title in headings.items():
@@ -723,7 +721,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.results_table.column("echo_3_m", width=80)
         self.results_table.column("echo_4_m", width=80)
         self.results_table.column("echo_5_m", width=80)
-        self.results_table.column("review_action", width=90, stretch=False)
         self.results_table.column("status", width=320)
 
         scroll = ttk.Scrollbar(table_frame, orient="vertical", command=self.results_table.yview)
@@ -731,6 +728,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.results_table.configure(yscrollcommand=scroll.set)
         self.results_table.bind("<<TreeviewSelect>>", self._on_results_table_select)
         self.results_table.bind("<Button-1>", self._on_results_table_click, add="+")
+        self.results_table.bind("<Double-1>", self._on_results_table_double_click, add="+")
         self.results_selection_diagnostics_var = tk.StringVar(value="Auswahl: 0 Zeilen")
         ctk.CTkLabel(
             table_frame,
@@ -1685,28 +1683,20 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _on_results_table_click(self, event: tk.Event) -> str | None:
         row_id = self.results_table.identify_row(event.y)
-        identify_column = getattr(self.results_table, "identify_column", None)
-        column_id = identify_column(event.x) if callable(identify_column) else ""
-        review_column_id = "#10"
-        try:
-            columns = tuple(self.results_table.cget("columns"))
-        except Exception:
-            columns = ()
-        if columns:
-            try:
-                review_column_id = f"#{columns.index('review_action') + 1}"
-            except ValueError:
-                pass
-        if row_id and column_id == review_column_id:
-            row_index = self.results_table.index(row_id)
-            self._open_review_for_result_row(row_index)
-            return "break"
         if row_id:
             return None
         region = self.results_table.identify("region", event.x, event.y)
         if region in {"heading", "separator"}:
             return None
         self._update_results_selection_diagnostics()
+        return "break"
+
+    def _on_results_table_double_click(self, event: tk.Event) -> str | None:
+        row_id = self.results_table.identify_row(event.y)
+        if not row_id:
+            return None
+        row_index = self.results_table.index(row_id)
+        self._open_review_for_result_row(row_index)
         return "break"
 
     def _open_review_for_result_row(self, row_index: int) -> None:
@@ -1798,7 +1788,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                     self._format_live_position_for_table(record),
                     self._format_live_distance_to_rx_for_table(record),
                     *self._format_echo_distances_for_table(result_payload.get("echo_delays")),
-                    "Review",
                     combined_status,
                 ),
             )
@@ -4215,7 +4204,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 live_position_text,
                 live_distance_to_rx,
                 *echo_distances,
-                "Review",
                 combined_status,
             ),
         )


### PR DESCRIPTION
### Motivation
- Simplify the results table UI by removing the dedicated "Review" action column and make review accessible by interacting with the row itself.
- Provide an intuitive and consistent way to open the review dialog by double-clicking a results row instead of targeting a specific cell.

### Description
- Removed the `review_action` column from the results table `columns` and `headings` definitions and removed its column configuration in `MissionWorkflowWindow` (`transceiver/mission_workflow_ui.py`).
- Replaced the previous per-cell review click logic with a double-click binding by adding `self.results_table.bind("<Double-1>", self._on_results_table_double_click, add="+")` and implemented `_on_results_table_double_click` to call `_open_review_for_result_row` for the clicked row.
- Updated all table `insert` and `item` value tuples to match the new column layout (removed the fixed "Review" value).
- Updated tests to reflect the new behavior by removing the `review_action` stub column and replacing the click-based test with a double-click test in `tests/test_mission_workflow_ui.py`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k 'results_table_click_on_empty_region or results_table_double_click_opens_review_for_row or open_review_for_result_row_normalizes_review_echo_delays_for_table_and_payload'`, and the selected tests passed.
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -q`, which reported a failure unrelated to this change caused by a headless `tkinter.messagebox` interaction in the test environment (existing UI headless test issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa17efddf0832181a2f9c6b7738faa)