### PR TITLE
Fix LIDAR overlay scan orientation

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -762,6 +762,32 @@ def test_extract_lidar_ranges_from_scan_text_supports_list_style() -> None:
     assert values[2] == 3.4
 
 
+def test_draw_lidar_scan_overlay_rotates_scan_180_degrees_to_match_map_heading() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._map_image_original = SimpleNamespace(width=lambda: 200, height=lambda: 120)
+    window._map_preview_scale = (1.0, 1.0)
+    window._map_preview_offset = (0.0, 0.0)
+    window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
+    window._is_pixel_inside_map = lambda *_args, **_kwargs: True
+    line_calls: list[tuple[float, float, float, float]] = []
+    window.map_preview_canvas = SimpleNamespace(
+        create_oval=lambda *_args, **_kwargs: None,
+        create_line=lambda sx, sy, ex, ey, **_kwargs: line_calls.append((sx, sy, ex, ey)),
+    )
+    window._append_validation = lambda _message: None
+
+    window._draw_lidar_scan_overlay_for_point(
+        point=MeasurementPoint(id="p1", name="P1", x=50.0, y=50.0, yaw=0.0),
+        scan={"angle_min": 0.0, "angle_increment": 0.0, "ranges": [10.0]},
+    )
+
+    assert len(line_calls) == 1
+    start_x, start_y, end_x, end_y = line_calls[0]
+    assert (start_x, start_y) == (50.0, 50.0)
+    assert end_x == pytest.approx(40.0)
+    assert end_y == pytest.approx(50.0)
+
+
 def test_draw_lidar_scan_overlay_deduplicates_dense_endpoints() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._map_image_original = SimpleNamespace(width=lambda: 200, height=lambda: 120)

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -59,6 +59,9 @@ LIDAR_OVERLAY_MAX_BEAMS_PER_CELL = 2
 LIDAR_OVERLAY_SMALL_MAP_REFERENCE_SIZE_PX = 600.0
 LIDAR_OVERLAY_SMALL_MAP_MIN_CELL_FACTOR = 0.35
 LIDAR_OVERLAY_MIN_CELL_SIZE_PX = 1.0
+# LIDAR scans are captured in the sensor frame, whose forward axis is mounted
+# opposite to the map/robot heading used by the mission points.
+LIDAR_OVERLAY_SENSOR_YAW_OFFSET_RAD = math.pi
 MEASUREMENT_START_LIVE_POSITION_WAIT_TIMEOUT_S = 1.6
 MEASUREMENT_START_LIVE_POSITION_WAIT_INTERVAL_S = 0.1
 LIVE_ECHO_CACHE_POSITION_DELTA_M = 0.015
@@ -2842,7 +2845,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             if idx % beam_stride != 0:
                 skipped_by_stride_count += 1
                 continue
-            beam_angle = point.yaw + angle_min + idx * angle_increment
+            beam_angle = (
+                point.yaw
+                + LIDAR_OVERLAY_SENSOR_YAW_OFFSET_RAD
+                + angle_min
+                + idx * angle_increment
+            )
             end_world_x = point.x + math.cos(beam_angle) * distance
             end_world_y = point.y + math.sin(beam_angle) * distance
             end_map_pixel = self._world_to_map_pixel(x=end_world_x, y=end_world_y, image_height=original.height())


### PR DESCRIPTION
### Motivation
- LIDAR reference scans were drawn rotated by 180° on the map because the sensor's forward axis is mounted opposite to the robot/map heading used for mission points, causing overlay beams to appear reversed.

### Description
- Add `LIDAR_OVERLAY_SENSOR_YAW_OFFSET_RAD = math.pi` and a clarifying comment in `transceiver/mission_workflow_ui.py` to document the sensor-frame yaw offset.
- Apply the offset when computing beam angles in `_draw_lidar_scan_overlay_for_point` by changing the `beam_angle` calculation to include `LIDAR_OVERLAY_SENSOR_YAW_OFFSET_RAD`.
- Add a regression test `test_draw_lidar_scan_overlay_rotates_scan_180_degrees_to_match_map_heading` in `tests/test_mission_workflow_ui.py` that verifies a 0° scan beam is drawn behind the measurement point after the correction.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` and the tests for the file passed (`83 passed`).
- Running the full test run with `PYTHONPATH=. pytest -q` still fails during collection due to unrelated import/runtime issues in the test environment and are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb6751c4808321861771ea06c4a486)