### PR TITLE
Track full result selection in static map signature

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -207,9 +207,12 @@ def test_static_map_layer_signature_tracks_full_reverse_result_selection() -> No
 
     window._selected_result_indices = (2, 1, 0)
     reverse_selection_signature = window._build_static_map_layer_signature(canvas_width=640, canvas_height=480)
+    window._selected_result_indices = (0, 1, 2)
+    normalized_selection_signature = window._build_static_map_layer_signature(canvas_width=640, canvas_height=480)
 
     assert window._selected_result_index == 0
     assert single_selection_signature != reverse_selection_signature
+    assert reverse_selection_signature == normalized_selection_signature
 
 
 def test_draw_selected_echo_overlay_uses_live_measurement_position() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1436,6 +1436,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _build_static_map_layer_signature(self, *, canvas_width: int, canvas_height: int) -> tuple[Any, ...]:
         mission_points_signature = tuple((point.id, point.x, point.y, point.yaw) for point in self._mission_points)
+        selected_result_indices_signature = tuple(sorted(getattr(self, "_selected_result_indices", ())))
         return (
             canvas_width,
             canvas_height,
@@ -1443,7 +1444,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             mission_points_signature,
             self._selected_point_index,
             self._selected_result_index,
-            self._selected_result_indices,
+            selected_result_indices_signature,
             self._rx_antenna_global_position,
             self._measurement_start_world_position,
             self._measurement_end_world_position,


### PR DESCRIPTION
### Motivation
- Ensure the static map layer cache invalidates when the full multi-selection of results changes (e.g. `(0,)` → `(0,1,2)`), even if `_selected_result_index` remains the same.

### Description
- Normalize and include the complete selected-result tuple in the static map signature by adding `selected_result_indices_signature = tuple(sorted(getattr(self, "_selected_result_indices", ())))` and using it in `_build_static_map_layer_signature` instead of the raw `_selected_result_indices`.
- Extend the reverse-selection test to assert that a reverse-ordered selection `(2,1,0)` normalizes to the same signature as `(0,1,2)` while still invalidating a prior single-selection signature.

### Testing
- Ran the focused signature and selection tests with `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py::test_static_map_layer_signature_tracks_full_forward_result_selection tests/test_mission_workflow_ui.py::test_static_map_layer_signature_tracks_full_reverse_result_selection tests/test_mission_workflow_ui.py::test_on_results_table_select_updates_multi_selection_and_diagnostics tests/test_mission_workflow_ui.py::test_draw_selected_echo_overlay_renders_all_selected_results -q`, all of which passed (`4 passed`).
- Ran the full test module with `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q`, which yielded many passing tests but revealed 3 unrelated failures in existing echo-probability overlay expectations (`90 passed, 3 failed`); running without `PYTHONPATH=.` fails collection due to import path issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc5c4f5f1083218d2be7ecd0dc38e7)