### PR TITLE
Add context menu to remove selected results in mission workflow

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -355,8 +355,20 @@ class _TreeviewSelectionStub:
     def selection(self) -> tuple[str, ...]:
         return self._selected
 
+    def selection_set(self, item_id: str) -> None:
+        self._selected = (item_id,)
+
     def index(self, item_id: str) -> int:
         return self._indices[item_id]
+
+    def get_children(self) -> tuple[str, ...]:
+        return tuple(sorted(self._indices, key=self._indices.__getitem__))
+
+    def delete(self, *item_ids: str) -> None:
+        for item_id in item_ids:
+            self._indices.pop(item_id, None)
+            self._selected = tuple(selected for selected in self._selected if selected != item_id)
+        self._indices = {item_id: index for index, item_id in enumerate(self.get_children())}
 
     def identify_row(self, _y: int) -> str:
         return self._row_id
@@ -424,6 +436,96 @@ def test_on_results_table_click_on_empty_region_preserves_multiselect() -> None:
     assert window._selected_result_indices == (0, 1)
     assert window._selected_result_index == 0
     assert window.results_selection_diagnostics_var.value == "Auswahl: 2 Zeilen"
+
+
+class _ResultsContextMenuStub:
+    def __init__(self) -> None:
+        self.labels: list[str] = []
+        self.popup_calls: list[tuple[int, int]] = []
+        self.release_count = 0
+
+    def entryconfigure(self, _index: int, *, label: str) -> None:
+        self.labels.append(label)
+
+    def tk_popup(self, x_root: int, y_root: int) -> None:
+        self.popup_calls.append((x_root, y_root))
+
+    def grab_release(self) -> None:
+        self.release_count += 1
+
+
+def test_on_results_table_context_menu_keeps_existing_multiselect_for_selected_row() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    table = _TreeviewSelectionStub()
+    table._row_id = "row-b"
+    table._selected = ("row-a", "row-b")
+    table._indices = {"row-a": 0, "row-b": 1, "row-c": 2}
+    menu = _ResultsContextMenuStub()
+    window.results_table = table
+    window.results_table_context_menu = menu
+    window.results_selection_diagnostics_var = _StringVarStub()
+    window._draw_map_preview = lambda: (_ for _ in ()).throw(AssertionError("must not redraw existing selection"))
+
+    result = window._on_results_table_context_menu(SimpleNamespace(x=5, y=6, x_root=50, y_root=60))
+
+    assert result == "break"
+    assert table.selection() == ("row-a", "row-b")
+    assert menu.labels == ["2 markierte Einträge entfernen"]
+    assert menu.popup_calls == [(50, 60)]
+    assert menu.release_count == 1
+
+
+def test_on_results_table_context_menu_selects_unselected_row() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    table = _TreeviewSelectionStub()
+    table._row_id = "row-c"
+    table._selected = ("row-a", "row-b")
+    table._indices = {"row-a": 0, "row-b": 1, "row-c": 2}
+    menu = _ResultsContextMenuStub()
+    window.results_table = table
+    window.results_table_context_menu = menu
+    window.results_selection_diagnostics_var = _StringVarStub()
+    draw_calls: list[str] = []
+    window._draw_map_preview = lambda: draw_calls.append("draw")
+
+    result = window._on_results_table_context_menu(SimpleNamespace(x=5, y=6, x_root=50, y_root=60))
+
+    assert result == "break"
+    assert table.selection() == ("row-c",)
+    assert window._selected_result_indices == (2,)
+    assert window._selected_result_index == 2
+    assert window.results_selection_diagnostics_var.value == "Auswahl: 1 Zeilen"
+    assert menu.labels == ["Markierten Eintrag entfernen"]
+    assert draw_calls == ["draw"]
+
+
+def test_remove_selected_results_removes_selected_records_and_persists() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    table = _TreeviewSelectionStub()
+    table._selected = ("row-a", "row-c")
+    table._indices = {"row-a": 0, "row-b": 1, "row-c": 2}
+    window.results_table = table
+    window._records = [
+        {"global_index": 0},
+        {"global_index": 1},
+        {"global_index": 2},
+    ]
+    window._selected_result_index = 0
+    window._selected_result_indices = (0, 2)
+    window.results_selection_diagnostics_var = _StringVarStub()
+    calls: list[str] = []
+    window._persist_workflow_state = lambda: calls.append("persist")
+    window._update_live_label = lambda: calls.append("live")
+    window._draw_map_preview = lambda: calls.append("draw")
+
+    window._remove_selected_results()
+
+    assert window._records == [{"global_index": 1}]
+    assert table.get_children() == ("row-b",)
+    assert window._selected_result_indices == ()
+    assert window._selected_result_index is None
+    assert window.results_selection_diagnostics_var.value == "Auswahl: 0 Zeilen"
+    assert calls == ["persist", "live", "draw"]
 
 
 def test_on_results_table_double_click_opens_review_for_row() -> None:
@@ -1240,12 +1342,12 @@ def test_confirm_measurement_after_navigation_failure_uses_point_index_in_prompt
     window.after = lambda _delay, callback: callback()
     window._append_validation = messages.append
 
-    def _askyesno(title: str, message: str, parent=None) -> bool:
+    def _askyesnocancel(title: str, message: str, parent=None) -> bool:
         asked["title"] = title
         asked["message"] = message
         return True
 
