### PR TITLE
Show power delay profile in mission review

### DIFF
--- a/tests/test_crosscorr_normalization.py
+++ b/tests/test_crosscorr_normalization.py
@@ -34,6 +34,7 @@ def _install_pyqtgraph_stub() -> None:
     pg_mod.Qt = qt_mod
     pg_mod.exporters = types.ModuleType("pyqtgraph.exporters")
     pg_mod.ScatterPlotItem = type("ScatterPlotItem", (), {})
+    pg_mod.ViewBox = type("ViewBox", (), {})
     pg_mod.PlotWidget = type("PlotWidget", (), {})
     pg_mod.InfiniteLine = type("InfiniteLine", (), {})
 
@@ -264,6 +265,14 @@ class _DummyEntryWidget:
 
     def get(self) -> str:
         return self._text
+
+
+def test_power_delay_profile_squares_cir_magnitude() -> None:
+    from transceiver.__main__ import _power_delay_profile_from_cir_magnitude
+
+    pdp = _power_delay_profile_from_cir_magnitude(np.array([0.0, 2.0, 3.5], dtype=float))
+
+    np.testing.assert_allclose(pdp, np.array([0.0, 4.0, 12.25], dtype=float))
 
 
 def test_rx_interpolation_factor_prefers_continuous_value_on_continuous_tab() -> None:

--- a/tests/test_receive_for_mission_threading.py
+++ b/tests/test_receive_for_mission_threading.py
@@ -365,6 +365,143 @@ def test_review_measurement_for_mission_applies_same_interpolation_as_single_rec
     assert outcome["approved"] is False
 
 
+def test_review_measurement_for_mission_passes_power_delay_profile_to_dialog(monkeypatch) -> None:
+    import numpy as np
+    import queue
+    import transceiver.__main__ as app_module
+
+    ui = object.__new__(TransceiverUI)
+    ui._ui = lambda callback: callback()
+    ui._out_queue = queue.Queue()
+    ui.latest_fs = 10.0
+    ui.rx_channel_2 = types.SimpleNamespace(get=lambda: False)
+    ui.rx_xcorr_normalized_enable = types.SimpleNamespace(get=lambda: False)
+    ui.rx_interpolation_enable = types.SimpleNamespace(get=lambda: False)
+    ui._select_rx_display_data = lambda loaded: (loaded, "CH0")
+    ui._get_crosscorr_reference = lambda: (np.array([1.0], dtype=float), "TX")
+    ui._apply_crosscorr_interpolation = (
+        lambda data, fs, ref_data, crosscorr_compare=None, **_kwargs: (data, ref_data, crosscorr_compare, fs)
+    )
+    ui._rx_effective_interpolation_factor = lambda: 1.0
+    ui._mission_workflow_window = None
+
+    monkeypatch.setattr(
+        app_module.rx_convert,
+        "load_iq_file",
+        lambda *_args, **_kwargs: np.array([2.0], dtype=float),
+    )
+    monkeypatch.setattr(app_module.pg, "mkQApp", lambda: types.SimpleNamespace(activeWindow=lambda: None))
+    monkeypatch.setattr(app_module, "_mission_review_qt_parent", lambda _qapp, _workflow_window: None)
+    monkeypatch.setattr(
+        app_module,
+        "_build_crosscorr_ctx",
+        lambda *_args, **_kwargs: {
+            "lags": np.array([0.0, 1.0, 2.0]),
+            "mag": np.array([2.0, 3.0, 4.0]),
+            "los_idx": 1,
+            "echo_indices": [2],
+            "period_samples": 3,
+        },
+    )
+    monkeypatch.setattr(app_module, "_classify_visible_xcorr_peaks", lambda *_args, **_kwargs: (2, 1, [2]))
+
+    dialog_init_kwargs: dict[str, object] = {}
+
+    class _DummyDialog:
+        def __init__(self, **kwargs):
+            dialog_init_kwargs.update(kwargs)
+            self.confirmed = False
+            self.selected_los_idx = None
+            self.selected_echo_indices = []
+            self.manual_lags = {}
+            self.echo_delays = []
+
+        def raise_(self):
+            return None
+
+        def activateWindow(self):
+            return None
+
+        def exec(self):
+            return 0
+
+    monkeypatch.setattr(app_module, "MissionMeasurementReviewDialog", _DummyDialog)
+
+    outcome = TransceiverUI.review_measurement_for_mission(
+        ui,
+        point_label="P1",
+        output_file="signals/rx/mission/demo.bin",
+    )
+
+    np.testing.assert_allclose(dialog_init_kwargs["magnitudes"], np.array([4.0, 9.0, 16.0]))
+    assert dialog_init_kwargs["los_idx"] == 1
+    assert dialog_init_kwargs["echo_indices"] == [2]
+    assert outcome["approved"] is False
+
+
+def test_review_auto_approve_detects_peaks_on_power_delay_profile(monkeypatch) -> None:
+    import numpy as np
+    import queue
+    import transceiver.__main__ as app_module
+
+    ui = object.__new__(TransceiverUI)
+    ui._ui = lambda callback: callback()
+    ui._out_queue = queue.Queue()
+    ui.latest_fs = 10.0
+    ui.rx_channel_2 = types.SimpleNamespace(get=lambda: False)
+    ui.rx_xcorr_normalized_enable = types.SimpleNamespace(get=lambda: False)
+    ui.rx_interpolation_enable = types.SimpleNamespace(get=lambda: False)
+    ui._select_rx_display_data = lambda loaded: (loaded, "CH0")
+    ui._get_crosscorr_reference = lambda: (np.array([1.0], dtype=float), "TX")
+    ui._apply_crosscorr_interpolation = (
+        lambda data, fs, ref_data, crosscorr_compare=None, **_kwargs: (data, ref_data, crosscorr_compare, fs)
+    )
+    ui._rx_effective_interpolation_factor = lambda: 1.0
+    ui._mission_workflow_window = None
+
+    monkeypatch.setattr(
+        app_module.rx_convert,
+        "load_iq_file",
+        lambda *_args, **_kwargs: np.array([2.0], dtype=float),
+    )
+    monkeypatch.setattr(app_module.pg, "mkQApp", lambda: types.SimpleNamespace(activeWindow=lambda: None))
+    monkeypatch.setattr(app_module, "_mission_review_qt_parent", lambda _qapp, _workflow_window: None)
+    monkeypatch.setattr(
+        app_module,
+        "_build_crosscorr_ctx",
+        lambda *_args, **_kwargs: {
+            "lags": np.array([0.0, 1.0, 2.0]),
+            "mag": np.array([2.0, 3.0, 4.0]),
+            "los_idx": 1,
+            "echo_indices": [2],
+            "period_samples": 3,
+        },
+    )
+
+    classified_inputs: list[np.ndarray] = []
+
+    def _fake_classify(magnitudes, **_kwargs):
+        classified_inputs.append(np.asarray(magnitudes, dtype=float))
+        return 2, 1, [2]
+
+    monkeypatch.setattr(app_module, "_classify_visible_xcorr_peaks", _fake_classify)
+
+    outcome = TransceiverUI.review_measurement_for_mission(
+        ui,
+        point_label="P1",
+        output_file="signals/rx/mission/demo.bin",
+        auto_approve=True,
+    )
+
+    assert classified_inputs
+    for classified_input in classified_inputs:
+        np.testing.assert_allclose(classified_input, np.array([4.0, 9.0, 16.0]))
+    assert outcome["approved"] is True
+    assert outcome["los_idx"] == 1
+    assert outcome["echo_indices"] == [2]
+    assert outcome["echo_delays"] == [1]
+
+
 def test_review_measurement_for_mission_uses_persisted_tx_reference_without_single_rx(
     monkeypatch, tmp_path
 ) -> None:

