### PR TITLE
Fix mission review dialog parenting to prefer Tk workflow native parent

### DIFF
--- a/tests/test_receive_for_mission_threading.py
+++ b/tests/test_receive_for_mission_threading.py
@@ -37,6 +37,7 @@ def _install_pyqtgraph_stub() -> None:
     pg_mod.Qt = qt_mod
     pg_mod.exporters = types.ModuleType("pyqtgraph.exporters")
     pg_mod.ScatterPlotItem = type("ScatterPlotItem", (), {})
+    pg_mod.ViewBox = type("ViewBox", (), {})
     pg_mod.PlotWidget = type("PlotWidget", (), {})
     pg_mod.InfiniteLine = type("InfiniteLine", (), {})
 
@@ -513,3 +514,115 @@ def test_render_continuous_payload_caches_mission_preview_distances_without_reco
 
     assert calls["count"] == 1
     assert ui._last_continuous_payload["mission_preview_echo_distances_m"] == [2.25, 4.5]
+
+
+def test_review_measurement_for_mission_uses_workflow_native_parent_not_qt_top_level(monkeypatch) -> None:
+    import numpy as np
+    import queue
+    import transceiver.__main__ as app_module
+
+    ui = object.__new__(TransceiverUI)
+    ui._ui = lambda callback: callback()
+    ui._out_queue = queue.Queue()
+    ui.latest_fs = 10.0
+    ui.rx_channel_2 = types.SimpleNamespace(get=lambda: False)
+    ui.rx_xcorr_normalized_enable = types.SimpleNamespace(get=lambda: False)
+    ui.rx_interpolation_enable = types.SimpleNamespace(get=lambda: False)
+    ui._select_rx_display_data = lambda loaded: (loaded, "CH0")
+    ui._get_crosscorr_reference = lambda: (np.array([1.0], dtype=float), "TX")
+    ui._apply_crosscorr_interpolation = (
+        lambda data, fs, ref_data, crosscorr_compare=None, **_kwargs: (data, ref_data, crosscorr_compare, fs)
+    )
+    ui._rx_effective_interpolation_factor = lambda: 1.0
+
+    workflow_calls: list[str] = []
+
+    class _WorkflowWindow:
+        def winfo_exists(self):
+            return True
+
+        def winfo_id(self):
+            return 12345
+
+        def deiconify(self):
+            workflow_calls.append("deiconify")
+
+        def lift(self):
+            workflow_calls.append("lift")
+
+        def after_idle(self, callback):
+            workflow_calls.append("after_idle")
+            callback()
+
+        def focus_force(self):
+            workflow_calls.append("focus_force")
+
+    ui._mission_workflow_window = _WorkflowWindow()
+
+    monkeypatch.setattr(
+        app_module.rx_convert,
+        "load_iq_file",
+        lambda *_args, **_kwargs: np.array([2.0], dtype=float),
+    )
+    monkeypatch.setattr(
+        app_module,
+        "_build_crosscorr_ctx",
+        lambda *_args, **_kwargs: {
+            "lags": np.array([0.0]),
+            "mag": np.array([1.0]),
+            "los_idx": 0,
+            "echo_indices": [],
+        },
+    )
+
+    class _DummyApp:
+        def activeWindow(self):
+            raise AssertionError("activeWindow must not be used while a workflow window exists")
+
+    monkeypatch.setattr(app_module.pg, "mkQApp", lambda: _DummyApp())
+    monkeypatch.setattr(
+        app_module.QtWidgets.QApplication,
+        "topLevelWidgets",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("topLevelWidgets must not be used while a workflow window exists")
+        ),
+        raising=False,
+    )
+
+    dialog_init_kwargs: dict[str, object] = {}
+    attached_workflow_windows: list[object | None] = []
+
+    class _DummyDialog:
+        def __init__(self, **kwargs):
+            dialog_init_kwargs.update(kwargs)
+            self.confirmed = False
+            self.selected_los_idx = None
+            self.selected_echo_indices = []
+            self.manual_lags = {}
+            self.echo_delays = []
+
+        def attach_tk_transient_parent(self, workflow_window):
+            attached_workflow_windows.append(workflow_window)
+            return True
+
+        def raise_(self):
+            return None
+
+        def activateWindow(self):
+            return None
+
+        def exec(self):
+            return 0
+
+    monkeypatch.setattr(app_module, "MissionMeasurementReviewDialog", _DummyDialog)
+
+    outcome = TransceiverUI.review_measurement_for_mission(
+        ui,
+        point_label="P1",
+        output_file="signals/rx/mission/demo.bin",
+    )
+
+    assert dialog_init_kwargs["parent"] is None
+    assert attached_workflow_windows == [ui._mission_workflow_window]
+    assert workflow_calls == ["deiconify", "lift", "after_idle", "focus_force"]
+    assert outcome["approved"] is False

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1709,6 +1709,91 @@ def _find_echo_marker_slot_near_lag(
     return nearest_slot
 
 
+def _valid_tk_window(window: object | None) -> object | None:
+    """Return a Tk window only when it still exists."""
+    if window is None:
+        return None
+    winfo_exists = getattr(window, "winfo_exists", None)
+    if not callable(winfo_exists):
+        return None
+    try:
+        if not bool(winfo_exists()):
+            return None
+    except Exception:
+        return None
+    return window
+
+
+def _mission_review_qt_parent(qapp: object, workflow_window: object | None) -> object | None:
+    """Resolve the Qt parent for the mission-review dialog.
+
+    The mission workflow is a Tk/CustomTkinter window, so it is intentionally
+    not represented by ``QApplication.activeWindow()``.  While the workflow
+    exists, the Qt dialog must therefore stay parentless on the QWidget side and
+    use the workflow's native window handle as transient parent instead.  Only
+    fall back to arbitrary Qt top-level windows when no workflow window exists.
+    """
+    if workflow_window is not None:
+        return None
+
+    active_window = None
+    active_window_getter = getattr(qapp, "activeWindow", None)
+    if callable(active_window_getter):
+        active_window = active_window_getter()
+    if active_window is not None:
+        return active_window
+
+    top_level_widgets = [
+        widget
+        for widget in QtWidgets.QApplication.topLevelWidgets()
+        if isinstance(widget, QtWidgets.QWidget) and widget.isVisible()
+    ]
+    return top_level_widgets[0] if top_level_widgets else None
+
+
+def _configure_qt_dialog_tk_transient_parent(
+    dialog: QtWidgets.QDialog,
+    workflow_window: object | None,
+) -> bool:
+    """Attach a Qt dialog transiently to an existing Tk workflow window.
+
+    Returns ``True`` when Qt accepted a native transient parent.  The created
+    ``QWindow`` wrapper is kept alive on the dialog for the dialog lifetime.
+    """
+    if workflow_window is None:
+        return False
+    winfo_id = getattr(workflow_window, "winfo_id", None)
+    if not callable(winfo_id):
+        return False
+    try:
+        native_parent_id = int(winfo_id())
+    except Exception as exc:
+        logging.debug("Mission review could not read Tk workflow window handle: %s", exc)
+        return False
+    if native_parent_id <= 0:
+        return False
+
+    try:
+        dialog.winId()
+        qt_window = dialog.windowHandle()
+        if qt_window is None:
+            return False
+        native_parent_window = QtGui.QWindow.fromWinId(native_parent_id)
+        if native_parent_window is None:
+            return False
+        qt_window.setTransientParent(native_parent_window)
+        dialog.setWindowModality(QtCore.Qt.WindowModal)
+        dialog._tk_transient_parent_window = native_parent_window
+        return True
+    except Exception as exc:
+        logging.debug(
+            "Mission review could not attach Qt dialog to Tk workflow window handle %s: %s",
+            native_parent_id,
+            exc,
+        )
+        return False
+
+
 class MissionMeasurementReviewDialog(QtWidgets.QDialog):
     """Blocking review dialog for mission cross-correlation peaks."""
 
@@ -1783,6 +1868,9 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
         button_row.addWidget(confirm_btn)
         layout.addLayout(button_row)
 
+    def attach_tk_transient_parent(self, workflow_window: object | None) -> bool:
+        """Use a Tk workflow window as this Qt dialog's native transient parent."""
+        return _configure_qt_dialog_tk_transient_parent(self, workflow_window)
 
     def _on_auto_detect(self) -> None:
         if self._magnitudes.size == 0 or self._lags.size == 0:
@@ -7536,14 +7624,8 @@ class TransceiverUI(ctk.CTk):
                     ]
                     return
 
