### PR TITLE
Show LiDAR reference overlay points only

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -809,11 +809,19 @@ def test_draw_lidar_scan_overlay_deduplicates_dense_endpoints() -> None:
     window._map_preview_offset = (0.0, 0.0)
     window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
     window._is_pixel_inside_map = lambda *_args, **_kwargs: True
-    line_calls: list[tuple[float, float, float, float]] = []
+    lidar_point_calls: list[tuple[tuple[float, ...], dict[str, object]]] = []
     messages: list[str] = []
+
+    def create_oval(*args, **kwargs):
+        if kwargs.get("fill") == "#fff176":
+            lidar_point_calls.append((args, kwargs))
+
+    def create_line(*_args, **_kwargs):
+        raise AssertionError("LiDAR reference overlay must not draw beam lines")
+
     window.map_preview_canvas = SimpleNamespace(
-        create_oval=lambda *_args, **_kwargs: None,
-        create_line=lambda sx, sy, ex, ey, **_kwargs: line_calls.append((sx, sy, ex, ey)),
+        create_oval=create_oval,
+        create_line=create_line,
     )
     window._append_validation = messages.append
 
@@ -822,10 +830,10 @@ def test_draw_lidar_scan_overlay_deduplicates_dense_endpoints() -> None:
         scan={"angle_min": 0.0, "angle_increment": 0.0, "ranges": [2.0] * 1800},
     )
 
-    assert len(line_calls) == 2
+    assert len(lidar_point_calls) == 2
     assert messages == [
         "ℹ️ LiDAR-Overlay: gültige Ranges=1800, Stride übersprungen=1350, "
-        "Zellfilter übersprungen=448, gezeichnet=2, Zellgröße=2.10px, Stride=4"
+        "Zellfilter übersprungen=448, Punkte gezeichnet=2, Zellgröße=2.10px, Stride=4"
     ]
 
 
@@ -836,11 +844,19 @@ def test_draw_lidar_scan_overlay_adapts_stride_for_large_scan() -> None:
     window._map_preview_offset = (0.0, 0.0)
     window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
     window._is_pixel_inside_map = lambda *_args, **_kwargs: True
-    line_calls: list[tuple[float, float, float, float]] = []
+    lidar_point_calls: list[tuple[tuple[float, ...], dict[str, object]]] = []
     messages: list[str] = []
+
+    def create_oval(*args, **kwargs):
+        if kwargs.get("fill") == "#fff176":
+            lidar_point_calls.append((args, kwargs))
+
+    def create_line(*_args, **_kwargs):
+        raise AssertionError("LiDAR reference overlay must not draw beam lines")
+
     window.map_preview_canvas = SimpleNamespace(
-        create_oval=lambda *_args, **_kwargs: None,
-        create_line=lambda sx, sy, ex, ey, **_kwargs: line_calls.append((sx, sy, ex, ey)),
+        create_oval=create_oval,
+        create_line=create_line,
     )
     window._append_validation = messages.append
 
@@ -849,10 +865,10 @@ def test_draw_lidar_scan_overlay_adapts_stride_for_large_scan() -> None:
         scan={"angle_min": 0.0, "angle_increment": 0.01, "ranges": [500.0] * 2000},
     )
 
-    assert len(line_calls) <= 700
+    assert len(lidar_point_calls) <= 700
     assert "gültige Ranges=2000" in messages[0]
     assert "Stride übersprungen=1500" in messages[0]
-    assert f"gezeichnet={len(line_calls)}" in messages[0]
+    assert f"Punkte gezeichnet={len(lidar_point_calls)}" in messages[0]
 
 
 def test_build_waypoint_arrow_polygon_points_to_positive_x_for_zero_yaw() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2813,8 +2813,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         start_x = start_map_pixel[0] * scale_x + offset_x
         start_y = start_map_pixel[1] * scale_y + offset_y
         preview_scale = max(scale_x, scale_y)
-        lidar_beam_width = max(2, min(4, int(round(2.0 * max(1.0, preview_scale)))))
-        lidar_hit_marker_radius = max(2.0, min(4.0, lidar_beam_width + 0.5))
+        lidar_hit_marker_radius = max(2.0, min(4.0, 2.5 * max(1.0, preview_scale)))
         self.map_preview_canvas.create_oval(
             start_x - 5,
             start_y - 5,
@@ -2878,14 +2877,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 skipped_by_cell_filter_count += 1
                 continue
             drawn_beam_cells[beam_cell] = current_cell_count + 1
-            self.map_preview_canvas.create_line(
-                start_x,
-                start_y,
-                end_x,
-                end_y,
-                fill="#ffb300",
-                width=lidar_beam_width,
-            )
             self.map_preview_canvas.create_oval(
                 end_x - lidar_hit_marker_radius,
                 end_y - lidar_hit_marker_radius,
@@ -2901,7 +2892,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             f"gültige Ranges={finite_positive_beam_count}, "
             f"Stride übersprungen={skipped_by_stride_count}, "
             f"Zellfilter übersprungen={skipped_by_cell_filter_count}, "
-            f"gezeichnet={drawn_beam_count}, "
+            f"Punkte gezeichnet={drawn_beam_count}, "
             f"Zellgröße={effective_cell_size_px:.2f}px, "
             f"Stride={beam_stride}"
         )


### PR DESCRIPTION
### Motivation
- Das LiDAR-Referenz-Overlay im Missions-Workflow soll nur noch die Trefferpunkte (Hit-Marker) anzeigen und keine Strahlen-/Beam-Linien mehr zeichnen, um die Karte weniger visuell zu überfrachten.

### Description
- Entfernt das Zeichnen der Beam-Linien in `MissionWorkflowWindow._draw_lidar_scan_overlay_for_point` und zeichnet nur noch Trefferpunkte mit `create_oval`.
- Passt die Trefferpunktgrößeberechnung (`lidar_hit_marker_radius`) an und entfernt die `lidar_beam_width`-abhängige Linienbreite.
- Aktualisiert die Overlay-Validierungsnachricht von `gezeichnet` zu `Punkte gezeichnet`.
- Aktualisiert Tests in `tests/test_mission_workflow_ui.py` so, dass sie fehlschlagen, falls Beam-Linien wieder mit `create_line` gezeichnet werden, und stattdessen nur die Trefferpunkt-`create_oval`-Aufrufe zählen.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -q` and the test suite passed.
- Running `pytest -q tests/test_mission_workflow_ui.py -q` without `PYTHONPATH=. ` failed during collection due to module import resolution in the test environment (missing `transceiver` on sys.path).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc4b5e52ec8321a49813b20e6da6fb)