--- a/transceiver/__main__.py
+++ b/transceiver/__main__.py
@@ -164,6 +164,11 @@ def _repetition_period_samples_from_tx(tx_length_samples: int, lag_step: int = 1
     return max(1, int(tx_length_samples) * max(1, int(lag_step)))
 
 
+def _power_delay_profile_from_cir_magnitude(magnitude: np.ndarray) -> np.ndarray:
+    """Return the power delay profile for magnitude-domain CIR samples."""
+    return np.square(np.abs(np.asarray(magnitude, dtype=float)))
+
+
 def _classify_visible_xcorr_peaks(
     mag: np.ndarray,
     *,
@@ -1896,8 +1901,8 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
 
         layout = QtWidgets.QVBoxLayout(self)
         header = QtWidgets.QLabel(
-            f"Crosscorrelation Review für {point_label}\n"
-            "Bitte LOS/Echo-Peaks prüfen und Messung explizit bestätigen."
+            f"Power-Delay-Profile Review für {point_label}\n"
+            "Bitte LOS/Echo-Peaks im Power Delay Profile prüfen und Messung explizit bestätigen."
         )
         layout.addWidget(header)
 
@@ -1908,9 +1913,9 @@ class MissionMeasurementReviewDialog(QtWidgets.QDialog):
         self._plot = plot_widget.getPlotItem()
         _style_pg_preview_axes(self._plot, PLOT_COLORS["text"])
         self._plot.showGrid(x=True, y=True, alpha=0.2)
-        self._plot.setTitle("Crosscorr. mit Peak-Labels")
+        self._plot.setTitle("Power Delay Profile mit Peak-Labels")
         self._plot.setLabel("bottom", "Lag")
-        self._plot.setLabel("left", "Magnitude")
+        self._plot.setLabel("left", "Power")
         layout.addWidget(plot_widget, stretch=1)
 
         self._stats_label = QtWidgets.QLabel("LOS-Echos: --")
@@ -7641,8 +7646,22 @@ class TransceiverUI(ctk.CTk):
                 )
                 lags = np.asarray(ctx.get("lags", np.array([], dtype=float)))
                 mag = np.asarray(ctx.get("mag", np.array([], dtype=float)))
-                los_idx = ctx.get("los_idx")
-                echo_indices = [int(idx) for idx in list(ctx.get("echo_indices", []))]
+                power_delay_profile = _power_delay_profile_from_cir_magnitude(mag)
+                period_samples = int(ctx.get("period_samples")) if ctx.get("period_samples") is not None else None
+                _review_highest_idx, detected_review_los_idx, detected_review_echo_indices = _classify_visible_xcorr_peaks(
+                    power_delay_profile,
+                    repetition_period_samples=max(1, int(period_samples or len(lags) or 1)),
+                )
+                los_idx = detected_review_los_idx if detected_review_los_idx is not None else ctx.get("los_idx")
+                if detected_review_los_idx is not None:
+                    echo_indices = _filter_peak_indices_to_period_group(
+                        lags,
+                        [int(idx) for idx in detected_review_echo_indices if idx is not None],
+                        int(detected_review_los_idx),
+                        period_samples,
+                    )
+                else:
+                    echo_indices = [int(idx) for idx in list(ctx.get("echo_indices", []))]
                 if isinstance(initial_review, dict) and lags.size:
                     prefill_los_lag = initial_review.get("los_lag")
                     if isinstance(prefill_los_lag, (int, float)):
@@ -7657,8 +7676,8 @@ class TransceiverUI(ctk.CTk):
                                 )
                         if prefilled_echo_indices:
                             echo_indices = prefilled_echo_indices