-                parent_window = qapp.activeWindow()
-                if parent_window is None:
-                    top_level_widgets = [
-                        widget
-                        for widget in QtWidgets.QApplication.topLevelWidgets()
-                        if isinstance(widget, QtWidgets.QWidget) and widget.isVisible()
-                    ]
-                    parent_window = top_level_widgets[0] if top_level_widgets else None
+                workflow_window = _valid_tk_window(getattr(self, "_mission_workflow_window", None))
+                parent_window = _mission_review_qt_parent(qapp, workflow_window)
                 dialog = MissionMeasurementReviewDialog(
                     parent=parent_window,
                     point_label=point_label,
@@ -7556,6 +7638,8 @@ class TransceiverUI(ctk.CTk):
                     else 1.0,
                     repetition_period_samples=int(ctx.get("period_samples")) if ctx.get("period_samples") is not None else None,
                 )
+                if workflow_window is not None:
+                    dialog.attach_tk_transient_parent(workflow_window)
                 dialog.raise_()
                 dialog.activateWindow()
                 logging.info(
@@ -7565,8 +7649,7 @@ class TransceiverUI(ctk.CTk):
                     outcome.get("detail", ""),
                 )
                 dialog_result = dialog.exec()
-                workflow_window = getattr(self, "_mission_workflow_window", None)
-                if workflow_window is not None and workflow_window.winfo_exists():
+                if workflow_window is not None:
                     workflow_window.deiconify()
                     workflow_window.lift()
                     workflow_window.after_idle(workflow_window.focus_force)


