### PR TITLE
Add Auto Detect context-menu action to results to apply measurement-review auto-detect

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -466,9 +466,10 @@ def test_on_results_table_context_menu_keeps_existing_multiselect_for_selected_r
     window.results_table = table
     window.results_table_context_menu = menu
     window._results_context_review_index = 0
-    window._results_context_move_up_index = 2
-    window._results_context_move_down_index = 3
-    window._results_context_remove_index = 5
+    window._results_context_auto_detect_index = 1
+    window._results_context_move_up_index = 3
+    window._results_context_move_down_index = 4
+    window._results_context_remove_index = 6
     window._records = [{}, {}, {}]
     window.results_selection_diagnostics_var = _StringVarStub()
     window._draw_map_preview = lambda: (_ for _ in ()).throw(AssertionError("must not redraw existing selection"))
@@ -479,11 +480,12 @@ def test_on_results_table_context_menu_keeps_existing_multiselect_for_selected_r
     assert table.selection() == ("row-a", "row-b")
     assert menu.labels == [
         "Measurement Review öffnen",
+        "Auto Detect auf 2 markierte Einträge anwenden",
         "2 markierte Einträge nach oben verschieben",
         "2 markierte Einträge nach unten verschieben",
         "2 markierte Einträge entfernen",
     ]
-    assert menu.states == ["disabled", "disabled", "normal", None]
+    assert menu.states == ["disabled", "normal", "disabled", "normal", None]
     assert menu.popup_calls == [(50, 60)]
     assert menu.release_count == 1
 
@@ -498,9 +500,10 @@ def test_on_results_table_context_menu_selects_unselected_row() -> None:
     window.results_table = table
     window.results_table_context_menu = menu
     window._results_context_review_index = 0
-    window._results_context_move_up_index = 2
-    window._results_context_move_down_index = 3
-    window._results_context_remove_index = 5
+    window._results_context_auto_detect_index = 1
+    window._results_context_move_up_index = 3
+    window._results_context_move_down_index = 4
+    window._results_context_remove_index = 6
     window._records = [{}, {}, {}]
     window.results_selection_diagnostics_var = _StringVarStub()
     draw_calls: list[str] = []
@@ -515,11 +518,12 @@ def test_on_results_table_context_menu_selects_unselected_row() -> None:
     assert window.results_selection_diagnostics_var.value == "Auswahl: 1 Zeilen"
     assert menu.labels == [
         "Measurement Review öffnen",
+        "Auto Detect auf markierten Eintrag anwenden",
         "Markierten Eintrag nach oben verschieben",
         "Markierten Eintrag nach unten verschieben",
         "Markierten Eintrag entfernen",
     ]
-    assert menu.states == ["normal", "normal", "disabled", None]
+    assert menu.states == ["normal", "normal", "normal", "disabled", None]
     assert draw_calls == ["draw"]
 
 
@@ -539,6 +543,99 @@ def test_open_review_for_selected_result_opens_only_single_selection() -> None:
     window._open_review_for_selected_result()
 
     assert calls == [1]
