### PR TITLE
Add per-point mission measurement count

### DIFF
--- a/tests/test_measurement_run_executor.py
+++ b/tests/test_measurement_run_executor.py
@@ -715,3 +715,66 @@ def test_invalid_start_point_index_raises_for_active_points() -> None:
             persist_result=lambda _payload: None,
             config=MeasurementRunExecutorConfig(start_point_index=1),
         )
+
+
+def test_measurements_per_point_triggers_multiple_measurements_after_single_navigation() -> None:
+    nav = FakeNavigator(["succeeded", "succeeded"])
+    observed_contexts: list[tuple[int, int, str | None]] = []
+    persisted: list[dict] = []
+
+    class ContextRecordingMeasurementService:
+        def trigger(self, point_context) -> dict:
+            observed_contexts.append(
+                (
+                    point_context.global_index,
+                    point_context.measurement_index,
+                    point_context.point.id,
+                )
+            )
+            return {
+                "measurement_id": f"{point_context.point.id}-{point_context.measurement_index}",
+                "measurement_index": point_context.measurement_index,
+            }
+
+    executor = MeasurementRunExecutor(
+        mission=_mission(),
+        navigator=nav,
+        measurement_service=ContextRecordingMeasurementService(),
+        persist_result=persisted.append,
+        config=MeasurementRunExecutorConfig(measurements_per_point=3),
+    )
+
+    final_state = executor.start()
+
+    assert final_state == "completed"
+    assert [item[0:2] for item in nav.calls] == [(1.0, 2.0), (3.0, 4.0)]
+    assert observed_contexts == [
+        (0, 0, "p1"),
+        (0, 1, "p1"),
+        (0, 2, "p1"),
+        (1, 0, "p2"),
+        (1, 1, "p2"),
+        (1, 2, "p2"),
+    ]
+    assert len(persisted) == 6
+    assert [payload["measurement_index"] for payload in persisted] == [0, 1, 2, 0, 1, 2]
+    assert all(payload["measurements_per_point"] == 3 for payload in persisted)
+    assert executor.records[0].measurement_result == {
+        "measurements_per_point": 3,
+        "measurements": [
+            {"measurement_id": "p1-0", "measurement_index": 0},
+            {"measurement_id": "p1-1", "measurement_index": 1},
+            {"measurement_id": "p1-2", "measurement_index": 2},
+        ],
+    }
+
+
+def test_measurements_per_point_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="measurements_per_point"):
+        MeasurementRunExecutor(
+            mission=_mission(),
+            navigator=FakeNavigator(["succeeded"]),
+            trigger_measurement=lambda point: {},
+            persist_result=lambda payload: None,
+            config=MeasurementRunExecutorConfig(measurements_per_point=0),
+        )

--- a/tests/test_mission_workflow_ui_state.py
+++ b/tests/test_mission_workflow_ui_state.py
@@ -202,3 +202,11 @@ def test_save_and_load_json_dict_preserves_mission_result_records(tmp_path) -> N
     loaded = _load_json_dict(state_file)
 
     assert loaded["records"] == payload["records"]
+
+
+def test_parse_positive_int_defaults_invalid_measurements_per_point() -> None:
+    from transceiver.mission_workflow_ui import _parse_positive_int
+
+    assert _parse_positive_int("3", default=1) == 3
+    assert _parse_positive_int("0", default=1) == 1
+    assert _parse_positive_int("invalid", default=1) == 1

--- a/transceiver/measurement_run_executor.py
+++ b/transceiver/measurement_run_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import math
 import threading
 import time
@@ -67,6 +68,8 @@ class PointExecutionContext:
     point_index: int
     global_index: int
     point: MeasurementPoint
+    measurement_index: int = 0
+    measurements_per_point: int = 1
 
 
 class CallableMeasurementService:
@@ -107,7 +110,19 @@ class JsonRunLogStore:
         point = payload["point"]
         global_index = payload.get("global_index", 0)
         point_id = point.get("id") or point.get("name") or f"point-{global_index}"
