### PR TITLE
Add toggles to show/hide multi-result echo evaluation and ellipses

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -253,6 +253,8 @@ def test_draw_selected_echo_overlay_renders_all_selected_results() -> None:
         },
     ]
     window._rx_antenna_global_position = (1.0, 1.0)
+    window.echo_heatmap_evaluation_visible_var = SimpleNamespace(get=lambda: False)
+    window.echo_heatmap_ellipses_visible_var = SimpleNamespace(get=lambda: True)
     window._mission_points = [
         MeasurementPoint(id="p0", name="P0", x=50.0, y=50.0, yaw=0.0),
         MeasurementPoint(id="p1", name="P1", x=60.0, y=60.0, yaw=0.0),
@@ -265,6 +267,33 @@ def test_draw_selected_echo_overlay_renders_all_selected_results() -> None:
     assert len(calls) == 2
     assert {call["measurement_position"] for call in calls} == {(7.0, -2.0), (8.0, -1.0)}
 
+
+
+def test_draw_selected_echo_overlay_hides_multi_selection_ellipses_by_default() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._selected_result_index = 0
+    window._selected_result_indices = (0, 1)
+    window._records = [
+        {
+            "live_position_at_measurement": {"x": 7.0, "y": -2.0},
+            "measurement": {"result": {"echo_delays": [{"distance_m": 3.0}]}},
+        },
+        {
+            "live_position_at_measurement": {"x": 8.0, "y": -1.0},
+            "measurement": {"result": {"echo_delays": [{"distance_m": 4.0}]}},
+        },
+    ]
+    window._rx_antenna_global_position = (1.0, 1.0)
+    probability_calls: list[dict[str, object]] = []
+    ellipse_calls: list[dict[str, object]] = []
+    window._draw_selected_echo_probability_overlay = lambda **kwargs: probability_calls.append(kwargs) or True
+    window._draw_echo_ellipse_for_overlay = lambda **kwargs: ellipse_calls.append(kwargs)
+
+    overlay_visible = window._draw_selected_echo_overlay()
+
+    assert overlay_visible is True
+    assert len(probability_calls) == 1
+    assert ellipse_calls == []
 
 def test_draw_selected_echo_probability_overlay_draws_dot_cloud_without_grid_rectangles() -> None:
     class FakeCanvas:
@@ -451,12 +480,16 @@ def test_workflow_state_payload_persists_echo_heatmap_settings() -> None:
     window.live_preview_enabled_var = SimpleNamespace(get=lambda: False)
     window.echo_heatmap_imaginary_line_width_var = SimpleNamespace(get=lambda: "6.5")
     window.echo_heatmap_min_visible_overlap_var = SimpleNamespace(get=lambda: "7")
+    window.echo_heatmap_evaluation_visible_var = SimpleNamespace(get=lambda: False)
+    window.echo_heatmap_ellipses_visible_var = SimpleNamespace(get=lambda: True)
     window._records = []
 
     payload = window._build_workflow_state_payload()
 
     assert payload["echo_heatmap_imaginary_line_width_cm"] == 6.5
     assert payload["echo_heatmap_min_visible_overlap"] == 7
+    assert payload["echo_heatmap_evaluation_visible"] is False
+    assert payload["echo_heatmap_ellipses_visible"] is True
 
 
 def test_selected_record_overlay_point_prefers_live_yaw() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -399,6 +399,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.echo_heatmap_antenna_opening_angle_deg_var = tk.StringVar(
             value=f"{MULTI_SELECTION_ECHO_DOT_ANTENNA_OPENING_ANGLE_DEG:g}"
         )
+        self.echo_heatmap_evaluation_visible_var = tk.BooleanVar(value=True)
+        self.echo_heatmap_ellipses_visible_var = tk.BooleanVar(value=False)
         self._echo_heatmap_settings_trace_pending = False
         self._live_pose_stream_active = False
 
@@ -469,6 +471,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         )
         return min(360.0, angle)
 
+    def _echo_heatmap_evaluation_visible(self) -> bool:
+        variable = getattr(self, "echo_heatmap_evaluation_visible_var", None)
+        if variable is None:
+            return True
+        return bool(variable.get())
+
+    def _echo_heatmap_ellipses_visible(self) -> bool:
+        variable = getattr(self, "echo_heatmap_ellipses_visible_var", None)
+        if variable is None:
+            return False
+        return bool(variable.get())
+
     def _build_echo_heatmap_settings_overlay(self) -> tk.Frame:
         frame = tk.Frame(
             self.map_preview_canvas,
@@ -521,6 +535,28 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             validatecommand=(self.register(self._validate_positive_float_input), "%P"),
             **entry_kwargs,
         ).grid(row=3, column=1, sticky="w", padx=(2, 8), pady=(2, 6))
+        checkbutton_kwargs = {
+            "bg": "#20242a",
+            "fg": "#f5f5f5",
+            "activebackground": "#20242a",
+            "activeforeground": "#f5f5f5",
+            "selectcolor": "#2f3640",
+            "anchor": "w",
+        }
+        tk.Checkbutton(
+            frame,
+            text="Auswertung anzeigen",
+            variable=self.echo_heatmap_evaluation_visible_var,
+            command=self._on_echo_heatmap_settings_changed,
+            **checkbutton_kwargs,
+        ).grid(row=4, column=0, columnspan=2, sticky="ew", padx=8, pady=(2, 0))
+        tk.Checkbutton(
+            frame,
+            text="Ellipsen anzeigen",
+            variable=self.echo_heatmap_ellipses_visible_var,
+            command=self._on_echo_heatmap_settings_changed,
+            **checkbutton_kwargs,
+        ).grid(row=5, column=0, columnspan=2, sticky="ew", padx=8, pady=(0, 6))
         return frame
 
     def _sync_echo_heatmap_settings_overlay(self, *, visible: bool) -> None:
