### PR TITLE
Add LiDAR overlay diagnostics and relax per-cell filtering

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -770,17 +770,23 @@ def test_draw_lidar_scan_overlay_deduplicates_dense_endpoints() -> None:
     window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
     window._is_pixel_inside_map = lambda *_args, **_kwargs: True
     line_calls: list[tuple[float, float, float, float]] = []
+    messages: list[str] = []
     window.map_preview_canvas = SimpleNamespace(
         create_oval=lambda *_args, **_kwargs: None,
         create_line=lambda sx, sy, ex, ey, **_kwargs: line_calls.append((sx, sy, ex, ey)),
     )
+    window._append_validation = messages.append
 
     window._draw_lidar_scan_overlay_for_point(
         point=MeasurementPoint(id="p1", name="P1", x=10.0, y=20.0, yaw=0.0),
         scan={"angle_min": 0.0, "angle_increment": 0.0, "ranges": [2.0] * 1800},
     )
 
-    assert len(line_calls) == 1
+    assert len(line_calls) == 2
+    assert messages == [
+        "ℹ️ LiDAR-Overlay: gültige Ranges=1800, Stride übersprungen=1350, "
+        "Zellfilter übersprungen=448, gezeichnet=2, Zellgröße=2.10px, Stride=4"
+    ]
 
 
 def test_draw_lidar_scan_overlay_adapts_stride_for_large_scan() -> None:
@@ -791,10 +797,12 @@ def test_draw_lidar_scan_overlay_adapts_stride_for_large_scan() -> None:
     window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
     window._is_pixel_inside_map = lambda *_args, **_kwargs: True
     line_calls: list[tuple[float, float, float, float]] = []
+    messages: list[str] = []
     window.map_preview_canvas = SimpleNamespace(
         create_oval=lambda *_args, **_kwargs: None,
         create_line=lambda sx, sy, ex, ey, **_kwargs: line_calls.append((sx, sy, ex, ey)),
     )
+    window._append_validation = messages.append
 
     window._draw_lidar_scan_overlay_for_point(
         point=MeasurementPoint(id="p2", name="P2", x=0.0, y=0.0, yaw=0.0),
@@ -802,6 +810,9 @@ def test_draw_lidar_scan_overlay_adapts_stride_for_large_scan() -> None:
     )
 
     assert len(line_calls) <= 700
+    assert "gültige Ranges=2000" in messages[0]
+    assert "Stride übersprungen=1500" in messages[0]
+    assert f"gezeichnet={len(line_calls)}" in messages[0]
 
 
 def test_build_waypoint_arrow_polygon_points_to_positive_x_for_zero_yaw() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -55,7 +55,10 @@ ECHO_OVERLAY_COLORS = ("#00796B", "#FFB300", "#8E24AA", "#00ACC1", "#F4511E")
 ECHO_HEADING_MARKERS = ("🟢", "🟠", "🟣", "🔵", "🟤")
 LIDAR_OVERLAY_MAX_DRAWN_BEAMS = 450
 LIDAR_OVERLAY_CELL_SIZE_PX = 3.0
-LIDAR_OVERLAY_MAX_BEAMS_PER_CELL = 1
+LIDAR_OVERLAY_MAX_BEAMS_PER_CELL = 2
+LIDAR_OVERLAY_SMALL_MAP_REFERENCE_SIZE_PX = 600.0
+LIDAR_OVERLAY_SMALL_MAP_MIN_CELL_FACTOR = 0.35
+LIDAR_OVERLAY_MIN_CELL_SIZE_PX = 1.0
 MEASUREMENT_START_LIVE_POSITION_WAIT_TIMEOUT_S = 1.6
 MEASUREMENT_START_LIVE_POSITION_WAIT_INTERVAL_S = 0.1
 LIVE_ECHO_CACHE_POSITION_DELTA_M = 0.015
