### PR TITLE
Hide LIDAR reference overlay for multi-selected results

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -387,6 +387,35 @@ def test_draw_selected_lidar_reference_overlay_uses_live_measurement_position() 
     assert point.y == -2.0
 
 
+def test_draw_selected_lidar_reference_overlay_skips_multiple_selected_results() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._selected_result_index = 0
+    window._selected_result_indices = (0, 1)
+    window._records = [
+        {
+            "point_index": 0,
+            "live_position_at_measurement": {"x": 7.0, "y": -2.0, "yaw": 0.25},
+            "measurement": {"result": {"lidar_reference": {"output_file": "scan.yaml"}}},
+        },
+        {
+            "point_index": 1,
+            "live_position_at_measurement": {"x": 8.0, "y": -1.0, "yaw": 0.5},
+            "measurement": {"result": {"lidar_reference": {"output_file": "scan-2.yaml"}}},
+        },
+    ]
+    window._mission_points = [
+        MeasurementPoint(id="p0", name="P0", x=50.0, y=50.0, yaw=0.0),
+        MeasurementPoint(id="p1", name="P1", x=60.0, y=60.0, yaw=0.0),
+    ]
+    window._load_lidar_scan_for_overlay = lambda _path: {"angle_min": 0.0, "angle_increment": 0.1, "ranges": [1.0]}
+    calls: list[dict[str, object]] = []
+    window._draw_lidar_scan_overlay_for_point = lambda **kwargs: calls.append(kwargs)
+
+    window._draw_selected_lidar_reference_overlay()
+
+    assert calls == []
+
+
 def test_resolve_cmd_vel_topic_uses_namespace_when_present() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._runtime_config = SimpleNamespace(ros2_namespace="robot1")

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2707,6 +2707,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         return points
 
     def _draw_selected_lidar_reference_overlay(self) -> None:
+        selected_indices = getattr(self, "_selected_result_indices", ())
+        if len(selected_indices) > 1:
+            return
         record = self._selected_record_payload()
         if record is None:
             return


### PR DESCRIPTION
### Motivation
- The LIDAR reference overlay is not meaningful when multiple measurement results are selected, so it should be suppressed for multi-selection to avoid visual clutter and confusion.

### Description
- Add an early-return in `MissionWorkflowWindow._draw_selected_lidar_reference_overlay` that skips drawing when `self._selected_result_indices` contains more than one index.
- Add a regression test `test_draw_selected_lidar_reference_overlay_skips_multiple_selected_results` in `tests/test_mission_workflow_ui.py` to ensure the overlay is skipped for multi-selection while preserving single-selection behavior.
- Modified files: `transceiver/mission_workflow_ui.py` and `tests/test_mission_workflow_ui.py`.

### Testing
- Ran `pytest tests/test_mission_workflow_ui.py -q` which initially failed during collection due to a missing `PYTHONPATH` leading to `ModuleNotFoundError` for the package import. 
- Re-ran with `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` and all tests in that file passed (`89 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc540f22a88321b160a527873ead38)