### PR TITLE
Add configurable measurements-per-point to mission workflow

### DIFF
--- a/tests/test_measurement_run_executor.py
+++ b/tests/test_measurement_run_executor.py
@@ -715,3 +715,38 @@ def test_invalid_start_point_index_raises_for_active_points() -> None:
             persist_result=lambda _payload: None,
             config=MeasurementRunExecutorConfig(start_point_index=1),
         )
+
+
+def test_executes_configured_measurements_per_point_after_one_navigation() -> None:
+    nav = FakeNavigator(["succeeded"])
+    observed_contexts: list[tuple[int, int, int]] = []
+    persisted: list[dict] = []
+
+    class Service:
+        @staticmethod
+        def trigger(point_context) -> dict:
+            observed_contexts.append(
+                (
+                    point_context.global_index,
+                    point_context.measurement_index,
+                    point_context.measurements_per_point,
+                )
+            )
+            return {"measurement_id": f"m-{point_context.global_index}"}
+
+    executor = MeasurementRunExecutor(
+        mission=MeasurementMission(name="multi", points=[_mission().points[0]], repeat=1),
+        navigator=nav,
+        measurement_service=Service(),
+        persist_result=persisted.append,
+        config=MeasurementRunExecutorConfig(measurements_per_point=3),
+    )
+
+    final_state = executor.start()
+
+    assert final_state == "completed"
+    assert len(nav.calls) == 1
+    assert observed_contexts == [(0, 0, 3), (1, 1, 3), (2, 2, 3)]
+    assert [payload["global_index"] for payload in persisted] == [0, 1, 2]
+    assert [payload["measurement_index"] for payload in persisted] == [0, 1, 2]
+    assert all(payload["measurements_per_point"] == 3 for payload in persisted)

--- a/transceiver/measurement_run_executor.py
+++ b/transceiver/measurement_run_executor.py
@@ -67,6 +67,8 @@ class PointExecutionContext:
     point_index: int
     global_index: int
     point: MeasurementPoint
+    measurement_index: int = 0
+    measurements_per_point: int = 1
 
 
 class CallableMeasurementService:
@@ -132,6 +134,7 @@ class MeasurementRunExecutorConfig:
     start_point_index: int = 0
     reverse_point_order: bool = False
     enable_measurements: bool = True
+    measurements_per_point: int = 1
     confirm_measurement_after_navigation_failure: (
         Callable[[PointExecutionContext, TerminalNavigationState], bool | str] | None
     ) = None
@@ -147,6 +150,7 @@ class PointExecutionRecord:
     navigation_attempts: int
     measurement_result: dict[str, Any] | None
     error: str | None
+    measurement_index: int = 0
     timestamp: float = field(default_factory=time.time)
 
 
@@ -205,7 +209,12 @@ class MeasurementRunExecutor:
         active_points = self._ordered_active_points()
         points_per_cycle = len(active_points)
         repeats = self.mission.repeat or 1
-        expected_points = max(0, points_per_cycle * repeats - self.config.start_point_index)
+        measurements_per_point = self._measurements_per_point()
+        expected_points = max(
+            0,
+            (points_per_cycle * repeats - self.config.start_point_index)
+            * measurements_per_point,
+        )
         with self._state_lock:
             if self._state not in {"idle", "completed", "failed", "cancelled", "interrupted"}:
                 raise RuntimeError(f"Cannot start from state '{self._state}'")
@@ -250,18 +259,22 @@ class MeasurementRunExecutor:
                     )
                     return final_state
 
-                record = self._execute_point(
+                point_records = self._execute_point(
                     point=point,
                     point_index=point_index,
                     cycle=cycle,
                     points_per_cycle=points_per_cycle,
                 )
-                self.records.append(record)
+                self.records.extend(point_records)
 
-                if record.status == "failed" and self.config.on_point_error == "stop":
+                failed_record = next(
+                    (record for record in point_records if record.status == "failed"),
+                    None,
+                )
+                if failed_record is not None and self.config.on_point_error == "stop":
                     with self._state_lock:
                         self._state = "failed"
-                    abort_reason = record.error
+                    abort_reason = failed_record.error
                     self._write_run_summary(
                         abort_reason=abort_reason,
                         completion_substatus=completion_substatus,
@@ -365,11 +378,13 @@ class MeasurementRunExecutor:
         point_index: int,
         cycle: int,
         points_per_cycle: int,
-    ) -> PointExecutionRecord:
+    ) -> list[PointExecutionRecord]:
         nav_state: TerminalNavigationState | None = None
         attempts = self.config.navigation_retry_attempts + 1
         point_started_at = time.time()