-        filename = f"point-{global_index:04d}-{_sanitize_filename(str(point_id))}.json"
+        measurement_index = payload.get("measurement_index")
+        measurement_suffix = (
+            f"-measurement-{measurement_index + 1:02d}"
+            if (
+                isinstance(measurement_index, int)
+                and payload.get("measurements_per_point", 1) != 1
+            )
+            else ""
+        )
+        filename = (
+            f"point-{global_index:04d}-"
+            f"{_sanitize_filename(str(point_id))}{measurement_suffix}.json"
+        )
         (self.directory / filename).write_text(
             json.dumps(payload, indent=2, ensure_ascii=False),
             encoding="utf-8",
@@ -132,6 +147,7 @@ class MeasurementRunExecutorConfig:
     start_point_index: int = 0
     reverse_point_order: bool = False
     enable_measurements: bool = True
+    measurements_per_point: int = 1
     confirm_measurement_after_navigation_failure: (
         Callable[[PointExecutionContext, TerminalNavigationState], bool | str] | None
     ) = None
@@ -185,6 +201,7 @@ class MeasurementRunExecutor:
         self.run_log_store = run_log_store
         self.on_runtime_event = on_runtime_event
         self.config = config or MeasurementRunExecutorConfig()
+        self._validate_measurements_per_point()
         self._validate_start_point_index()
 
         self._state: ExecutorState = "idle"
@@ -386,11 +403,8 @@ class MeasurementRunExecutor:
         attempt = 0
         while attempt < attempts:
             attempt += 1
-            nav_state = self.navigator.navigate_to_point(
-                self._to_navigation_point(
-                    point, rotate_heading_by_pi=self.config.reverse_point_order
-                ),
-                timeout_s=self.config.goal_reached_timeout_s,
+            nav_state = self._navigate_to_point(
+                point,
                 on_navigation_event=_emit_navigation_event,
             )
             if nav_state == "succeeded":
@@ -431,11 +445,8 @@ class MeasurementRunExecutor:
                     proceed_with_measurement = False
                     retry_navigation = False
             if not self._cancel_requested and retry_navigation:
-                nav_state = self.navigator.navigate_to_point(
-                    self._to_navigation_point(
-                        point, rotate_heading_by_pi=self.config.reverse_point_order
-                    ),
-                    timeout_s=self.config.goal_reached_timeout_s,
+                nav_state = self._navigate_to_point(
+                    point,
                     on_navigation_event=_emit_navigation_event,
                 )
                 attempt += 1
@@ -533,7 +544,59 @@ class MeasurementRunExecutor:
             )
 
         try:
-            measurement_result = self.measurement_service.trigger(point_context)
+            measurement_results: list[dict[str, Any]] = []
+            for measurement_index in range(self.config.measurements_per_point):
+                if measurement_index > 0 and not self._wait_until_resumed_or_stopped():
+                    record = PointExecutionRecord(
+                        index=global_index,
+                        point_id=point.id,
+                        point_name=point.name,
+                        status="skipped",
+                        navigation_state="canceled",
+                        navigation_attempts=attempt,
+                        measurement_result=None,
+                        error="run_cancelled.manual_stop",
+                    )
+                    self._persist_point_log(
+                        point=point,
+                        point_index=point_index,
+                        cycle=cycle,
+                        global_index=global_index,
+                        navigation_state="canceled",
+                        navigation_attempts=attempt,
+                        point_started_at=point_started_at,
+                        measurement_result=None,
+                        measurement_status="skipped",
+                        error=record.error,
+                        navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
+                        measurement_index=measurement_index,
+                    )
+                    return record
+                point_context = PointExecutionContext(
+                    mission_name=self.mission.name,
+                    cycle=cycle,
+                    point_index=point_index,
+                    global_index=global_index,
+                    point=point,
+                    measurement_index=measurement_index,
+                    measurements_per_point=self.config.measurements_per_point,
+                )
+                measurement_result = self.measurement_service.trigger(point_context)
+                measurement_results.append(measurement_result)
+                self._persist_point_log(
+                    point=point,
+                    point_index=point_index,
+                    cycle=cycle,
+                    global_index=global_index,
+                    navigation_state=nav_state,
+                    navigation_attempts=attempt,
+                    point_started_at=point_started_at,
+                    measurement_result=measurement_result,
+                    measurement_status="succeeded",
+                    error=None,
+                    navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
+                    measurement_index=measurement_index,
+                )
         except Exception as exc:
             error_code = str(exc)
             review_reason: str | None = None
@@ -577,22 +640,18 @@ class MeasurementRunExecutor:
                 measurement_status="failed",
                 error=record.error,
                 navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
+                measurement_index=getattr(point_context, "measurement_index", 0),
             )
             return record
 
-        self._persist_point_log(
-            point=point,
-            point_index=point_index,
-            cycle=cycle,
-            global_index=global_index,
-            navigation_state=nav_state,
-            navigation_attempts=attempt,
-            point_started_at=point_started_at,
-            measurement_result=measurement_result,
-            measurement_status="succeeded",
-            error=None,
-            navigation_duration_s=max(0.0, navigation_done_at - point_started_at),
-        )
+        aggregate_measurement_result: dict[str, Any]
+        if len(measurement_results) == 1:
+            aggregate_measurement_result = measurement_results[0]
+        else:
+            aggregate_measurement_result = {
+                "measurements_per_point": self.config.measurements_per_point,
+                "measurements": measurement_results,
+            }
 
         return PointExecutionRecord(
             index=global_index,
@@ -601,8 +660,40 @@ class MeasurementRunExecutor:
             status="succeeded",
             navigation_state=nav_state,
             navigation_attempts=attempt,
-            measurement_result=measurement_result,
+            measurement_result=aggregate_measurement_result,
             error=None,
+        )
+
+    def _navigate_to_point(
+        self,
+        point: MeasurementPoint,
+        *,
+        on_navigation_event: Callable[[dict[str, Any]], None] | None,
+    ) -> TerminalNavigationState:
+        navigation_point = self._to_navigation_point(
+            point, rotate_heading_by_pi=self.config.reverse_point_order
+        )
+        navigate_to_point = self.navigator.navigate_to_point
+        try:
+            signature = inspect.signature(navigate_to_point)
+            accepts_runtime_events = (
+                "on_navigation_event" in signature.parameters
+                or any(
+                    parameter.kind == inspect.Parameter.VAR_KEYWORD
+                    for parameter in signature.parameters.values()
+                )
+            )
+        except (TypeError, ValueError):
+            accepts_runtime_events = True
+        if accepts_runtime_events:
+            return navigate_to_point(
+                navigation_point,
+                timeout_s=self.config.goal_reached_timeout_s,
+                on_navigation_event=on_navigation_event,
+            )
+        return navigate_to_point(
+            navigation_point,
+            timeout_s=self.config.goal_reached_timeout_s,
         )
 
     def _emit_runtime_event(self, payload: dict[str, Any]) -> None:
@@ -627,6 +718,7 @@ class MeasurementRunExecutor:
         measurement_result: dict[str, Any] | None,
         measurement_status: str,
         error: str | None,
+        measurement_index: int = 0,
     ) -> None:
         point_ended_at = time.time()
         measurement_payload = deepcopy(measurement_result)
