### PR TITLE
Draw evaluation points above echo ellipses

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -269,6 +269,36 @@ def test_draw_selected_echo_overlay_renders_all_selected_results() -> None:
 
 
 
+
+def test_draw_selected_echo_overlay_draws_evaluation_points_above_ellipses() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._selected_result_index = 0
+    window._selected_result_indices = (0, 1)
+    window._records = [
+        {
+            "live_position_at_measurement": {"x": 7.0, "y": -2.0},
+            "measurement": {"result": {"echo_delays": [{"distance_m": 3.0}]}},
+        },
+        {
+            "live_position_at_measurement": {"x": 8.0, "y": -1.0},
+            "measurement": {"result": {"echo_delays": [{"distance_m": 4.0}]}},
+        },
+    ]
+    window._rx_antenna_global_position = (1.0, 1.0)
+    window.echo_heatmap_evaluation_visible_var = SimpleNamespace(get=lambda: True)
+    window.echo_heatmap_ellipses_visible_var = SimpleNamespace(get=lambda: True)
+    draw_order: list[str] = []
+    window._draw_echo_ellipse_for_overlay = lambda **_kwargs: draw_order.append("ellipse")
+    window._draw_selected_echo_probability_overlay = (
+        lambda **_kwargs: draw_order.append("evaluation") or True
+    )
+
+    overlay_visible = window._draw_selected_echo_overlay()
+
+    assert overlay_visible is True
+    assert draw_order == ["ellipse", "ellipse", "evaluation"]
+
+
 def test_draw_selected_echo_overlay_hides_multi_selection_ellipses_by_default() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._selected_result_index = 0

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2572,39 +2572,34 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             return False
         selected_records = self._selected_record_payloads()
         multiple_records_selected = len(selected_records) > 1
-        if (
-            multiple_records_selected
-            and self._echo_heatmap_evaluation_visible()
-            and self._draw_selected_echo_probability_overlay(
+        ellipses_visible = not multiple_records_selected or self._echo_heatmap_ellipses_visible()
+        if ellipses_visible:
+            for record in selected_records:
+                measurement_position = self._selected_record_measurement_position(record)
+                if measurement_position is None:
+                    continue
+                measurement = record.get("measurement")
+                if not isinstance(measurement, dict):
+                    continue
+                result = measurement.get("result")
+                if not isinstance(result, dict):
+                    continue
+                echo_distances = self._extract_echo_distances(result.get("echo_delays"), limit=len(ECHO_OVERLAY_COLORS))
+                if not echo_distances:
+                    continue
+                for echo_index, echo_distance in enumerate(echo_distances):
+                    color = ECHO_OVERLAY_COLORS[echo_index % len(ECHO_OVERLAY_COLORS)]
+                    self._draw_echo_ellipse_for_overlay(
+                        rx_position=rx_position,
+                        measurement_position=measurement_position,
+                        echo_distance_m=echo_distance,
+                        color=color,
+                    )
+        if multiple_records_selected and self._echo_heatmap_evaluation_visible():
+            self._draw_selected_echo_probability_overlay(
                 rx_position=rx_position,
                 records=selected_records,
             )
-            and not self._echo_heatmap_ellipses_visible()
-        ):
-            return True
-        if multiple_records_selected and not self._echo_heatmap_ellipses_visible():
-            return True
-        for record in selected_records:
-            measurement_position = self._selected_record_measurement_position(record)
-            if measurement_position is None:
-                continue
-            measurement = record.get("measurement")
-            if not isinstance(measurement, dict):
-                continue
-            result = measurement.get("result")
-            if not isinstance(result, dict):
-                continue
-            echo_distances = self._extract_echo_distances(result.get("echo_delays"), limit=len(ECHO_OVERLAY_COLORS))
-            if not echo_distances:
-                continue
-            for echo_index, echo_distance in enumerate(echo_distances):
-                color = ECHO_OVERLAY_COLORS[echo_index % len(ECHO_OVERLAY_COLORS)]
-                self._draw_echo_ellipse_for_overlay(
-                    rx_position=rx_position,
-                    measurement_position=measurement_position,
-                    echo_distance_m=echo_distance,
-                    color=color,
-                )
         return multiple_records_selected
 
     def _draw_selected_echo_probability_overlay(


### PR DESCRIPTION
### Motivation
- Ensure multi-selection evaluation points remain visually on top of echo ellipses in the map overlay so the evaluation markers are not obscured by the ellipse drawing.

### Description
- Change drawing order in `MissionWorkflowWindow._draw_selected_echo_overlay` to render echo ellipses first and then render the multi-selection evaluation overlay when multiple records are selected.
- Compute `ellipses_visible` as `not multiple_records_selected or self._echo_heatmap_ellipses_visible()` and branch accordingly in `transceiver/mission_workflow_ui.py`.
- Add a regression test `test_draw_selected_echo_overlay_draws_evaluation_points_above_ellipses` to `tests/test_mission_workflow_ui.py` that asserts the draw order is `ellipse`, `ellipse`, `evaluation` when both layers are visible.

### Testing
- Running `pytest tests/test_mission_workflow_ui.py -q` initially failed during import due to missing local package on `PYTHONPATH` (module import error) and was resolved by setting `PYTHONPATH=.`. 
- Running `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` executed the test file and completed successfully with `97 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a199c20e3e08321af4b0c1e52bcd328)