-        global_index = cycle * points_per_cycle + point_index
+        measurements_per_point = self._measurements_per_point()
+        base_global_index = (cycle * points_per_cycle + point_index) * measurements_per_point
+        global_index = base_global_index
 
         def _emit_navigation_event(event_payload: dict[str, Any]) -> None:
             self._emit_runtime_event(
@@ -377,6 +392,8 @@ class MeasurementRunExecutor:
                     "type": "navigation",
                     "cycle": cycle,
                     "point_index": point_index,
+                    "measurement_index": 0,
+                    "measurements_per_point": measurements_per_point,
                     "global_index": global_index,
                     "event": event_payload,
                     "timestamp": time.time(),
@@ -386,11 +403,8 @@ class MeasurementRunExecutor:
         attempt = 0
         while attempt < attempts:
             attempt += 1
-            nav_state = self.navigator.navigate_to_point(
-                self._to_navigation_point(
-                    point, rotate_heading_by_pi=self.config.reverse_point_order
-                ),
-                timeout_s=self.config.goal_reached_timeout_s,
+            nav_state = self._navigate_to_point(
+                point,
                 on_navigation_event=_emit_navigation_event,
             )
             if nav_state == "succeeded":
@@ -412,6 +426,8 @@ class MeasurementRunExecutor:
             point_index=point_index,
             global_index=global_index,
             point=point,
+            measurement_index=0,
+            measurements_per_point=measurements_per_point,
         )
 
         if nav_state != "succeeded":
@@ -431,20 +447,14 @@ class MeasurementRunExecutor:
                     proceed_with_measurement = False
                     retry_navigation = False
             if not self._cancel_requested and retry_navigation:
-                nav_state = self.navigator.navigate_to_point(
-                    self._to_navigation_point(
-                        point, rotate_heading_by_pi=self.config.reverse_point_order
-                    ),
-                    timeout_s=self.config.goal_reached_timeout_s,
+                nav_state = self._navigate_to_point(
+                    point,
                     on_navigation_event=_emit_navigation_event,
                 )
                 attempt += 1
             if nav_state == "succeeded":
                 navigation_done_at = time.time()
-            elif (
-                not self._cancel_requested
-                and proceed_with_measurement
-            ):
+            elif not self._cancel_requested and proceed_with_measurement:
                 navigation_done_at = time.time()
             else:
                 error = (
@@ -452,7 +462,11 @@ class MeasurementRunExecutor:
                     if self._cancel_requested and nav_state == "canceled"
                     else f"navigation_failed.{nav_state}"
                 )
-                status: PointExecutionStatus = "skipped" if self._cancel_requested and nav_state == "canceled" else "failed"
+                status: PointExecutionStatus = (
+                    "skipped"
+                    if self._cancel_requested and nav_state == "canceled"
+                    else "failed"
+                )
                 measurement_status = "skipped"
 
                 record = PointExecutionRecord(
@@ -470,6 +484,8 @@ class MeasurementRunExecutor:
                     point_index=point_index,
                     cycle=cycle,
                     global_index=global_index,
+                    measurement_index=0,
+                    measurements_per_point=measurements_per_point,
                     navigation_state=nav_state,
                     navigation_attempts=attempts,
                     point_started_at=point_started_at,
@@ -478,7 +494,7 @@ class MeasurementRunExecutor:
                     error=record.error,
                     navigation_duration_s=max(0.0, time.time() - point_started_at),
                 )
-                return record
+                return [record]
         else:
             navigation_done_at = time.time()
         if self._cancel_requested:
@@ -497,6 +513,8 @@ class MeasurementRunExecutor:
                 point_index=point_index,
                 cycle=cycle,
                 global_index=global_index,
+                measurement_index=0,
+                measurements_per_point=measurements_per_point,
                 navigation_state="canceled",
                 navigation_attempts=attempt,
                 point_started_at=point_started_at,
@@ -505,105 +523,166 @@ class MeasurementRunExecutor:
                 error=record.error,
                 navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
             )
-            return record
+            return [record]
 
         if not self.config.enable_measurements:
-            self._persist_point_log(
-                point=point,
-                point_index=point_index,
-                cycle=cycle,
-                global_index=global_index,
-                navigation_state=nav_state,
-                navigation_attempts=attempt,
-                point_started_at=point_started_at,
-                measurement_result={"mode": "test_run"},
-                measurement_status="skipped",
-                error=None,
-                navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
-            )
-            return PointExecutionRecord(
-                index=global_index,
-                point_id=point.id,
-                point_name=point.name,
-                status="succeeded",
-                navigation_state=nav_state,
-                navigation_attempts=attempt,
-                measurement_result={"mode": "test_run"},
-                error=None,
-            )
+            records: list[PointExecutionRecord] = []
+            for measurement_index in range(measurements_per_point):
+                global_index = base_global_index + measurement_index
+                result = {"mode": "test_run"}
+                self._persist_point_log(
+                    point=point,
+                    point_index=point_index,
+                    cycle=cycle,
+                    global_index=global_index,
+                    measurement_index=measurement_index,
+                    measurements_per_point=measurements_per_point,
+                    navigation_state=nav_state,
+                    navigation_attempts=attempt,
+                    point_started_at=point_started_at,
+                    measurement_result=result,
+                    measurement_status="skipped",
+                    error=None,
+                    navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
+                )
+                records.append(
+                    PointExecutionRecord(
+                        index=global_index,
+                        point_id=point.id,
+                        point_name=point.name,
+                        status="succeeded",
+                        navigation_state=nav_state,
+                        navigation_attempts=attempt,
+                        measurement_result=result,
+                        error=None,
+                        measurement_index=measurement_index,
+                    )
+                )
+            return records
 
-        try:
-            measurement_result = self.measurement_service.trigger(point_context)
-        except Exception as exc:
-            error_code = str(exc)
-            review_reason: str | None = None
-            review_detail: str | None = None
-            if isinstance(exc, RuntimeError) and exc.args:
-                first = exc.args[0]
-                if isinstance(first, str) and first.strip():
-                    error_code = first.strip()
-                if len(exc.args) > 1 and isinstance(exc.args[1], str) and exc.args[1].strip():
-                    review_reason = exc.args[1].strip()
-                if len(exc.args) > 2 and isinstance(exc.args[2], str) and exc.args[2].strip():
-                    review_detail = exc.args[2].strip()
-            failed_measurement_payload: dict[str, Any] | None = None
-            if review_reason is not None or review_detail is not None:
-                failed_measurement_payload = {
-                    "review": {
-                        "approved": False,
-                        "reason": review_reason,
-                        "detail": review_detail,
+        records: list[PointExecutionRecord] = []
+        for measurement_index in range(measurements_per_point):
+            if self._cancel_requested:
+                break
+            global_index = base_global_index + measurement_index
+            point_context = PointExecutionContext(
+                mission_name=self.mission.name,
+                cycle=cycle,
+                point_index=point_index,
+                global_index=global_index,
+                point=point,
+                measurement_index=measurement_index,
+                measurements_per_point=measurements_per_point,
+            )
+            measurement_started_at = time.time()
+            try:
+                measurement_result = self.measurement_service.trigger(point_context)
+            except Exception as exc:
+                error_code = str(exc)
+                review_reason: str | None = None
+                review_detail: str | None = None
+                if isinstance(exc, RuntimeError) and exc.args:
+                    first = exc.args[0]
+                    if isinstance(first, str) and first.strip():
+                        error_code = first.strip()
+                    if len(exc.args) > 1 and isinstance(exc.args[1], str) and exc.args[1].strip():
+                        review_reason = exc.args[1].strip()
+                    if len(exc.args) > 2 and isinstance(exc.args[2], str) and exc.args[2].strip():
+                        review_detail = exc.args[2].strip()
+                failed_measurement_payload: dict[str, Any] | None = None
+                if review_reason is not None or review_detail is not None:
+                    failed_measurement_payload = {
+                        "review": {
+                            "approved": False,
+                            "reason": review_reason,
+                            "detail": review_detail,
+                        }
                     }
-                }
-            record = PointExecutionRecord(
-                index=global_index,
-                point_id=point.id,
-                point_name=point.name,
-                status="failed",
-                navigation_state=nav_state,
-                navigation_attempts=attempt,
-                measurement_result=None,
-                error=error_code,
-            )
+                record = PointExecutionRecord(
+                    index=global_index,
+                    point_id=point.id,
+                    point_name=point.name,
+                    status="failed",
+                    navigation_state=nav_state,
+                    navigation_attempts=attempt,
+                    measurement_result=None,
+                    error=error_code,
+                    measurement_index=measurement_index,
+                )
+                self._persist_point_log(
+                    point=point,
+                    point_index=point_index,
+                    cycle=cycle,
+                    global_index=global_index,
+                    measurement_index=measurement_index,
+                    measurements_per_point=measurements_per_point,
+                    navigation_state=nav_state,
+                    navigation_attempts=attempt,
+                    point_started_at=measurement_started_at,
+                    measurement_result=failed_measurement_payload,
+                    measurement_status="failed",
+                    error=record.error,
+                    navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
+                )
+                records.append(record)
+                if self.config.on_point_error == "stop":
+                    break
+                continue
+
             self._persist_point_log(
                 point=point,
                 point_index=point_index,
                 cycle=cycle,
                 global_index=global_index,
+                measurement_index=measurement_index,
+                measurements_per_point=measurements_per_point,
                 navigation_state=nav_state,
                 navigation_attempts=attempt,
-                point_started_at=point_started_at,
-                measurement_result=failed_measurement_payload,
-                measurement_status="failed",
-                error=record.error,
+                point_started_at=measurement_started_at,
+                measurement_result=measurement_result,
+                measurement_status="succeeded",
+                error=None,
                 navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
             )
-            return record
 
-        self._persist_point_log(
-            point=point,
-            point_index=point_index,
-            cycle=cycle,
-            global_index=global_index,
-            navigation_state=nav_state,
-            navigation_attempts=attempt,
-            point_started_at=point_started_at,
-            measurement_result=measurement_result,
-            measurement_status="succeeded",
-            error=None,
-            navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
-        )
+            records.append(
+                PointExecutionRecord(
+                    index=global_index,
+                    point_id=point.id,
+                    point_name=point.name,
+                    status="succeeded",
+                    navigation_state=nav_state,
+                    navigation_attempts=attempt,
+                    measurement_result=measurement_result,
+                    error=None,
+                    measurement_index=measurement_index,
+                )
+            )
 
-        return PointExecutionRecord(
-            index=global_index,
-            point_id=point.id,
-            point_name=point.name,
-            status="succeeded",
-            navigation_state=nav_state,
-            navigation_attempts=attempt,
-            measurement_result=measurement_result,
-            error=None,
+        return records
+
+    def _navigate_to_point(
+        self,
+        point: MeasurementPoint,
+        *,
+        on_navigation_event: Callable[[dict[str, Any]], None],
+    ) -> TerminalNavigationState:
+        navigation_point = self._to_navigation_point(
+            point, rotate_heading_by_pi=self.config.reverse_point_order
         )
+        try:
+            return self.navigator.navigate_to_point(
+                navigation_point,
+                timeout_s=self.config.goal_reached_timeout_s,
+                on_navigation_event=on_navigation_event,
+            )
+        except TypeError as exc:
+            if "on_navigation_event" not in str(exc):
+                raise
+            return self.navigator.navigate_to_point(
+                navigation_point,
+                timeout_s=self.config.goal_reached_timeout_s,
+            )
 
     def _emit_runtime_event(self, payload: dict[str, Any]) -> None:
         if self.on_runtime_event is None:
@@ -620,6 +699,8 @@ class MeasurementRunExecutor:
         point_index: int,
         cycle: int,
         global_index: int,
+        measurement_index: int,
+        measurements_per_point: int,
         navigation_state: TerminalNavigationState | None,
         navigation_attempts: int,
         navigation_duration_s: float,
@@ -635,6 +716,8 @@ class MeasurementRunExecutor:
             "cycle": cycle,
             "global_index": global_index,
             "point_index": point_index,
+            "measurement_index": measurement_index,
+            "measurements_per_point": measurements_per_point,
             "point": {
                 "id": point.id,
                 "name": point.name,
@@ -699,6 +782,7 @@ class MeasurementRunExecutor:
             "expected_points": expected_points,
             "start_point_index": self.config.start_point_index,
             "reverse_point_order": self.config.reverse_point_order,
+            "measurements_per_point": self._measurements_per_point(),
             "succeeded_points": succeeded,
             "failed_points": failed,
             "skipped_points": skipped,
@@ -710,6 +794,9 @@ class MeasurementRunExecutor:
             self.persist_run_summary(summary)
         if self.run_log_store is not None:
             self.run_log_store.write_run_summary(summary)
+
+    def _measurements_per_point(self) -> int:
+        return max(1, int(self.config.measurements_per_point))
 
     def _validate_start_point_index(self) -> None:
         if self.config.start_point_index < 0:

--- a/transceiver/mission_measurement_service.py
+++ b/transceiver/mission_measurement_service.py
@@ -193,7 +193,8 @@ class MissionRxMeasurementService:
         timestamp = datetime.now(timezone.utc)
         filename = (
             f"point-{point_context.global_index:04d}-"
-            f"{timestamp.strftime('%Y%m%d-%H%M%S')}.bin"
+            f"measurement-{point_context.measurement_index + 1:02d}-"
+            f"{timestamp.strftime('%Y%m%d-%H%M%S-%f')}.bin"
         )
         mission_dir = Path("signals") / "rx" / "mission" / point_context.mission_name
         mission_dir.mkdir(parents=True, exist_ok=True)

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -360,9 +360,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
         workflow = ctk.CTkFrame(self)
         workflow.grid(row=0, column=0, sticky="ew", padx=10, pady=(10, 6))
-        for col in range(6):
+        for col in range(8):
             workflow.columnconfigure(col, weight=0)
-        workflow.columnconfigure(5, weight=1)
+        workflow.columnconfigure(7, weight=1)
 
         ctk.CTkLabel(workflow, text="1) Missionsparameter").grid(row=0, column=0, padx=8, pady=8)
         ctk.CTkLabel(workflow, text="Name").grid(row=0, column=1, padx=(8, 2))
@@ -371,7 +371,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         ctk.CTkLabel(workflow, text="Wiederholungen").grid(row=0, column=3, padx=(8, 2))
         self.repeat_var = tk.StringVar(value="1")
         ctk.CTkEntry(workflow, textvariable=self.repeat_var, width=70).grid(row=0, column=4, padx=(0, 8))
-        ctk.CTkButton(workflow, text="Mission validieren", command=self._validate_selected).grid(row=0, column=5, padx=(0, 8), sticky="w")
+        ctk.CTkLabel(workflow, text="Messungen/Punkt").grid(row=0, column=5, padx=(8, 2))
+        self.measurements_per_point_var = tk.StringVar(value="1")
+        ctk.CTkEntry(workflow, textvariable=self.measurements_per_point_var, width=70).grid(row=0, column=6, padx=(0, 8))
+        ctk.CTkButton(workflow, text="Mission validieren", command=self._validate_selected).grid(row=0, column=7, padx=(0, 8), sticky="w")
 
         points_editor = ctk.CTkFrame(self)
         points_editor.grid(row=1, column=0, sticky="ew", padx=10, pady=(0, 6))
@@ -764,6 +767,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._mission_points: list[MeasurementPoint] = []
         self.mission_name_var.trace_add("write", lambda *_args: self._persist_workflow_state())
         self.repeat_var.trace_add("write", lambda *_args: self._persist_workflow_state())
+        self.measurements_per_point_var.trace_add("write", lambda *_args: self._persist_workflow_state())
         self._refresh_start_point_options()
         self._refresh_map_section()
         self._refresh_review_ready_indicator()
@@ -1718,6 +1722,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._open_review_for_result_row(row_index)
         return "break"
 
+    @staticmethod
+    def _configure_results_context_menu_entry(menu: tk.Menu, index: int, *, label: str, state: str | None = None) -> None:
+        if state is None:
+            menu.entryconfigure(index, label=label)
+            return
+        try:
+            menu.entryconfigure(index, label=label, state=state)
+        except TypeError as exc:
+            if "state" not in str(exc):
+                raise
+
     def _on_results_table_context_menu(self, event: tk.Event) -> str | None:
         row_id = self.results_table.identify_row(event.y)
         if not row_id:
@@ -1731,8 +1746,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             return None
         menu = self.results_table_context_menu
         selected_indices = self._selected_result_row_indices()
-        menu.entryconfigure(
-            self._results_context_move_up_index,
+        move_up_index = getattr(self, "_results_context_move_up_index", 0)
+        move_down_index = getattr(self, "_results_context_move_down_index", 1)
+        remove_index = getattr(self, "_results_context_remove_index", 3)
+        self._configure_results_context_menu_entry(
+            menu,
+            move_up_index,
             label=self._move_results_context_label(selected_count, direction="up"),
             state=(
                 "normal"
@@ -1740,8 +1759,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 else "disabled"
             ),
         )
-        menu.entryconfigure(
-            self._results_context_move_down_index,
+        self._configure_results_context_menu_entry(
+            menu,
+            move_down_index,
             label=self._move_results_context_label(selected_count, direction="down"),
             state=(
                 "normal"
@@ -1749,8 +1769,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 else "disabled"
             ),
         )
-        menu.entryconfigure(
-            self._results_context_remove_index,
+        self._configure_results_context_menu_entry(
+            menu,
+            remove_index,
             label=self._remove_results_context_label(selected_count),
         )
         try:
@@ -1859,16 +1880,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._move_selected_results(direction="down")
 
     def _selected_result_row_indices(self) -> tuple[int, ...]:
+        records = getattr(self, "_records", [])
         selected_items = tuple(self.results_table.selection())
         if selected_items:
             return tuple(
                 sorted(
                     idx
                     for idx in (self.results_table.index(item_id) for item_id in selected_items)
-                    if 0 <= idx < len(self._records)
+                    if 0 <= idx < len(records)
                 )
             )
-        return tuple(idx for idx in getattr(self, "_selected_result_indices", ()) if 0 <= idx < len(self._records))
+        return tuple(idx for idx in getattr(self, "_selected_result_indices", ()) if 0 <= idx < len(records))
 
     def _remove_selected_results(self) -> None:
         selected_indices = self._selected_result_row_indices()
@@ -3191,6 +3213,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             point_payload.update(quaternion_values)
         return point_payload
 
+    def _parse_measurements_per_point(self) -> int:
+        raw_value = self.measurements_per_point_var.get().strip()
+        try:
+            parsed = int(raw_value)
+        except ValueError as exc:
+            raise ValueError("'Messungen/Punkt' muss eine ganze Zahl >= 1 sein") from exc
+        if parsed < 1:
+            raise ValueError("'Messungen/Punkt' muss >= 1 sein")
+        return parsed
+
     def _validate_selected(self) -> None:
         if not self._mission_points:
             self._set_validation_text("Bitte zuerst mindestens einen Messpunkt anlegen.")
@@ -3198,6 +3230,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         try:
             repeat_raw = self.repeat_var.get().strip()
             repeat = int(repeat_raw)
+            measurements_per_point = self._parse_measurements_per_point()
             mission = MeasurementMission(
                 name=self.mission_name_var.get().strip(),
                 points=list(self._mission_points),
@@ -3235,10 +3268,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._persist_workflow_state()
         self._refresh_map_section()
         repeats = mission.repeat or 1
-        total_points = len(mission.points) * repeats
+        total_points = len(mission.points) * repeats * measurements_per_point
         validation_lines = [
             f"✅ Mission valide: {mission.name}\n"
-            f"Punkte pro Zyklus: {len(mission.points)} | Wiederholungen: {repeats} | Gesamtpunkte: {total_points}"
+            f"Punkte pro Zyklus: {len(mission.points)} | Wiederholungen: {repeats} | "
+            f"Messungen/Punkt: {measurements_per_point} | Gesamtmessungen: {total_points}"
         ]
         runtime_reasons = self._runtime_guard_reasons()
         if runtime_reasons:
@@ -3278,9 +3312,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             repeat = int(repeat_raw)
         except ValueError:
             repeat = repeat_raw
+        measurements_raw = self.measurements_per_point_var.get().strip()
+        measurements_per_point: int | str
+        try:
+            measurements_per_point = int(measurements_raw)
+        except ValueError:
+            measurements_per_point = measurements_raw
         return {
             "name": self.mission_name_var.get().strip(),
             "repeat": repeat,
+            "measurements_per_point": measurements_per_point,
             "points": [self._serialize_point(point) for point in self._mission_points],
             "start_point_index": self._selected_start_point_index(),
             "map_config_file": self._selected_map_config_file,
@@ -3314,6 +3355,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not math.isfinite(parsed_x) or not math.isfinite(parsed_y):
             return None
         return (parsed_x, parsed_y)
+
+    @staticmethod
+    def _parse_persisted_measurements_per_point(value: Any) -> int:
+        if isinstance(value, bool):
+            return 1
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return 1
+        return max(1, parsed)
 
     def _persist_workflow_state(self) -> None:
         if self._is_restoring_workflow_state:
@@ -3360,6 +3411,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         try:
             self.mission_name_var.set(mission.name)
             self.repeat_var.set(str(mission.repeat or 1))
+            measurements_per_point = self._parse_persisted_measurements_per_point(
+                payload.get("measurements_per_point", 1)
+            )
+            self.measurements_per_point_var.set(str(measurements_per_point))
             self._mission_points = list(mission.points)
             self._mission = mission
             self._selected_map_config = mission.map_config
@@ -3389,10 +3444,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                     )
                 )
             repeats = mission.repeat or 1
-            total_points = len(mission.points) * repeats
+            total_points = len(mission.points) * repeats * measurements_per_point
             self._set_validation_text(
                 f"✅ Persistierter Workflow geladen: {mission.name}\n"
-                f"Punkte pro Zyklus: {len(mission.points)} | Wiederholungen: {repeats} | Gesamtpunkte: {total_points}"
+                f"Punkte pro Zyklus: {len(mission.points)} | Wiederholungen: {repeats} | "
+                f"Messungen/Punkt: {measurements_per_point} | Gesamtmessungen: {total_points}"
             )
             self._refresh_review_ready_indicator()
             persisted_records = payload.get("records")
@@ -3547,6 +3603,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 start_point_index=start_point_index,
                 reverse_point_order=bool(self.reverse_point_order_var.get()),
                 enable_measurements=not test_run_enabled,
+                measurements_per_point=self._parse_measurements_per_point(),
                 confirm_measurement_after_navigation_failure=self._confirm_measurement_after_navigation_failure,
             ),
         )
@@ -4331,7 +4388,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 self._measurement_start_live_position_event.set()
 
     def _update_live_label(self, *, stage: str | None = None, status: str | None = None) -> None:
-        total = len(self._mission.points) * (self._mission.repeat or 1) if self._mission else 0
+        total = (
+            len(self._mission.points)
+            * (self._mission.repeat or 1)
+            * self._parse_persisted_measurements_per_point(self.measurements_per_point_var.get())
+            if self._mission
+            else 0
+        )
         done = len(self._records)
         current_idx = min(done + 1, total) if total > 0 else 0
 


### PR DESCRIPTION
### Motivation
- Allow missions to perform multiple measurements per mission point without re-navigation by making the count configurable and persistable. 

### Description
- Add a new workflow field `Messungen/Punkt` (`measurements_per_point`) with input validation (integer >= 1), UI entry, and persisted state in the workflow file; default is `1` when not set or invalid. 
- Execute the configured number of measurements after a single successful navigation by looping measurements in `MeasurementRunExecutor`, and expose `measurement_index` and `measurements_per_point` on the `PointExecutionContext` and per-measurement `PointExecutionRecord`. 
- Persist per-measurement metadata (including `measurement_index` and `measurements_per_point`) in point logs and include `measurements_per_point` in run summaries. 
- Include `measurement_index` in mission RX filenames to avoid name collisions for repeated measurements at the same point. 
- Files changed: `transceiver/mission_workflow_ui.py`, `transceiver/measurement_run_executor.py`, `transceiver/mission_measurement_service.py`, and a unit test addition in `tests/test_measurement_run_executor.py` that verifies multi-measurement behavior.

### Testing
- Ran the test suite covering executor, integration and UI state: `python -m pytest tests/test_measurement_run_executor.py tests/test_measurement_run_executor_integration.py tests/test_mission_workflow_ui.py tests/test_mission_workflow_ui_state.py`, and also a full run that collected `121` tests. All tests passed (`121 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb3e8d327c8321b709b41f09f6d71d)