### PR TITLE
Place clear results button beside scrollbar

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -749,17 +749,20 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             command=self._remove_selected_results,
         )
         self.results_selection_diagnostics_var = tk.StringVar(value="Auswahl: 0 Zeilen")
+        results_footer = ctk.CTkFrame(table_frame, fg_color="transparent")
+        results_footer.grid(row=1, column=0, sticky="ew", pady=(4, 0))
+        results_footer.columnconfigure(0, weight=1)
         ctk.CTkLabel(
-            table_frame,
+            results_footer,
             textvariable=self.results_selection_diagnostics_var,
             anchor="w",
             justify="left",
-        ).grid(row=1, column=0, sticky="ew", padx=(2, 0), pady=(4, 0))
+        ).grid(row=0, column=0, sticky="ew", padx=(2, 0))
         ctk.CTkButton(
-            table_frame,
+            results_footer,
             text="Ergebnisliste leeren",
             command=self._clear_results_table,
-        ).grid(row=1, column=1, sticky="e", padx=(8, 0), pady=(4, 0))
+        ).grid(row=0, column=1, sticky="e", padx=(8, 0))
 
         self._mission_points: list[MeasurementPoint] = []
         self.mission_name_var.trace_add("write", lambda *_args: self._persist_workflow_state())


### PR DESCRIPTION
### Motivation
- Prevent the "Ergebnisliste leeren" button from forcing the width of the vertical scrollbar and improve the footer layout so the diagnostics label sits left and the clear button is directly left of the scrollbar.

### Description
- Create a new footer frame `results_footer` inside the table column and move the selection diagnostics label and the clear button into it in `transceiver/mission_workflow_ui.py`.
- Configure `results_footer.columnconfigure(0, weight=1)` so the diagnostics label expands and the button is aligned to the right next to the scrollbar.
- Adjust the grid coordinates for the moved widgets so the scrollbar remains in column 1 and the footer occupies column 0 under the table.

### Testing
- Ran `python -m py_compile transceiver/mission_workflow_ui.py` which succeeded. 
- Ran `python -m pytest tests/test_mission_workflow_ui.py tests/test_mission_workflow_ui_state.py` which produced `89 passed, 2 failed`; the two failures are `test_on_results_table_context_menu_keeps_existing_multiselect_for_selected_row` and `test_on_results_table_context_menu_selects_unselected_row` and fail with `AttributeError: 'MissionWorkflowWindow' object has no attribute '_records'` when tests instantiate `MissionWorkflowWindow` via `__new__` without setting `_records`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb3f0875648321a7cb25da029479bf)