+
+
+def test_auto_detect_selected_results_confirms_once_and_updates_multiple_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._records = [
+        {
+            "global_index": 0,
+            "point_index": 0,
+            "error": "",
+            "measurement": {"status": "succeeded", "result": {"output_file": "a.bin"}},
+        },
+        {
+            "global_index": 1,
+            "point_index": 1,
+            "error": "",
+            "measurement": {"status": "succeeded", "result": {"output_file": "b.bin"}},
+        },
+    ]
+
+    class _DummyResultsTable:
+        def __init__(self) -> None:
+            self.updated: list[tuple[str, tuple[str, ...]]] = []
+
+        def selection(self):  # type: ignore[no-untyped-def]
+            return ()
+
+        def get_children(self):  # type: ignore[no-untyped-def]
+            return ("row-a", "row-b")
+
+        def item(self, item_id, **kwargs):  # type: ignore[no-untyped-def]
+            self.updated.append((item_id, kwargs["values"]))
+
+    table = _DummyResultsTable()
+    window.results_table = table
+    window._selected_result_indices = (0, 1)
+    window._format_live_position_for_table = lambda _payload: "-"
+    window._format_live_distance_to_rx_for_table = lambda _payload: "-"
+    messages: list[str] = []
+    calls: list[dict[str, object]] = []
+    lifecycle: list[str] = []
+    window._append_validation = messages.append
+    window._persist_workflow_state = lambda: lifecycle.append("persist")
+    window._update_live_label = lambda: lifecycle.append("live")
+    window._draw_map_preview = lambda: lifecycle.append("draw")
+    window._update_results_selection_diagnostics = lambda: lifecycle.append("diagnostics")
+    window.master = SimpleNamespace(
+        review_measurement_for_mission=lambda **kwargs: calls.append(kwargs) or {
+            "approved": True,
+            "los_lag": 10,
+            "echo_lags": [25],
+        }
+    )
+    ask_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "transceiver.mission_workflow_ui.messagebox.askyesno",
+        lambda title, message, parent=None: ask_calls.append((title, message)) or True,
+    )
+
+    window._auto_detect_selected_results()
+
+    assert len(ask_calls) == 1
+    assert "2 markierte Einträge" in ask_calls[0][1]
+    assert [call["auto_approve"] for call in calls] == [True, True]
+    assert [call["output_file"] for call in calls] == ["a.bin", "b.bin"]
+    assert window._records[0]["measurement"]["result"]["echo_delays"] == [
+        {"echo_index": 0, "delta_lag": 15.0, "distance_m": 22.5}
+    ]
+    assert window._records[1]["measurement"]["result"]["echo_delays"] == [
+        {"echo_index": 0, "delta_lag": 15.0, "distance_m": 22.5}
+    ]
+    assert [item_id for item_id, _values in table.updated] == ["row-a", "row-b"]
+    assert lifecycle == ["persist", "live", "draw", "diagnostics"]
+    assert any("Auto Detect" in message for message in messages)
+
+
+def test_auto_detect_selected_results_aborts_when_confirmation_declines(monkeypatch: pytest.MonkeyPatch) -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._records = [{"measurement": {"result": {"output_file": "a.bin"}}}]
+    window.results_table = SimpleNamespace(selection=lambda: ())
+    window._selected_result_indices = (0,)
+    messages: list[str] = []
+    calls: list[str] = []
+    window._append_validation = messages.append
+    window.master = SimpleNamespace(review_measurement_for_mission=lambda **_kwargs: calls.append("review"))
+    monkeypatch.setattr(
+        "transceiver.mission_workflow_ui.messagebox.askyesno",
+        lambda *_args, **_kwargs: False,
+    )
+
+    window._auto_detect_selected_results()
+
+    assert calls == []
+    assert any("abgebrochen" in message for message in messages)
 
 
 def test_remove_selected_results_removes_selected_records_and_persists() -> None:

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -7665,10 +7665,27 @@ class TransceiverUI(ctk.CTk):
                     outcome["detail"] = detail
                     return
                 if auto_approve:
+                    _highest_idx, detected_los_idx, detected_echo_indices = _classify_visible_xcorr_peaks(
+                        mag,
+                        repetition_period_samples=max(1, int(ctx.get("period_samples") or len(lags) or 1)),
+                    )
+                    if detected_los_idx is None:
+                        detail = "Auto Detect konnte keinen LOS-Peak bestimmen."
+                        outcome["approved"] = False
+                        outcome["reason"] = REVIEW_REASON_NO_DETECTABLE_LOS
+                        outcome["detail"] = detail
+                        return
+                    period_samples = int(ctx.get("period_samples")) if ctx.get("period_samples") is not None else None
+                    filtered_echo_indices = _filter_peak_indices_to_period_group(
+                        lags,
+                        [int(idx) for idx in detected_echo_indices if idx is not None],
+                        int(detected_los_idx),
+                        period_samples,
+                    )
                     interpolation_enabled = bool(self.rx_interpolation_enable.get())
                     interpolation_factor = self._rx_effective_interpolation_factor()
-                    los_idx_final = int(los_idx)
-                    echo_indices_final = [int(idx) for idx in echo_indices]
+                    los_idx_final = int(detected_los_idx)
+                    echo_indices_final = [int(idx) for idx in filtered_echo_indices]
                     los_lag = int(round(float(lags[los_idx_final])))
                     outcome["approved"] = True
                     outcome["reason"] = ""

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -768,19 +768,24 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             label="Measurement Review öffnen",
             command=self._open_review_for_selected_result,
         )
+        self._results_context_auto_detect_index = 1
+        self.results_table_context_menu.add_command(
+            label="Auto Detect anwenden",
+            command=self._auto_detect_selected_results,
+        )
         self.results_table_context_menu.add_separator()
-        self._results_context_move_up_index = 2
+        self._results_context_move_up_index = 3
         self.results_table_context_menu.add_command(
             label="Markierte Einträge nach oben verschieben",
             command=self._move_selected_results_up,
         )
-        self._results_context_move_down_index = 3
+        self._results_context_move_down_index = 4
         self.results_table_context_menu.add_command(
             label="Markierte Einträge nach unten verschieben",
             command=self._move_selected_results_down,
         )
         self.results_table_context_menu.add_separator()
