### PR TITLE
Map-Signatur um Mehrfachauswahl erweitern

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1443,6 +1443,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             mission_points_signature,
             self._selected_point_index,
             self._selected_result_index,
+            self._selected_result_indices,
             self._rx_antenna_global_position,
             self._measurement_start_world_position,
             self._measurement_end_world_position,


### PR DESCRIPTION
### Motivation
- Damit Änderungen der Mehrfachauswahl das statische Karten-Layer neu zeichnen, auch wenn `self._selected_result_index` unverändert bleibt (z. B. Shift-Mehrfachauswahl), soll die Signatur erweitert werden.

### Description
- Füge `self._selected_result_indices` direkt neben `self._selected_result_index` in die Rückgabe von `_build_static_map_layer_signature()` in `transceiver/mission_workflow_ui.py` ein.

### Testing
- `python -m py_compile transceiver/mission_workflow_ui.py` wurde ausgeführt und schlägt fehl nicht (kompiliert erfolgreich).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc58f915548321af92745d8c34697b)