@@ -664,6 +756,8 @@ class MeasurementRunExecutor:
                 "timeout_s": self.config.goal_reached_timeout_s,
                 "duration_s": navigation_duration_s,
             },
+            "measurement_index": measurement_index,
+            "measurements_per_point": self.config.measurements_per_point,
             "measurement": {
                 "status": measurement_status,
                 "id": _extract_measurement_id(measurement_payload),
@@ -699,6 +793,7 @@ class MeasurementRunExecutor:
             "expected_points": expected_points,
             "start_point_index": self.config.start_point_index,
             "reverse_point_order": self.config.reverse_point_order,
+            "measurements_per_point": self.config.measurements_per_point,
             "succeeded_points": succeeded,
             "failed_points": failed,
             "skipped_points": skipped,
@@ -710,6 +805,10 @@ class MeasurementRunExecutor:
             self.persist_run_summary(summary)
         if self.run_log_store is not None:
             self.run_log_store.write_run_summary(summary)
+
+    def _validate_measurements_per_point(self) -> None:
+        if self.config.measurements_per_point < 1:
+            raise ValueError("measurements_per_point must be >= 1")
 
     def _validate_start_point_index(self) -> None:
         if self.config.start_point_index < 0:

--- a/transceiver/mission_measurement_service.py
+++ b/transceiver/mission_measurement_service.py
@@ -191,9 +191,14 @@ class MissionRxMeasurementService:
     def trigger(self, point_context: PointExecutionContext) -> dict[str, Any]:
         self._on_status("measurement", "running")
         timestamp = datetime.now(timezone.utc)
+        measurement_suffix = (
+            f"-measurement-{point_context.measurement_index + 1:02d}"
+            if point_context.measurements_per_point > 1
+            else ""
+        )
         filename = (
-            f"point-{point_context.global_index:04d}-"
-            f"{timestamp.strftime('%Y%m%d-%H%M%S')}.bin"
+            f"point-{point_context.global_index:04d}{measurement_suffix}-"
+            f"{timestamp.strftime('%Y%m%d-%H%M%S-%f')}.bin"
         )
         mission_dir = Path("signals") / "rx" / "mission" / point_context.mission_name
         mission_dir.mkdir(parents=True, exist_ok=True)
@@ -296,7 +301,12 @@ class MissionRxMeasurementService:
 
         self._on_status("measurement", "succeeded")
         payload = {
-            "measurement_id": f"{point_context.mission_name}-{point_context.global_index:04d}-{int(timestamp.timestamp())}",
+            "measurement_id": (
+                f"{point_context.mission_name}-{point_context.global_index:04d}-"
+                f"{point_context.measurement_index + 1:02d}-{int(timestamp.timestamp())}"
+            ),
+            "measurement_index": point_context.measurement_index,
+            "measurements_per_point": point_context.measurements_per_point,
             "file_ref": file_ref,
             "point_id": point_context.point.id,
             "timestamp": timestamp.isoformat(),

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -86,6 +86,14 @@ def _save_json_dict(path: Path, payload: dict[str, Any]) -> None:
         return
 
 
+def _parse_positive_int(value: Any, *, default: int = 1) -> int:
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 1 else default
+
+
 def _map_executor_state_to_ui_text(state: str, completion_substatus: str | None = None) -> str:
     mapping = {
         "completed": "Abgeschlossen",
@@ -341,6 +349,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.lidar_reference_enabled_var = tk.BooleanVar(value=True)
         self.manual_review_enabled_var = tk.BooleanVar(value=True)
         self.test_run_enabled_var = tk.BooleanVar(value=False)
+        self.measurements_per_point_var = tk.StringVar(value="1")
         self.manual_navigation_enabled_var = tk.BooleanVar(value=False)
         self.live_pose_stream_enabled_var = tk.BooleanVar(value=False)
         self.live_preview_enabled_var = tk.BooleanVar(value=False)
@@ -583,9 +592,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
         controls = ctk.CTkFrame(side_panel)
         controls.grid(row=2, column=0, sticky="ew", padx=0, pady=0)
-        for col in range(5):
+        for col in range(6):
             controls.columnconfigure(col, weight=0)
-        controls.columnconfigure(4, weight=1)
+        controls.columnconfigure(5, weight=1)
         controls.rowconfigure(3, weight=1)
 
         ctk.CTkLabel(controls, text="5) Laufsteuerung").grid(row=0, column=0, columnspan=5, sticky="w", padx=8, pady=(8, 4))
@@ -612,6 +621,15 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             command=lambda _value: self._persist_workflow_state(),
         )
         self.start_point_combo.grid(row=1, column=3, columnspan=2, padx=(0, 8), pady=(0, 4), sticky="w")
+        measurements_frame = ctk.CTkFrame(controls, fg_color="transparent")
+        measurements_frame.grid(row=1, column=5, padx=(10, 8), pady=(0, 4), sticky="w")
+        ctk.CTkLabel(measurements_frame, text="Messungen/Punkt").grid(row=0, column=0, padx=(0, 4), sticky="e")
+        ctk.CTkEntry(
+            measurements_frame,
+            textvariable=self.measurements_per_point_var,
+            width=56,
+            validatecommand=(self.register(self._validate_positive_integer_input), "%P"),
+        ).grid(row=0, column=1, sticky="w")
         self.reverse_point_order_var = tk.BooleanVar(value=False)
         ctk.CTkCheckBox(
             controls,
@@ -767,6 +785,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._mission_points: list[MeasurementPoint] = []
         self.mission_name_var.trace_add("write", lambda *_args: self._persist_workflow_state())
         self.repeat_var.trace_add("write", lambda *_args: self._persist_workflow_state())
+        self.measurements_per_point_var.trace_add("write", lambda *_args: self._persist_workflow_state())
         self._refresh_start_point_options()
         self._refresh_map_section()
         self._refresh_review_ready_indicator()
@@ -1797,8 +1816,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             error_text = f"{error_text}: {review_detail}" if error_text else review_detail
         combined_status = self._compose_table_outcome(payload, error_text)
         echo_distances = self._format_echo_distances_for_table(result.get("echo_delays"))
+        measurement_label = self._format_one_based_index(payload.get("global_index"))
+        measurement_index = payload.get("measurement_index")
+        measurements_per_point = payload.get("measurements_per_point")
+        if (
+            isinstance(measurement_index, int)
+            and isinstance(measurements_per_point, int)
+            and measurements_per_point > 1
+        ):
+            measurement_label = f"{measurement_label}.{measurement_index + 1}"
         return (
-            self._format_one_based_index(payload.get("global_index")),
+            measurement_label,
             self._format_one_based_index(payload.get("point_index")),
             self._format_live_position_for_table(payload),
             self._format_live_distance_to_rx_for_table(payload),
@@ -3286,6 +3314,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "repeat": repeat,
             "points": [self._serialize_point(point) for point in self._mission_points],
             "start_point_index": self._selected_start_point_index(),
+            "measurements_per_point": _parse_positive_int(
+                self.measurements_per_point_var.get(), default=1
+            ),
             "map_config_file": self._selected_map_config_file,
             "rx_antenna_global_position": self._serialize_rx_antenna_global_position(),
             "lidar_reference_enabled": bool(self.lidar_reference_enabled_var.get()),
@@ -3375,6 +3406,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self.lidar_reference_enabled_var.set(bool(payload.get("lidar_reference_enabled", True)))
             self.manual_review_enabled_var.set(bool(payload.get("manual_review_enabled", True)))
             self.test_run_enabled_var.set(bool(payload.get("test_run_enabled", False)))
+            self.measurements_per_point_var.set(
+                str(_parse_positive_int(payload.get("measurements_per_point", 1), default=1))
+            )
             self.manual_navigation_enabled_var.set(bool(payload.get("manual_navigation_enabled", False)))
             self.reverse_point_order_var.set(bool(payload.get("reverse_point_order", False)))
             self.live_pose_stream_enabled_var.set(bool(payload.get("live_pose_stream_enabled", False)))
@@ -3489,6 +3523,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             )
             self._append_validation("❌ Run-Start blockiert: " + " | ".join(reasons))
             return
+        measurements_per_point = _parse_positive_int(self.measurements_per_point_var.get(), default=1)
+        if self.measurements_per_point_var.get().strip() != str(measurements_per_point):
+            self.measurements_per_point_var.set(str(measurements_per_point))
         test_run_enabled = self._is_test_run_enabled()
         if not test_run_enabled and not self._ensure_transmitter_before_run():
             return
@@ -3550,6 +3587,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 start_point_index=start_point_index,
                 reverse_point_order=bool(self.reverse_point_order_var.get()),
                 enable_measurements=not test_run_enabled,
+                measurements_per_point=measurements_per_point,
                 confirm_measurement_after_navigation_failure=self._confirm_measurement_after_navigation_failure,
             ),
         )


### PR DESCRIPTION
### Motivation
- Provide a workflow-level, persistent control to configure how many measurements are executed per mission point, with a default of `1` and persisted value. 
- Ensure repeated measurements produce distinct files/IDs and are tracked in executor logs and UI result rows.

### Description
- Add a `measurements_per_point` UI field (`measurements_per_point_var`) with input validation and persistence in `MissionWorkflowWindow` and `build/restore` state handling (`transceiver/mission_workflow_ui.py`).
- Extend execution context and config with `PointExecutionContext.measurement_index`, `PointExecutionContext.measurements_per_point` and `MeasurementRunExecutorConfig.measurements_per_point`, validate the value and run a loop to perform multiple measurements per point in `MeasurementRunExecutor` (`transceiver/measurement_run_executor.py`).
- Aggregate multiple measurement results into a single `PointExecutionRecord.measurement_result` when applicable, and include `measurement_index`/`measurements_per_point` in persisted payloads and run summaries; adapt run-log filename generation to include a measurement suffix (`JsonRunLogStore`).
- Make `MissionRxMeasurementService.trigger` produce per-measurement filenames and include measurement index/count and a measurement-aware `measurement_id` in returned payloads (`transceiver/mission_measurement_service.py`).
- Show sub-measurement indices in the results table label when `measurements_per_point > 1` and wire the UI control into the executor invocation so the configured value is used at run start (`transceiver/mission_workflow_ui.py`).
- Add regression tests for multi-measurement execution and persisted value parsing (`tests/test_measurement_run_executor.py`, `tests/test_mission_workflow_ui_state.py`).

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_measurement_run_executor.py tests/test_measurement_run_executor_integration.py tests/test_mission_measurement_service.py tests/test_mission_workflow_ui_state.py` and all tests passed (`53 passed`).
- Ran `git diff --check` to ensure there are no whitespace/format issues and it reported clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb4acc44748321a584a63b71de9009)