### PR TITLE
Make mission-review workflow focus restore robust and log transient-parent attach failures

### DIFF
--- a/tests/test_receive_for_mission_threading.py
+++ b/tests/test_receive_for_mission_threading.py
@@ -550,8 +550,15 @@ def test_review_measurement_for_mission_uses_workflow_native_parent_not_qt_top_l
         def lift(self):
             workflow_calls.append("lift")
 
+        def attributes(self, name, value):
+            workflow_calls.append(f"attributes:{name}:{value}")
+
         def after_idle(self, callback):
             workflow_calls.append("after_idle")
+            callback()
+
+        def after(self, delay_ms, callback):
+            workflow_calls.append(f"after:{delay_ms}")
             callback()
 
         def focus_force(self):
@@ -624,5 +631,134 @@ def test_review_measurement_for_mission_uses_workflow_native_parent_not_qt_top_l
 
     assert dialog_init_kwargs["parent"] is None
     assert attached_workflow_windows == [ui._mission_workflow_window]
-    assert workflow_calls == ["deiconify", "lift", "after_idle", "focus_force"]
+    assert workflow_calls == [
+        "deiconify",
+        "lift",
+        "attributes:-topmost:True",
+        "after_idle",
+        "focus_force",
+        "after:50",
+        "attributes:-topmost:False",
+    ]
+    assert outcome["approved"] is False
+
+
+def test_review_measurement_for_mission_restores_workflow_when_native_parent_attach_fails(
+    monkeypatch, caplog
+) -> None:
+    import logging
+    import numpy as np
+    import queue
+    import transceiver.__main__ as app_module
+
+    ui = object.__new__(TransceiverUI)
+    ui._ui = lambda callback: callback()
+    ui._out_queue = queue.Queue()
+    ui.latest_fs = 10.0
+    ui.rx_channel_2 = types.SimpleNamespace(get=lambda: False)
+    ui.rx_xcorr_normalized_enable = types.SimpleNamespace(get=lambda: False)
+    ui.rx_interpolation_enable = types.SimpleNamespace(get=lambda: False)
+    ui._select_rx_display_data = lambda loaded: (loaded, "CH0")
+    ui._get_crosscorr_reference = lambda: (np.array([1.0], dtype=float), "TX")
+    ui._apply_crosscorr_interpolation = (
+        lambda data, fs, ref_data, crosscorr_compare=None, **_kwargs: (data, ref_data, crosscorr_compare, fs)
+    )
+    ui._rx_effective_interpolation_factor = lambda: 1.0
+
+    workflow_calls: list[str] = []
+
+    class _WorkflowWindow:
+        def winfo_exists(self):
+            return True
+
+        def winfo_id(self):
+            return 12345
+
+        def deiconify(self):
+            workflow_calls.append("deiconify")
+
+        def lift(self):
+            workflow_calls.append("lift")
+
+        def attributes(self, name, value):
+            workflow_calls.append(f"attributes:{name}:{value}")
+
+        def after_idle(self, callback):
+            workflow_calls.append("after_idle")
+            callback()
+
+        def after(self, delay_ms, callback):
+            workflow_calls.append(f"after:{delay_ms}")
+            callback()
+
+        def focus_force(self):
+            workflow_calls.append("focus_force")
+
+    ui._mission_workflow_window = _WorkflowWindow()
+
+    monkeypatch.setattr(
+        app_module.rx_convert,
+        "load_iq_file",
+        lambda *_args, **_kwargs: np.array([2.0], dtype=float),
+    )
+    monkeypatch.setattr(
+        app_module,
+        "_build_crosscorr_ctx",
+        lambda *_args, **_kwargs: {
+            "lags": np.array([0.0]),
+            "mag": np.array([1.0]),
+            "los_idx": 0,
+            "echo_indices": [],
+        },
+    )
+
+    class _DummyApp:
+        def activeWindow(self):
+            raise AssertionError("activeWindow must not be used while a workflow window exists")
+
+    monkeypatch.setattr(app_module.pg, "mkQApp", lambda: _DummyApp())
+
+    attached_workflow_windows: list[object | None] = []
+
+    class _DummyDialog:
+        def __init__(self, **_kwargs):
+            self.confirmed = False
+            self.selected_los_idx = None
+            self.selected_echo_indices = []
+            self.manual_lags = {}
+            self.echo_delays = []
+
+        def attach_tk_transient_parent(self, workflow_window):
+            attached_workflow_windows.append(workflow_window)
+            return False
+
+        def raise_(self):
+            return None
+
+        def activateWindow(self):
+            return None
+
+        def exec(self):
+            return 0
+
+    monkeypatch.setattr(app_module, "MissionMeasurementReviewDialog", _DummyDialog)
+
+    with caplog.at_level(logging.WARNING, logger=app_module._LOGGER.name):
+        outcome = TransceiverUI.review_measurement_for_mission(
+            ui,
+            point_label="P1",
+            output_file="signals/rx/mission/demo.bin",
+        )
+
+    assert attached_workflow_windows == [ui._mission_workflow_window]
+    assert "without native Tk transient parent binding" in caplog.text
+    assert workflow_calls == [
+        "deiconify",
+        "lift",
+        "attributes:-topmost:True",
+        "after_idle",
+        "focus_force",
+        "after:50",
+        "attributes:-topmost:False",
+    ]
     assert outcome["approved"] is False

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -1724,6 +1724,71 @@ def _valid_tk_window(window: object | None) -> object | None:
     return window
 
 