-                if lags.size == 0 or mag.size == 0 or los_idx is None:
-                    detail = "Crosscorrelation enthält keine auswertbaren Peaks (LOS fehlt)."
+                if lags.size == 0 or power_delay_profile.size == 0 or los_idx is None:
+                    detail = "Power Delay Profile enthält keine auswertbaren Peaks (LOS fehlt)."
                     messagebox.showerror("Mission Review", detail)
                     outcome["approved"] = False
                     outcome["reason"] = REVIEW_REASON_NO_DETECTABLE_LOS
@@ -7666,8 +7685,8 @@ class TransceiverUI(ctk.CTk):
                     return
                 if auto_approve:
                     _highest_idx, detected_los_idx, detected_echo_indices = _classify_visible_xcorr_peaks(
-                        mag,
-                        repetition_period_samples=max(1, int(ctx.get("period_samples") or len(lags) or 1)),
+                        power_delay_profile,
+                        repetition_period_samples=max(1, int(period_samples or len(lags) or 1)),
                     )
                     if detected_los_idx is None:
                         detail = "Auto Detect konnte keinen LOS-Peak bestimmen."
@@ -7675,7 +7694,6 @@ class TransceiverUI(ctk.CTk):
                         outcome["reason"] = REVIEW_REASON_NO_DETECTABLE_LOS
                         outcome["detail"] = detail
                         return
-                    period_samples = int(ctx.get("period_samples")) if ctx.get("period_samples") is not None else None
                     filtered_echo_indices = _filter_peak_indices_to_period_group(
                         lags,
                         [int(idx) for idx in detected_echo_indices if idx is not None],
@@ -7712,7 +7730,7 @@ class TransceiverUI(ctk.CTk):
                     parent=parent_window,
                     point_label=point_label,
                     lags=lags,
-                    magnitudes=mag,
+                    magnitudes=power_delay_profile,
                     los_idx=int(los_idx),
                     echo_indices=echo_indices,
                     interpolation_factor=self._rx_effective_interpolation_factor()


### PR DESCRIPTION
### Motivation
- The mission measurement review should display the Power Delay Profile (PDP) instead of the channel impulse response magnitude so LOS/echo detection and auto-detect operate on power (|h|^2) as requested.

### Description
- Add `_power_delay_profile_from_cir_magnitude(magnitude)` which returns the squared magnitude (power) of CIR samples and use it as the review trace.
- Use the PDP for automatic peak detection (auto-detect / auto-approve) and for the data passed into the review dialog instead of the original CIR magnitude.
- Update UI text and plot labels in the review dialog to reference the Power Delay Profile and show the Y-axis as "Power".
- Add unit/regression tests for the PDP conversion, ensure the review dialog receives the PDP, and verify auto-approve uses the PDP; also add a small test stub update (pyqtgraph `ViewBox`) to support test execution.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_crosscorr_normalization.py::test_power_delay_profile_squares_cir_magnitude` which passed (PDP conversion verified).
- Ran `PYTHONPATH=. pytest tests/test_receive_for_mission_threading.py::test_review_measurement_for_mission_passes_power_delay_profile_to_dialog` which passed (dialog receives PDP).
- Ran `PYTHONPATH=. pytest tests/test_receive_for_mission_threading.py::test_review_auto_approve_detects_peaks_on_power_delay_profile` which passed (auto-detect exercised on PDP).
- Performed `python -m py_compile transceiver/__main__.py tests/test_crosscorr_normalization.py tests/test_receive_for_mission_threading.py` which succeeded (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a18674f26208321bbd2cff2156742ec)