-    monkeypatch.setattr("transceiver.mission_workflow_ui.messagebox.askyesno", _askyesno)
+    monkeypatch.setattr("transceiver.mission_workflow_ui.messagebox.askyesnocancel", _askyesnocancel)
 
     decision = window._confirm_measurement_after_navigation_failure(
         point_context=SimpleNamespace(

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -729,6 +729,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.results_table.bind("<<TreeviewSelect>>", self._on_results_table_select)
         self.results_table.bind("<Button-1>", self._on_results_table_click, add="+")
         self.results_table.bind("<Double-1>", self._on_results_table_double_click, add="+")
+        self.results_table.bind("<Button-3>", self._on_results_table_context_menu, add="+")
+        self.results_table.bind("<Control-Button-1>", self._on_results_table_context_menu, add="+")
+        self.results_table_context_menu = tk.Menu(self.results_table, tearoff=False)
+        self.results_table_context_menu.add_command(
+            label="Markierte Einträge entfernen",
+            command=self._remove_selected_results,
+        )
         self.results_selection_diagnostics_var = tk.StringVar(value="Auswahl: 0 Zeilen")
         ctk.CTkLabel(
             table_frame,
@@ -1698,6 +1705,60 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         row_index = self.results_table.index(row_id)
         self._open_review_for_result_row(row_index)
         return "break"
+
+    def _on_results_table_context_menu(self, event: tk.Event) -> str | None:
+        row_id = self.results_table.identify_row(event.y)
+        if not row_id:
+            return None
+        selected_items = tuple(self.results_table.selection())
+        if row_id not in selected_items:
+            self.results_table.selection_set(row_id)
+            self._on_results_table_select(event)
+        selected_count = len(self.results_table.selection())
+        if selected_count <= 0:
+            return None
+        menu = self.results_table_context_menu
+        menu.entryconfigure(0, label=self._remove_results_context_label(selected_count))
+        try:
+            menu.tk_popup(event.x_root, event.y_root)
+        finally:
+            menu.grab_release()
+        return "break"
+
+    @staticmethod
+    def _remove_results_context_label(selected_count: int) -> str:
+        if selected_count == 1:
+            return "Markierten Eintrag entfernen"
+        return f"{selected_count} markierte Einträge entfernen"
+
+    def _selected_result_row_indices(self) -> tuple[int, ...]:
+        selected_items = tuple(self.results_table.selection())
+        if selected_items:
+            return tuple(
+                sorted(
+                    idx
+                    for idx in (self.results_table.index(item_id) for item_id in selected_items)
+                    if 0 <= idx < len(self._records)
+                )
+            )
+        return tuple(idx for idx in getattr(self, "_selected_result_indices", ()) if 0 <= idx < len(self._records))
+
+    def _remove_selected_results(self) -> None:
+        selected_indices = self._selected_result_row_indices()
+        if not selected_indices:
+            return
+        children = tuple(self.results_table.get_children())
+        for row_index in reversed(selected_indices):
+            if 0 <= row_index < len(self._records):
+                del self._records[row_index]
+            if 0 <= row_index < len(children):
+                self.results_table.delete(children[row_index])
+        self._selected_result_index = None
+        self._selected_result_indices = ()
+        self._update_results_selection_diagnostics()
+        self._persist_workflow_state()
+        self._update_live_label()
+        self._draw_map_preview()
 
     def _open_review_for_result_row(self, row_index: int) -> None:
         if row_index < 0 or row_index >= len(self._records):


### PR DESCRIPTION
### Motivation
- Provide a way to remove one or more marked rows from the mission results table via a context menu (right-click / Ctrl+click). This improves workflow convenience and parity with the points editor which already has a remove action.

### Description
- Bind right-click and Control+click on the results treeview and add a context menu with a "Markierte Einträge entfernen" command. (`transceiver/mission_workflow_ui.py`) 
- Implement `_on_results_table_context_menu` to preserve existing multi-selection, select the clicked row when needed, and show a localized menu label that reflects the selected count. (`transceiver/mission_workflow_ui.py`)
- Implement `_selected_result_row_indices` and `_remove_selected_results` which remove selected records from `self._records`, delete corresponding treeview children, clear selection state, persist the workflow state, refresh the live label and redraw the map preview. (`transceiver/mission_workflow_ui.py`)
- Add small robustness changes around menu popup/cleanup and safe access to `_selected_result_indices`. (`transceiver/mission_workflow_ui.py`)
- Add unit tests and stubs to cover context-menu behavior, selecting on context-click, single/multiple removal, and update an existing test to use the current `askyesnocancel` flow. (`tests/test_mission_workflow_ui.py`)

### Testing
- Ran context-focused tests: `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` and observed `79 passed` for that test module.  
- Ran a filtered set of context/menu tests and helpers (selection and removal): `pytest -q -k 'results_table_context_menu or remove_selected_results or on_results_table_select or on_results_table_click_on_empty_region or on_results_table_double_click'` and observed `6 passed, 73 deselected`.  
- Verified the modified files compile with `python -m py_compile transceiver/mission_workflow_ui.py tests/test_mission_workflow_ui.py`.  
- A full `PYTHONPATH=. pytest -q` invocation still fails during collection due to unrelated pre-existing issues in other test modules (errors in `tests/test_correlation_utils.py`, `tests/test_crosscorr_normalization.py`, and `tests/test_receive_for_mission_threading.py`), but those failures are not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb27bb029c8321b968c2e3ff24aa5b)