### PR TITLE
Static map layer-Signatur um vollständige Ergebnis-Auswahl erweitern

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -169,6 +169,49 @@ def test_selected_record_measurement_position_returns_none_without_live_coordina
     assert position is None
 
 
+def _window_for_static_map_layer_signature() -> MissionWorkflowWindow:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission_points = [MeasurementPoint(id="p0", name="P0", x=1.0, y=2.0, yaw=0.0)]
+    window._map_image_original = object()
+    window._selected_point_index = None
+    window._selected_result_index = None
+    window._selected_result_indices = ()
+    window._rx_antenna_global_position = None
+    window._measurement_start_world_position = None
+    window._measurement_end_world_position = None
+    window._pending_nav2point_world_position = None
+    window._pending_nav2point_yaw_radians = None
+    window._pending_waypoint_world_position = None
+    window._pending_waypoint_yaw_radians = None
+    return window
+
+
+def test_static_map_layer_signature_tracks_full_forward_result_selection() -> None:
+    window = _window_for_static_map_layer_signature()
+    window._selected_result_index = 0
+    window._selected_result_indices = (0,)
+    single_selection_signature = window._build_static_map_layer_signature(canvas_width=640, canvas_height=480)
+
+    window._selected_result_indices = (0, 1, 2)
+    multi_selection_signature = window._build_static_map_layer_signature(canvas_width=640, canvas_height=480)
+
+    assert window._selected_result_index == 0
+    assert single_selection_signature != multi_selection_signature
+
+
+def test_static_map_layer_signature_tracks_full_reverse_result_selection() -> None:
+    window = _window_for_static_map_layer_signature()
+    window._selected_result_index = 0
+    window._selected_result_indices = (0,)
+    single_selection_signature = window._build_static_map_layer_signature(canvas_width=640, canvas_height=480)
+
+    window._selected_result_indices = (2, 1, 0)
+    reverse_selection_signature = window._build_static_map_layer_signature(canvas_width=640, canvas_height=480)
+
+    assert window._selected_result_index == 0
+    assert single_selection_signature != reverse_selection_signature
+
+
 def test_draw_selected_echo_overlay_uses_live_measurement_position() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._selected_result_index = 0

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1442,6 +1442,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             mission_points_signature,
             self._selected_point_index,
             self._selected_result_index,
+            tuple(getattr(self, "_selected_result_indices", ())),
             self._rx_antenna_global_position,
             self._measurement_start_world_position,
             self._measurement_end_world_position,


### PR DESCRIPTION
### Motivation
- Statische Overlay-Renderings müssen invalidiert werden, wenn sich die Mehrfachauswahl der Ergebnisse ändert, auch wenn der primäre `_selected_result_index` unverändert bleibt.

### Description
- Ergänzt in `_build_static_map_layer_signature` die vollständige Ergebnis-Auswahl als `tuple(getattr(self, "_selected_result_indices", ()))` direkt neben `self._selected_result_index`.
- Fügt in `tests/test_mission_workflow_ui.py` einen Test-Helper `_window_for_static_map_layer_signature` hinzu, der ein minimales Window-Objekt für Signatur-Tests initialisiert.
- Ergänzt zwei Regressionstests: einer, der die Änderung von Einzel- zu Mehrfachauswahl `(0,) -> (0,1,2)` prüft, und einer, der die rückwärts gerichtete Auswahl `(0,) -> (2,1,0)` prüft, wobei `_selected_result_index == 0` bleibt.

### Testing
- `python -m pytest tests/test_mission_workflow_ui.py -q` wurde ausgeführt und lieferte `93 passed`.
- Ein direkter `pytest tests/test_mission_workflow_ui.py -q` Aufruf schlug zuvor während der Test-Collection mit `ModuleNotFoundError: No module named 'transceiver'` fehl; der `python -m pytest` Aufruf lief erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc560bcf2883219cfb6d11281612f1)