### PR TITLE
Fix workflow UI f-string syntax

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3778,11 +3778,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self.reverse_point_order_var.set(bool(payload.get("reverse_point_order", False)))
             self.live_pose_stream_enabled_var.set(bool(payload.get("live_pose_stream_enabled", False)))
             self.live_preview_enabled_var.set(bool(payload.get("live_preview_enabled", False)))
+            echo_heatmap_imaginary_line_width_px = _parse_positive_float(
+                payload.get("echo_heatmap_imaginary_line_width_px"),
+                default=MULTI_SELECTION_ECHO_DOT_IMAGINARY_LINE_WIDTH_PX,
+            )
             self.echo_heatmap_imaginary_line_width_var.set(
-                f"{_parse_positive_float(
-                    payload.get('echo_heatmap_imaginary_line_width_px'),
-                    default=MULTI_SELECTION_ECHO_DOT_IMAGINARY_LINE_WIDTH_PX,
-                ):g}"
+                f"{echo_heatmap_imaginary_line_width_px:g}"
             )
             self.echo_heatmap_min_visible_overlap_var.set(
                 str(


### PR DESCRIPTION
### Motivation
- The UI failed to start due to a `SyntaxError` caused by a multiline expression inside an f-string when parsing the echo heatmap imaginary line width.

### Description
- Extract the parsed value from `_parse_positive_float(...)` into a local variable `echo_heatmap_imaginary_line_width_px` before formatting it.
- Replace the previous multiline f-string expression with a single `f"{echo_heatmap_imaginary_line_width_px:g}"` to ensure the file parses correctly and behavior remains unchanged.

### Testing
- Ran `python -m py_compile transceiver/mission_workflow_ui.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc5f7ab7ec8321a1a7ef946ac530b8)