### PR TITLE
Fix mission workflow integer validation callback

### DIFF
--- a/tests/test_mission_workflow_ui_state.py
+++ b/tests/test_mission_workflow_ui_state.py
@@ -210,3 +210,24 @@ def test_parse_positive_int_defaults_invalid_measurements_per_point() -> None:
     assert _parse_positive_int("3", default=1) == 3
     assert _parse_positive_int("0", default=1) == 1
     assert _parse_positive_int("invalid", default=1) == 1
+
+
+def test_validate_positive_integer_input_allows_editing_valid_values() -> None:
+    from transceiver.mission_workflow_ui import MissionWorkflowWindow
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+
+    assert window._validate_positive_integer_input("") is True
+    assert window._validate_positive_integer_input("1") is True
+    assert window._validate_positive_integer_input("25") is True
+
+
+def test_validate_positive_integer_input_rejects_invalid_values() -> None:
+    from transceiver.mission_workflow_ui import MissionWorkflowWindow
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+
+    assert window._validate_positive_integer_input("0") is False
+    assert window._validate_positive_integer_input("-1") is False
+    assert window._validate_positive_integer_input("1.5") is False
+    assert window._validate_positive_integer_input("abc") is False

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -94,6 +94,15 @@ def _parse_positive_int(value: Any, *, default: int = 1) -> int:
     return parsed if parsed >= 1 else default
 
 
+def _is_positive_integer_entry_value(value: Any) -> bool:
+    text = str(value)
+    if text == "":
+        return True
+    if not text.isdecimal():
+        return False
+    return int(text) >= 1
+
+
 def _map_executor_state_to_ui_text(state: str, completion_substatus: str | None = None) -> str:
     mapping = {
         "completed": "Abgeschlossen",
@@ -362,6 +371,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.after_idle(self._stabilize_initial_geometry)
         self.after_idle(self._open_maximized)
 
+    def _validate_positive_integer_input(self, proposed_value: str) -> bool:
+        return _is_positive_integer_entry_value(proposed_value)
+
     def _build_ui(self) -> None:
         self.columnconfigure(0, weight=1)
         self.rowconfigure(2, weight=1)
@@ -628,6 +640,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             measurements_frame,
             textvariable=self.measurements_per_point_var,
             width=56,
+            validate="key",
             validatecommand=(self.register(self._validate_positive_integer_input), "%P"),
         ).grid(row=0, column=1, sticky="w")
         self.reverse_point_order_var = tk.BooleanVar(value=False)


### PR DESCRIPTION
### Motivation
- Opening the Mission Workflow window raised an `AttributeError` because the entry validation callback referenced a missing method for validating the "Messungen/Punkt" field.
- The measurements-per-point entry should validate input at key time so invalid values are rejected while editing, and empty input must be allowed during editing.
- Add regression tests to prevent this class of UI validation regressions.

### Description
- Added a helper `def _is_positive_integer_entry_value(value: Any) -> bool` that accepts empty strings and enforces integer values >= 1 for entry validation.
- Implemented `MissionWorkflowWindow._validate_positive_integer_input(self, proposed_value: str) -> bool` that delegates to the new helper and prevents the `AttributeError` when building the UI.
- Enabled key-level validation on the measurements-per-point entry by setting `validate="key"` and keeping the `validatecommand` registration, and added unit tests in `tests/test_mission_workflow_ui_state.py` covering valid and invalid edit states.

### Testing
- Ran the new UI-state unit tests with `python -m pytest tests/test_mission_workflow_ui_state.py::test_parse_positive_int_defaults_invalid_measurements_per_point tests/test_mission_workflow_ui_state.py::test_validate_positive_integer_input_allows_editing_valid_values tests/test_mission_workflow_ui_state.py::test_validate_positive_integer_input_rejects_invalid_values`, and they all passed (`3 passed`).
- Ran the full `tests/test_mission_workflow_ui_state.py` suite and the new tests passed (`all passed`).
- Running the broader UI test suite `tests/test_mission_workflow_ui.py` together with the state tests produced two preexisting failures in context-menu tests that construct `MissionWorkflowWindow` via `__new__` without initializing `_records`, which is unrelated to the added validation callback.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb4dc8b7bc8321809aa4e46bc172d3)