### PR TITLE
Fix LiDAR overlay scanner rotation

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -762,6 +762,17 @@ def test_extract_lidar_ranges_from_scan_text_supports_list_style() -> None:
     assert values[2] == 3.4
 
 
+def test_lidar_overlay_beam_angle_compensates_left_rotated_scanner() -> None:
+    angle = MissionWorkflowWindow._lidar_overlay_beam_angle(
+        point_yaw=0.0,
+        angle_min=0.0,
+        angle_increment=0.0,
+        beam_index=0,
+    )
+
+    assert angle == pytest.approx(math.pi / 2.0)
+
+
 def test_draw_lidar_scan_overlay_deduplicates_dense_endpoints() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._map_image_original = SimpleNamespace(width=lambda: 200, height=lambda: 120)

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -59,6 +59,7 @@ LIDAR_OVERLAY_MAX_BEAMS_PER_CELL = 2
 LIDAR_OVERLAY_SMALL_MAP_REFERENCE_SIZE_PX = 600.0
 LIDAR_OVERLAY_SMALL_MAP_MIN_CELL_FACTOR = 0.35
 LIDAR_OVERLAY_MIN_CELL_SIZE_PX = 1.0
+LIDAR_OVERLAY_SCANNER_YAW_OFFSET_RAD = math.pi / 2.0
 MEASUREMENT_START_LIVE_POSITION_WAIT_TIMEOUT_S = 1.6
 MEASUREMENT_START_LIVE_POSITION_WAIT_INTERVAL_S = 0.1
 LIVE_ECHO_CACHE_POSITION_DELTA_M = 0.015
@@ -2785,6 +2786,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             parsed.append(value)
         return parsed
 
+    @staticmethod
+    def _lidar_overlay_beam_angle(
+        *,
+        point_yaw: float,
+        angle_min: float,
+        angle_increment: float,
+        beam_index: int,
+    ) -> float:
+        return point_yaw + LIDAR_OVERLAY_SCANNER_YAW_OFFSET_RAD + angle_min + beam_index * angle_increment
+
     def _draw_lidar_scan_overlay_for_point(self, *, point: MeasurementPoint, scan: dict[str, Any]) -> None:
         original = self._map_image_original
         if original is None:
@@ -2842,7 +2853,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             if idx % beam_stride != 0:
                 skipped_by_stride_count += 1
                 continue
-            beam_angle = point.yaw + angle_min + idx * angle_increment
+            beam_angle = self._lidar_overlay_beam_angle(
+                point_yaw=point.yaw,
+                angle_min=angle_min,
+                angle_increment=angle_increment,
+                beam_index=idx,
+            )
             end_world_x = point.x + math.cos(beam_angle) * distance
             end_world_y = point.y + math.sin(beam_angle) * distance
             end_map_pixel = self._world_to_map_pixel(x=end_world_x, y=end_world_y, image_height=original.height())


### PR DESCRIPTION
### Motivation
- The LiDAR scanner was rotated 90° to the left which caused reference scan overlays to be drawn with the wrong orientation on the map and must be compensated in the overlay math.  

### Description
- Add `LIDAR_OVERLAY_SCANNER_YAW_OFFSET_RAD = math.pi / 2.0`, introduce `MissionWorkflowWindow._lidar_overlay_beam_angle(...)`, and use it to compute beam endpoints inside `_draw_lidar_scan_overlay_for_point`.  
- Add `test_lidar_overlay_beam_angle_compensates_left_rotated_scanner` to verify the +90° offset behavior.  

### Testing
- `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` was run and passed (83 passed).  
- Running the full suite with `PYTHONPATH=. pytest -q` fails during collection because of unrelated pre-existing issues (`ImportError` for `_suppress_nearby_candidates` and `TypeError: __mro_entries__ must return a tuple`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb6b7e8c2c8321a14cf31f66be185d)