### PR DESCRIPTION
### Motivation
- Der Review-Dialog wurde bisher über `qapp.activeWindow()` / beliebige Qt-Top-Level-Widgets geparentet, was in einer App mit einem Tk/CustomTkinter Workflow-Fenster zu falscher Elternschaft und Fokusproblemen führt. 
- Ziel ist, das vorhandene Workflow-Fenster (`self._mission_workflow_window`) explizit zu verwenden und Qt-Top-Level-Parents nur als Fallback zu belassen.

### Description
- Neue Helfer in `transceiver/__main__.py`: `_valid_tk_window`, `_mission_review_qt_parent` und `_configure_qt_dialog_tk_transient_parent` zur Validierung des Tk-Workflow-Fensters, Auflösung des Qt-Parent-Fallbacks und zum Setzen eines nativen transienten Elternfensters mittels `QWindow.fromWinId()`/`setTransientParent()`.
- `MissionMeasurementReviewDialog` erhält `attach_tk_transient_parent()` um die Plattform-spezifische Native-Handle-Anbindung vom Dialog selbst zu machen.
- `review_measurement_for_mission` wurde so angepasst, dass vor Erzeugung des Dialogs `self._mission_workflow_window` geprüft wird; wenn vorhanden wird kein Qt-`activeWindow()` als primärer Parent verwendet, stattdessen der Dialog parentless angelegt und anschließend via `winfo_id()` transient an das Tk-Fenster gehängt; Qt-Top-Level-Fallback bleibt nur, falls kein Workflow-Fenster existiert.
- `tests/test_receive_for_mission_threading.py` erhielt einen Smoke-Test `test_review_measurement_for_mission_uses_workflow_native_parent_not_qt_top_level` der sicherstellt, dass bei vorhandenem Workflow-Fenster weder `activeWindow()` noch `topLevelWidgets()` verwendet werden und das Workflow-Fenster als angehängter Parent verwendet wird, sowie eine Ergänzung der Test-Pyqtgraph-Stub (`ViewBox`).

### Testing
- Kompilierungstest: `python -m py_compile transceiver/__main__.py tests/test_receive_for_mission_threading.py` executed successfully.
- Targeted unit tests: `python -m pytest -q tests/test_receive_for_mission_threading.py::test_review_measurement_for_mission_uses_workflow_native_parent_not_qt_top_level` passed.
- Related grouped tests: running the three review-related tests with `python -m pytest -q tests/test_receive_for_mission_threading.py::test_review_measurement_for_mission_applies_same_interpolation_as_single_receive tests/test_receive_for_mission_threading.py::test_review_measurement_for_mission_uses_persisted_tx_reference_without_single_rx tests/test_receive_for_mission_threading.py::test_review_measurement_for_mission_uses_workflow_native_parent_not_qt_top_level` produced all passing results (3 passed).
- Full file run: `python -m pytest -q tests/test_receive_for_mission_threading.py` reports one unrelated existing failure (`test_render_continuous_payload_caches_mission_preview_distances_without_recompute`) raising a `RecursionError` in the test harness; this failure appears pre-existing / unrelated to the dialog-parent changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb209139e88321a2a8bac9cc5fcb06)