-        self._results_context_remove_index = 5
+        self._results_context_remove_index = 6
         self.results_table_context_menu.add_command(
             label="Markierte Einträge entfernen",
             command=self._remove_selected_results,
@@ -1778,6 +1783,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             state="normal" if len(selected_indices) == 1 else "disabled",
         )
         menu.entryconfigure(
+            self._results_context_auto_detect_index,
+            label=self._auto_detect_results_context_label(selected_count),
+            state="normal" if selected_indices else "disabled",
+        )
+        menu.entryconfigure(
             self._results_context_move_up_index,
             label=self._move_results_context_label(selected_count, direction="up"),
             state=(
@@ -1804,6 +1814,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         finally:
             menu.grab_release()
         return "break"
+
+    @staticmethod
+    def _auto_detect_results_context_label(selected_count: int) -> str:
+        if selected_count == 1:
+            return "Auto Detect auf markierten Eintrag anwenden"
+        return f"Auto Detect auf {selected_count} markierte Einträge anwenden"
 
     @staticmethod
     def _remove_results_context_label(selected_count: int) -> str:
@@ -1948,18 +1964,60 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._update_live_label()
         self._draw_map_preview()
 
-    def _open_review_for_result_row(self, row_index: int) -> None:
-        if row_index < 0 or row_index >= len(self._records):
+    def _auto_detect_selected_results(self) -> None:
+        selected_indices = self._selected_result_row_indices()
+        if not selected_indices:
             return
+        selected_count = len(selected_indices)
+        message = (
+            "Auto Detect aus dem Measurement Review auf den markierten Eintrag anwenden?"
+            if selected_count == 1
+            else f"Auto Detect aus dem Measurement Review auf {selected_count} markierte Einträge anwenden?"
+        )
+        if not messagebox.askyesno("Auto Detect anwenden", message, parent=self):
+            self._append_validation("ℹ️ Auto Detect wurde abgebrochen; Messresultate bleiben unverändert.")
+            return
+
+        applied_count = 0
+        failed_count = 0
+        for row_index in selected_indices:
+            if self._run_review_for_result_row(row_index, auto_approve=True):
+                applied_count += 1
+            else:
+                failed_count += 1
+        if applied_count:
+            self._persist_workflow_state()
+            for row_index in selected_indices:
+                self._refresh_result_table_row(row_index)
+            self._update_live_label()
+            self._draw_map_preview()
+        self._update_results_selection_diagnostics()
+        if failed_count:
+            self._append_validation(
+                f"⚠️ Auto Detect angewendet: {applied_count} erfolgreich, {failed_count} fehlgeschlagen/übersprungen."
+            )
+        else:
+            self._append_validation(f"✅ Auto Detect auf {applied_count} Ergebnis(se) angewendet.")
+
+    def _open_review_for_result_row(self, row_index: int) -> None:
+        if self._run_review_for_result_row(row_index, auto_approve=False):
+            self._persist_workflow_state()
+            self._refresh_result_table_row(row_index)
+            self._update_results_selection_diagnostics()
+            self._draw_map_preview()
+
+    def _run_review_for_result_row(self, row_index: int, *, auto_approve: bool) -> bool:
+        if row_index < 0 or row_index >= len(self._records):
+            return False
         record = self._records[row_index]
         if not isinstance(record, dict):
-            return
+            return False
         measurement = record.get("measurement")
         if not isinstance(measurement, dict):
-            return
+            return False
         result_payload = measurement.get("result")
         if not isinstance(result_payload, dict):
-            return
+            return False
         output_file = result_payload.get("output_file")
         if (not isinstance(output_file, str) or not output_file.strip()) and isinstance(result_payload.get("file_ref"), str):
             output_file = result_payload.get("file_ref")
@@ -1969,33 +2027,41 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 output_file = rx_payload.get("output_file")
         if not isinstance(output_file, str) or not output_file.strip():
             self._append_validation("⚠️ Review kann nicht geöffnet werden: output_file fehlt.")
-            return
+            return False
         review_fn = getattr(self.master, "review_measurement_for_mission", None)
         if not callable(review_fn):
             self._append_validation("⚠️ Review kann nicht geöffnet werden: Review-Funktion nicht verfügbar.")
-            return
+            return False
         point_label = f"Punktindex {self._format_one_based_index(record.get('global_index'))}"
         review_prefill = self._build_review_prefill_from_result(result_payload)
+        kwargs: dict[str, Any] = {
+            "point_label": point_label,
+            "output_file": output_file,
+            "initial_review": review_prefill,
+        }
+        if auto_approve:
+            kwargs["auto_approve"] = True
         try:
-            review_outcome = review_fn(
-                point_label=point_label,
-                output_file=output_file,
-                initial_review=review_prefill,
-            )
+            review_outcome = review_fn(**kwargs)
         except Exception as exc:
             self._append_validation(f"⚠️ Review konnte nicht geöffnet werden: {exc}")
-            return
+            return False
         if not isinstance(review_outcome, dict):
-            return
+            return False
         if not bool(review_outcome.get("approved")):
-            self._append_validation("ℹ️ Review nicht freigegeben; Messresultat bleibt unverändert.")
-            return
+            action = "Auto Detect" if auto_approve else "Review"
+            self._append_validation(f"ℹ️ {action} nicht freigegeben; Messresultat bleibt unverändert.")
+            return False
 
+        self._apply_review_outcome_to_result(result_payload, review_outcome)
+        return True
+
+    def _apply_review_outcome_to_result(self, result_payload: dict[str, Any], review_outcome: dict[str, Any]) -> None:
         normalized_echo_delays = self._normalize_review_echo_delays(review_outcome)
         if normalized_echo_delays:
             review_outcome["echo_delays"] = normalized_echo_delays
 
-        for key in (
+        review_keys = (
             "manual_lags",
             "los_idx",
             "echo_indices",
@@ -2004,7 +2070,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "echo_delays",
             "interpolation_enabled",
             "interpolation_factor",
-        ):
+        )
+        for key in review_keys:
             if key in review_outcome:
                 result_payload[key] = review_outcome.get(key)
 
@@ -2012,36 +2079,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if not isinstance(review_payload, dict):
             review_payload = {}
             result_payload["review"] = review_payload
-        for key in (
-            "manual_lags",
-            "los_idx",
-            "echo_indices",
-            "los_lag",
-            "echo_lags",
-            "echo_delays",
-            "interpolation_enabled",
-            "interpolation_factor",
-        ):
+        for key in review_keys:
             if key in review_outcome:
                 review_payload[key] = review_outcome.get(key)
 
-        self._persist_workflow_state()
-        if 0 <= row_index < len(self.results_table.get_children()):
-            error_text = record.get("error") or ""
-            combined_status = self._compose_table_outcome(record, error_text)
-            self.results_table.item(
-                self.results_table.get_children()[row_index],
-                values=(
-                    self._format_one_based_index(record.get("global_index")),
-                    self._format_one_based_index(record.get("point_index")),
-                    self._format_live_position_for_table(record),
-                    self._format_live_distance_to_rx_for_table(record),
-                    *self._format_echo_distances_for_table(result_payload.get("echo_delays")),
-                    combined_status,
-                ),
-            )
-        self._update_results_selection_diagnostics()
-        self._draw_map_preview()
+    def _refresh_result_table_row(self, row_index: int) -> None:
+        if not 0 <= row_index < len(self._records):
+            return
+        children = tuple(self.results_table.get_children())
+        if not 0 <= row_index < len(children):
+            return
+        self.results_table.item(children[row_index], values=self._result_table_values(self._records[row_index]))
 
     @staticmethod
     def _normalize_review_echo_delays(review_outcome: dict[str, Any]) -> list[dict[str, Any]]:


### PR DESCRIPTION
### Motivation
- Provide a convenient way to run the Measurement Review auto-detect on one or multiple selected rows in the mission results table via the context menu, with a one-time confirmation before applying changes.

### Description
- Add an `Auto Detect anwenden` context-menu entry and dynamic single/multi-selection labels via `self._results_context_auto_detect_index` and `_auto_detect_results_context_label` in `transceiver/mission_workflow_ui.py`.
- Implement `_auto_detect_selected_results` to show a confirmation, iterate selected rows and call a new review runner that invokes the review pipeline with `auto_approve=True` and applies normalized review outcomes back into result payloads and the table.
- Refactor review application into ` _run_review_for_result_row`, `_apply_review_outcome_to_result` and `_refresh_result_table_row` so manual review and context-menu auto-detect share output-file fallback, normalization and persistence logic.
- Update the mission review auto-approve path in `transceiver/__main__.py` to perform the same peak classification/filtering used by the interactive dialog before producing an approved outcome.
- Add tests to `tests/test_mission_workflow_ui.py` to assert context-menu labels/states and to exercise multi-row Auto Detect application and cancellation.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` which passed (`82 passed`).
- Ran `PYTHONPATH=. pytest -q tests/test_receive_for_mission_threading.py -k 'review_measurement_for_mission'` which passed (`4 passed, 8 deselected`).
- Ran `python -m compileall transceiver/mission_workflow_ui.py transceiver/__main__.py` which succeeded.
- Running the entire test suite with `PYTHONPATH=. pytest -q` currently fails during collection due to existing unrelated test/environment issues (imports / PyQt/Tk stubbing errors) and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb51071898832192ca1cadcf75cacb)