@@ -673,6 +709,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "write", lambda *_args: self._on_echo_heatmap_settings_changed()
         )
         self.echo_heatmap_antenna_opening_angle_deg_var.trace_add(
+            "write", lambda *_args: self._on_echo_heatmap_settings_changed()
+        )
+        self.echo_heatmap_evaluation_visible_var.trace_add(
+            "write", lambda *_args: self._on_echo_heatmap_settings_changed()
+        )
+        self.echo_heatmap_ellipses_visible_var.trace_add(
             "write", lambda *_args: self._on_echo_heatmap_settings_changed()
         )
         self._map_image_original: tk.PhotoImage | None = None
@@ -1640,6 +1682,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._measurement_end_world_position,
             self._echo_heatmap_imaginary_line_width_cm(),
             self._echo_heatmap_min_visible_overlap(),
+            self._echo_heatmap_evaluation_visible(),
+            self._echo_heatmap_ellipses_visible(),
             self._pending_nav2point_world_position,
             self._pending_nav2point_yaw_radians,
             self._pending_waypoint_world_position,
@@ -2526,10 +2570,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if rx_position is None:
             return False
         selected_records = self._selected_record_payloads()
-        if len(selected_records) > 1 and self._draw_selected_echo_probability_overlay(
-            rx_position=rx_position,
-            records=selected_records,
+        multiple_records_selected = len(selected_records) > 1
+        if (
+            multiple_records_selected
+            and self._echo_heatmap_evaluation_visible()
+            and self._draw_selected_echo_probability_overlay(
+                rx_position=rx_position,
+                records=selected_records,
+            )
+            and not self._echo_heatmap_ellipses_visible()
         ):
+            return True
+        if multiple_records_selected and not self._echo_heatmap_ellipses_visible():
             return True
         for record in selected_records:
             measurement_position = self._selected_record_measurement_position(record)
@@ -2552,7 +2604,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                     echo_distance_m=echo_distance,
                     color=color,
                 )
-        return False
+        return multiple_records_selected
 
     def _draw_selected_echo_probability_overlay(
         self,
@@ -3768,6 +3820,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "echo_heatmap_imaginary_line_width_cm": self._echo_heatmap_imaginary_line_width_cm(),
             "echo_heatmap_min_visible_overlap": self._echo_heatmap_min_visible_overlap(),
             "echo_heatmap_antenna_opening_angle_deg": self._echo_heatmap_antenna_opening_angle_deg(),
+            "echo_heatmap_evaluation_visible": self._echo_heatmap_evaluation_visible(),
+            "echo_heatmap_ellipses_visible": self._echo_heatmap_ellipses_visible(),
             "records": self._records,
         }
 
@@ -3882,6 +3936,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             )
             self.echo_heatmap_antenna_opening_angle_deg_var.set(
                 f"{min(360.0, echo_heatmap_antenna_opening_angle_deg):g}"
+            )
+            self.echo_heatmap_evaluation_visible_var.set(
+                bool(payload.get("echo_heatmap_evaluation_visible", True))
+            )
+            self.echo_heatmap_ellipses_visible_var.set(
+                bool(payload.get("echo_heatmap_ellipses_visible", False))
             )
             self._refresh_points_table()
             self._refresh_map_section()


### PR DESCRIPTION
### Motivation
- Provide controls to let users show/hide the multi-result echo evaluation dots (Auswertung) and the computed ellipses independently when multiple results are selected on the map.
- Keep the current default behavior (evaluation visible) while making ellipses opt-in to reduce visual clutter for multi-selection overlays.

### Description
- Introduce two new boolean UI variables `echo_heatmap_evaluation_visible_var` (default `True`) and `echo_heatmap_ellipses_visible_var` (default `False`) and accessor methods `._echo_heatmap_evaluation_visible()` and `._echo_heatmap_ellipses_visible()`.
- Add two checkboxes to the Echo-Heatmap overlay labeled `Auswertung anzeigen` and `Ellipsen anzeigen`, wired to redraw via `_on_echo_heatmap_settings_changed()` when toggled.
- Update multi-selection overlay rendering in `_draw_selected_echo_overlay()` to respect the toggles so that the probability/dot heatmap is shown by default while ellipses are drawn only when enabled; ensure the overlay return value reflects multi-selection visibility.
- Persist and restore the new flags in the workflow state payload via `_build_workflow_state_payload()` and `_restore_workflow_state()` and include them in the static layer signature so redraws consider the flags.
- Add and update unit tests to cover the new default behavior and state persistence, and add trace handling for the new variables.

### Testing
- Ran unit tests with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py tests/test_mission_workflow_ui_state.py -q`, and they passed.
- Verified module compiles with `python -m py_compile transceiver/mission_workflow_ui.py`, which succeeded.
- Additional focused runs of `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -q` and `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui_state.py -q` also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19969d8c708321aba7e75869102208)