@@ -2812,12 +2815,29 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         )
         beam_stride = max(1, finite_positive_beam_count // LIDAR_OVERLAY_MAX_DRAWN_BEAMS)
         density_factor = max(1.0, math.sqrt(finite_positive_beam_count / float(LIDAR_OVERLAY_MAX_DRAWN_BEAMS)))
-        effective_cell_size_px = LIDAR_OVERLAY_CELL_SIZE_PX * density_factor
+        preview_width = original.width() * scale_x
+        preview_height = original.height() * scale_y
+        preview_min_dimension = max(1.0, min(preview_width, preview_height))
+        small_map_cell_factor = min(
+            1.0,
+            max(
+                LIDAR_OVERLAY_SMALL_MAP_MIN_CELL_FACTOR,
+                preview_min_dimension / LIDAR_OVERLAY_SMALL_MAP_REFERENCE_SIZE_PX,
+            ),
+        )
+        effective_cell_size_px = max(
+            LIDAR_OVERLAY_MIN_CELL_SIZE_PX,
+            LIDAR_OVERLAY_CELL_SIZE_PX * density_factor * small_map_cell_factor,
+        )
+        skipped_by_stride_count = 0
+        skipped_by_cell_filter_count = 0
+        drawn_beam_count = 0
         drawn_beam_cells: dict[tuple[int, int], int] = {}
         for idx, distance in enumerate(ranges):
-            if not math.isfinite(distance) or distance <= 0.0:
+            if not isinstance(distance, (int, float)) or not math.isfinite(distance) or distance <= 0.0:
                 continue
             if idx % beam_stride != 0:
+                skipped_by_stride_count += 1
                 continue
             beam_angle = point.yaw + angle_min + idx * angle_increment
             end_world_x = point.x + math.cos(beam_angle) * distance
@@ -2833,6 +2853,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             )
             current_cell_count = drawn_beam_cells.get(beam_cell, 0)
             if current_cell_count >= LIDAR_OVERLAY_MAX_BEAMS_PER_CELL:
+                skipped_by_cell_filter_count += 1
                 continue
             drawn_beam_cells[beam_cell] = current_cell_count + 1
             self.map_preview_canvas.create_line(
@@ -2844,6 +2865,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 width=1,
                 stipple="gray25",
             )
+            drawn_beam_count += 1
+        self._append_validation(
+            "ℹ️ LiDAR-Overlay: "
+            f"gültige Ranges={finite_positive_beam_count}, "
+            f"Stride übersprungen={skipped_by_stride_count}, "
+            f"Zellfilter übersprungen={skipped_by_cell_filter_count}, "
+            f"gezeichnet={drawn_beam_count}, "
+            f"Zellgröße={effective_cell_size_px:.2f}px, "
+            f"Stride={beam_stride}"
+        )
 
     def _draw_live_marker(self) -> None:
         mission = self._mission


### PR DESCRIPTION
### Motivation
- Reduce excessive filtering of LiDAR overlay beams on small map previews by making the effective cell size adaptive to the preview dimensions and by allowing more beams per cell. 
- Make overlay behavior observable at runtime by emitting counts for valid ranges, stride-skipped beams, cell-filter-skipped beams and actually drawn beams.

### Description
- Increased `LIDAR_OVERLAY_MAX_BEAMS_PER_CELL` from `1` to `2` and added `LIDAR_OVERLAY_SMALL_MAP_REFERENCE_SIZE_PX`, `LIDAR_OVERLAY_SMALL_MAP_MIN_CELL_FACTOR` and `LIDAR_OVERLAY_MIN_CELL_SIZE_PX` to control smaller effective cell sizes for small previews. 
- Compute `effective_cell_size_px` using `original.width()/height()` and `_map_preview_scale` with a small-map scaling factor and a minimum cell size. 
- Added diagnostic counters `skipped_by_stride_count`, `skipped_by_cell_filter_count` and `drawn_beam_count` and emit a summary string via `_append_validation(...)` that includes `gültige Ranges`, `Stride übersprungen`, `Zellfilter übersprungen`, `gezeichnet`, `Zellgröße` and `Stride`. 
- Updated `tests/test_mission_workflow_ui.py` to capture `_append_validation` output and adjust assertions to reflect the relaxed per-cell limit and diagnostic message presence.

### Testing
- Ran `python -m pytest tests/test_mission_workflow_ui.py -q`, which passed (the modified file’s tests executed successfully).
- Ran `python -m compileall transceiver tests/test_mission_workflow_ui.py` which completed without errors.
- Ran full test suite with `python -m pytest -q`, which aborted during unrelated collection errors (missing `_suppress_nearby_candidates` import in `transceiver.helpers.correlation_utils` and a `TypeError: __mro_entries__ must return a tuple` from `transceiver/__main__.py`) that are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb575d8d788321ac540c7bab54f2c6)