+def _restore_workflow_window_focus(workflow_window: object | None) -> None:
+    """Bring the mission workflow window back to front after Qt review closes."""
+    workflow_window = _valid_tk_window(workflow_window)
+    if workflow_window is None:
+        return
+
+    def _call(method_name: str, *args: object) -> None:
+        method = getattr(workflow_window, method_name, None)
+        if not callable(method):
+            return
+        try:
+            method(*args)
+        except Exception:
+            _LOGGER.debug(
+                "Mission workflow focus restore failed during %s",
+                method_name,
+                exc_info=True,
+            )
+
+    def _set_topmost(enabled: bool) -> None:
+        attributes = getattr(workflow_window, "attributes", None)
+        if not callable(attributes):
+            return
+        try:
+            attributes("-topmost", bool(enabled))
+        except Exception:
+            _LOGGER.debug(
+                "Mission workflow focus restore failed during topmost=%s",
+                enabled,
+                exc_info=True,
+            )
+
+    def _release_topmost() -> None:
+        _set_topmost(False)
+
+    def _focus_and_schedule_release() -> None:
+        _call("focus_force")
+        after = getattr(workflow_window, "after", None)
+        if callable(after):
+            try:
+                after(50, _release_topmost)
+                return
+            except Exception:
+                _LOGGER.debug(
+                    "Mission workflow focus restore failed while scheduling topmost release",
+                    exc_info=True,
+                )
+        _release_topmost()
+
+    _call("deiconify")
+    _call("lift")
+    _set_topmost(True)
+    after_idle = getattr(workflow_window, "after_idle", None)
+    if callable(after_idle):
+        try:
+            after_idle(_focus_and_schedule_release)
+            return
+        except Exception:
+            _LOGGER.debug(
+                "Mission workflow focus restore failed while scheduling focus boost",
+                exc_info=True,
+            )
+    _focus_and_schedule_release()
+
+
 def _mission_review_qt_parent(qapp: object, workflow_window: object | None) -> object | None:
     """Resolve the Qt parent for the mission-review dialog.
 
@@ -7638,21 +7703,32 @@ class TransceiverUI(ctk.CTk):
                     else 1.0,
                     repetition_period_samples=int(ctx.get("period_samples")) if ctx.get("period_samples") is not None else None,
                 )
+                transient_attached = True
                 if workflow_window is not None:
-                    dialog.attach_tk_transient_parent(workflow_window)
-                dialog.raise_()
-                dialog.activateWindow()
-                logging.info(
-                    "Mission review opening dialog: point_label=%s reason=%s detail=%s",
-                    point_label,
-                    outcome.get("reason", ""),
-                    outcome.get("detail", ""),
-                )
-                dialog_result = dialog.exec()
-                if workflow_window is not None:
-                    workflow_window.deiconify()
-                    workflow_window.lift()
-                    workflow_window.after_idle(workflow_window.focus_force)
+                    try:
+                        transient_attached = bool(dialog.attach_tk_transient_parent(workflow_window))
+                    except Exception:
+                        transient_attached = False
+                        _LOGGER.warning(
+                            "Mission review failed to attach Tk transient parent for workflow window",
+                            exc_info=True,
+                        )
+                    if not transient_attached:
+                        _LOGGER.warning(
+                            "Mission review dialog is opening without native Tk transient parent binding"
+                        )
+                try:
+                    dialog.raise_()
+                    dialog.activateWindow()
+                    logging.info(
+                        "Mission review opening dialog: point_label=%s reason=%s detail=%s",
+                        point_label,
+                        outcome.get("reason", ""),
+                        outcome.get("detail", ""),
+                    )
+                    dialog_result = dialog.exec()
+                finally:
+                    _restore_workflow_window_focus(workflow_window)
                 logging.info(
                     "Mission review dialog finished: point_label=%s result=%s confirmed=%s reason=%s detail=%s",
                     point_label,


### PR DESCRIPTION
### Motivation
- Ensure the Mission Review dialog does not leave the Tk/CustomTkinter mission workflow window unfocused when native transient parent attachment fails or raises. 
- Make failures of the native Qt/Tk transient-parent binding visible via logs so platform-specific issues are easier to diagnose. 
- Encapsulate the restore sequence into a helper so the restore runs reliably even when exceptions occur during dialog execution. 

### Description
- Add a new helper ` _restore_workflow_window_focus(workflow_window)` that validates the Tk window and performs `deiconify()`, `lift()`, `focus_force()` and a short `attributes("-topmost", True)`/`attributes("-topmost", False)` boost scheduled with `after_idle`/`after`. 
- Store the boolean return value of `dialog.attach_tk_transient_parent(workflow_window)` and log a warning when the call returns `False` or raises an exception. 
- Wrap the dialog execution in a `try`/`finally` so `_restore_workflow_window_focus(...)` always runs after `dialog.exec()` completes or if dialog code raises. 
- Extend `tests/test_receive_for_mission_threading.py` to assert the stronger restore sequence and add a test where `attach_tk_transient_parent(...)` returns `False` but the workflow restore still executes and a warning is emitted. 

### Testing
- Ran the two focused tests with `PYTHONPATH=. pytest -q tests/test_receive_for_mission_threading.py::test_review_measurement_for_mission_uses_workflow_native_parent_not_qt_top_level tests/test_receive_for_mission_threading.py::test_review_measurement_for_mission_restores_workflow_when_native_parent_attach_fails -q` and both passed. 
- Compiled files with `python3 -m py_compile transceiver/__main__.py tests/test_receive_for_mission_threading.py` which succeeded. 
- Running the full test module with `PYTHONPATH=. pytest -q tests/test_receive_for_mission_threading.py -q` in this environment hit an unrelated existing Tk recursion failure in `test_render_continuous_payload_caches_mission_preview_distances_without_recompute`, so the full file did not pass here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb265cd1908321b2057928141ee368)