### PR TITLE
Limit heatmap point scaling to distinct positions

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -307,6 +307,47 @@ def test_draw_selected_echo_probability_overlay_scales_overlapping_point_radius(
     assert kwargs["fill"] == "#F4511E"
 
 
+def test_draw_selected_echo_probability_overlay_does_not_scale_same_position_overlap() -> None:
+    class FakeCanvas:
+        def __init__(self) -> None:
+            self.ovals: list[tuple[tuple[float, ...], dict[str, object]]] = []
+
+        def create_oval(self, *coords: float, **kwargs: object) -> int:
+            self.ovals.append((coords, kwargs))
+            return len(self.ovals)
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission = SimpleNamespace(map_config=SimpleNamespace(resolution=1.0))
+    window._map_image_original = SimpleNamespace(height=lambda: 100)
+    window._records = []
+    window._mission_points = []
+    window.map_preview_canvas = FakeCanvas()
+    window._append_validation = lambda _message: None
+    records = [
+        {
+            "live_position_at_measurement": {"x": 0.0, "y": 0.0},
+            "measurement": {"result": {"echo_delays": [{"distance_m": 1.0}]}},
+        },
+        {
+            "live_position_at_measurement": {"x": 0.0, "y": 0.0},
+            "measurement": {"result": {"echo_delays": [{"distance_m": 1.0}]}},
+        },
+    ]
+    window._build_echo_overlay_preview_points = lambda **_kwargs: ([10.0, 10.0], 1)
+
+    drawn = window._draw_selected_echo_probability_overlay(
+        rx_position=(0.0, 0.0),
+        records=records,
+    )
+
+    assert drawn is True
+    assert len(window.map_preview_canvas.ovals) == 1
+    coords, kwargs = window.map_preview_canvas.ovals[0]
+    radius = (coords[2] - coords[0]) / 2.0
+    assert radius == pytest.approx(0.65)
+    assert kwargs["fill"] == "#00796B"
+
+
 def test_selected_record_overlay_point_prefers_live_yaw() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._mission_points = [MeasurementPoint(id="p0", name="P0", x=50.0, y=50.0, yaw=0.5)]

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2375,12 +2375,21 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 sampled_point_count += 1
                 bucket = ellipse_point_cells.setdefault(
                     cell,
-                    {"x": 0.0, "y": 0.0, "samples": 0, "ellipses": set()},
+                    {
+                        "x": 0.0,
+                        "y": 0.0,
+                        "samples": 0,
+                        "ellipses": set(),
+                        "positions": set(),
+                    },
                 )
                 bucket["x"] += float(px)
                 bucket["y"] += float(py)
                 bucket["samples"] += 1
                 bucket["ellipses"].add(candidate_count)
+                bucket["positions"].add(
+                    (float(measurement_position[0]), float(measurement_position[1]))
+                )
         if not ellipse_point_cells:
             return False
         drawn_points = 0
@@ -2392,17 +2401,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             ellipse_count = len(bucket["ellipses"])
             if ellipse_count <= 0:
                 continue
-            max_overlap = max(max_overlap, ellipse_count)
+            position_count = len(bucket["positions"])
+            max_overlap = max(max_overlap, position_count)
             center_x = float(bucket["x"]) / sample_count
             center_y = float(bucket["y"]) / sample_count
             radius = min(
                 MULTI_SELECTION_ECHO_DOT_MAX_RADIUS_PX,
                 MULTI_SELECTION_ECHO_DOT_BASE_RADIUS_PX
-                + ((ellipse_count - 1) * MULTI_SELECTION_ECHO_DOT_OVERLAP_RADIUS_STEP_PX),
+                + ((position_count - 1) * MULTI_SELECTION_ECHO_DOT_OVERLAP_RADIUS_STEP_PX),
             )
             color = (
                 MULTI_SELECTION_ECHO_DOT_OVERLAP_COLOR
-                if ellipse_count > 1
+                if position_count > 1
                 else MULTI_SELECTION_ECHO_DOT_COLOR
             )
             self.map_preview_canvas.create_oval(


### PR DESCRIPTION
### Motivation
- Prevent heatmap dots from being enlarged when multiple ellipse samples come from the same measurement position, so visual overlap reflects distinct measurement origins only.
- Add a regression test to ensure identical-position records do not trigger overlap scaling or overlap color.

### Description
- Track originating measurement `(x,y)` coordinates per heatmap bucket by adding a `positions` set to the bucket structure in `transceiver/mission_workflow_ui.py`.
- Use the number of distinct positions (`position_count`) rather than the number of contributing ellipses to compute `radius`, `color`, and debug `max_overlap` for heatmap dots. (Replace usage of `ellipse_count` with `position_count` for scaling/color decisions.)
- Add a test `test_draw_selected_echo_probability_overlay_does_not_scale_same_position_overlap` to `tests/test_mission_workflow_ui.py` that verifies two records from the same coordinates do not enlarge the dot and keep the non-overlap color.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k 'echo_probability_overlay'` which passed (`3 passed, 85 deselected`).
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` which passed (`88 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc50012698832187a7e65a534e62f8)