### PR TITLE
Clear results selection on empty table clicks

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -358,6 +358,9 @@ class _TreeviewSelectionStub:
     def selection_set(self, item_id: str) -> None:
         self._selected = (item_id,)
 
+    def selection_remove(self, *item_ids: str) -> None:
+        self._selected = tuple(selected for selected in self._selected if selected not in item_ids)
+
     def index(self, item_id: str) -> int:
         return self._indices[item_id]
 
@@ -418,24 +421,50 @@ def test_on_results_table_select_updates_multi_selection_and_diagnostics() -> No
     assert draw_calls == ["draw"]
 
 
-def test_on_results_table_click_on_empty_region_preserves_multiselect() -> None:
+def test_on_results_table_click_on_empty_region_clears_multiselect() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     table = _TreeviewSelectionStub()
     table._selected = ("row-a", "row-b")
+    table._indices = {"row-a": 0, "row-b": 1}
     table._region = "cell"
     table._row_id = ""
     window.results_table = table
     window._selected_result_index = 0
     window._selected_result_indices = (0, 1)
     window.results_selection_diagnostics_var = _StringVarStub()
-    window._draw_map_preview = lambda: (_ for _ in ()).throw(AssertionError("must not redraw on empty click"))
+    draw_calls: list[str] = []
+    window._draw_map_preview = lambda: draw_calls.append("draw")
 
     result = window._on_results_table_click(SimpleNamespace(x=5, y=5))
 
     assert result == "break"
-    assert window._selected_result_indices == (0, 1)
+    assert table.selection() == ()
+    assert window._selected_result_indices == ()
+    assert window._selected_result_index is None
+    assert window.results_selection_diagnostics_var.value == "Auswahl: 0 Zeilen"
+    assert draw_calls == ["draw"]
+
+
+@pytest.mark.parametrize("region", ["heading", "separator"])
+def test_on_results_table_click_ignores_table_chrome_without_clearing_selection(region: str) -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    table = _TreeviewSelectionStub()
+    table._selected = ("row-a",)
+    table._indices = {"row-a": 0}
+    table._region = region
+    table._row_id = ""
+    window.results_table = table
+    window._selected_result_index = 0
+    window._selected_result_indices = (0,)
+    window.results_selection_diagnostics_var = _StringVarStub()
+    window._draw_map_preview = lambda: (_ for _ in ()).throw(AssertionError("must not redraw on table chrome click"))
+
+    result = window._on_results_table_click(SimpleNamespace(x=5, y=5))
+
+    assert result is None
+    assert table.selection() == ("row-a",)
+    assert window._selected_result_indices == (0,)
     assert window._selected_result_index == 0
-    assert window.results_selection_diagnostics_var.value == "Auswahl: 2 Zeilen"
 
 
 class _ResultsContextMenuStub:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1757,7 +1757,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         region = self.results_table.identify("region", event.x, event.y)
         if region in {"heading", "separator"}:
             return None
-        self._update_results_selection_diagnostics()
+        selected_items = self.results_table.selection()
+        if selected_items:
+            self.results_table.selection_remove(*selected_items)
+        self._on_results_table_select(event)
         return "break"
 
     def _on_results_table_double_click(self, event: tk.Event) -> str | None:


### PR DESCRIPTION
### Motivation
- Ensure that clicking an empty area of the results Treeview (non-row, non-heading, non-separator) clears the visible selection and synchronizes internal selection state, diagnostics and map preview so UI state cannot get out of sync.

### Description
- Update `transceiver/mission_workflow_ui.py` `_on_results_table_click` to, when clicking an empty non-`heading`/`separator` region, explicitly clear the Treeview selection via `selection_remove(...)` and then route through `_on_results_table_select(event)` to synchronize `_selected_result_index`, `_selected_result_indices`, diagnostics and the map preview instead of only calling `_update_results_selection_diagnostics()`.
- Keep existing behavior: clicks on real rows still return `None` (allowing default Treeview behavior) and clicks on `heading`/`separator` regions are still ignored.
- Update `tests/test_mission_workflow_ui.py` by adding a `selection_remove` implementation to the Treeview stub and replacing/adding tests to assert that empty-area clicks clear the selection and redraw the map preview, and that `heading`/`separator` clicks do not clear the selection.
- Changes touch `transceiver/mission_workflow_ui.py` and `tests/test_mission_workflow_ui.py` to introduce and validate the new behavior.

### Testing
- Ran the focused test module with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -q` and all tests passed.
- Ran `git diff --check` to ensure no whitespace or diff issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb6ebf5a4c8321be5025055c74bdf2)