### PR TITLE
Clip echo overlay ellipses to antenna opening

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1284,6 +1284,84 @@ def test_build_waypoint_arrow_polygon_points_up_for_ninety_degree_yaw() -> None:
     assert round(right_y, 3) == 54.0
 
 
+
+def test_build_echo_overlay_preview_points_clips_to_antenna_opening() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission = SimpleNamespace(
+        map_config=SimpleNamespace(resolution=1.0, origin=(0.0, 0.0, 0.0))
+    )
+    window._map_image_original = SimpleNamespace(height=lambda: 100, width=lambda: 100)
+    window._map_preview_scale = (1.0, 1.0)
+    window._map_preview_offset = (0.0, 0.0)
+    window._ellipse_unit_circle_cache = {}
+
+    full_points, _line_width = window._build_echo_overlay_preview_points(
+        rx_position=(-1.0, 0.0),
+        measurement_position=(1.0, 0.0),
+        echo_distance_m=2.0,
+        sample_levels=(72, 72, 72),
+    )
+    clipped_points, _line_width = window._build_echo_overlay_preview_points(
+        rx_position=(-1.0, 0.0),
+        measurement_position=(1.0, 0.0),
+        echo_distance_m=2.0,
+        sample_levels=(72, 72, 72),
+        antenna_origin=(1.0, 0.0),
+        antenna_yaw=math.pi,
+        antenna_half_angle_rad=math.radians(35.0),
+    )
+
+    assert full_points is not None
+    assert clipped_points is not None
+    assert any(not math.isfinite(value) for value in clipped_points)
+    finite_pairs = [
+        (px, py)
+        for px, py in zip(clipped_points[0::2], clipped_points[1::2])
+        if math.isfinite(px) and math.isfinite(py)
+    ]
+    assert finite_pairs
+    assert len(finite_pairs) < (len(full_points) // 2)
+    for preview_x, preview_y in finite_pairs:
+        world_point = (preview_x, 100.0 - preview_y)
+        assert window._is_world_point_inside_antenna_opening(
+            origin=(1.0, 0.0),
+            yaw=math.pi,
+            target=world_point,
+            half_angle_rad=math.radians(35.0),
+        )
+
+
+def test_draw_echo_ellipse_for_overlay_splits_clipped_segments() -> None:
+    class FakeCanvas:
+        def __init__(self) -> None:
+            self.lines: list[tuple[tuple[float, ...], dict[str, object]]] = []
+
+        def create_line(self, *coords: float, **kwargs: object) -> int:
+            self.lines.append((coords, kwargs))
+            return len(self.lines)
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.map_preview_canvas = FakeCanvas()
+    window._build_echo_overlay_preview_points = lambda **_kwargs: (
+        [1.0, 1.0, 2.0, 2.0, math.nan, math.nan, 3.0, 3.0, 4.0, 4.0],
+        2,
+    )
+
+    item_id = window._draw_echo_ellipse_for_overlay(
+        rx_position=(0.0, 0.0),
+        measurement_position=(1.0, 0.0),
+        echo_distance_m=1.0,
+        color="#ff0000",
+        antenna_origin=(1.0, 0.0),
+        antenna_yaw=0.0,
+        antenna_half_angle_rad=math.radians(45.0),
+    )
+
+    assert item_id == 1
+    assert len(window.map_preview_canvas.lines) == 2
+    assert window.map_preview_canvas.lines[0][0] == (1.0, 1.0, 2.0, 2.0)
+    assert window.map_preview_canvas.lines[1][0] == (3.0, 3.0, 4.0, 4.0)
+
 def test_compute_bistatic_echo_ellipse_axes_uses_sum_path_geometry() -> None:
     axes = _compute_bistatic_echo_ellipse_axes(distance_rx_to_point=10.0, echo_distance_m=6.0)
 

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2594,6 +2594,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 echo_distances = self._extract_echo_distances(result.get("echo_delays"), limit=len(ECHO_OVERLAY_COLORS))
                 if not echo_distances:
                     continue
+                overlay_point = self._selected_record_overlay_point(
+                    record,
+                    measurement_position=measurement_position,
+                )
+                opening_half_angle_rad = math.radians(
+                    self._echo_heatmap_antenna_opening_angle_deg() / 2.0
+                )
                 for echo_index, echo_distance in enumerate(echo_distances):
                     color = ECHO_OVERLAY_COLORS[echo_index % len(ECHO_OVERLAY_COLORS)]
                     self._draw_echo_ellipse_for_overlay(
@@ -2601,6 +2608,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                         measurement_position=measurement_position,
                         echo_distance_m=echo_distance,
                         color=color,
+                        antenna_origin=(overlay_point.x, overlay_point.y) if overlay_point is not None else None,
+                        antenna_yaw=overlay_point.yaw if overlay_point is not None else None,
+                        antenna_half_angle_rad=opening_half_angle_rad,
                     )
         if multiple_records_selected and self._echo_heatmap_evaluation_visible():
             self._draw_selected_echo_probability_overlay(
@@ -2934,6 +2944,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         measurement_position: tuple[float, float],
         echo_distance_m: float,
         sample_levels: tuple[int, int, int] = LIVE_ECHO_SAMPLING_NORMAL,
+        antenna_origin: tuple[float, float] | None = None,
+        antenna_yaw: float | None = None,
+        antenna_half_angle_rad: float | None = None,
     ) -> tuple[list[float] | None, int]:
         mission = self._mission
         original = self._map_image_original
@@ -2984,21 +2997,36 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         cos_angle = math.cos(angle)
         sin_angle = math.sin(angle)
         preview_points: list[float] = []
+        filter_by_opening = (
+            antenna_origin is not None
+            and isinstance(antenna_yaw, (int, float))
+            and isinstance(antenna_half_angle_rad, (int, float))
+        )
         for unit_cos, unit_sin in unit_circle_points:
             local_x = semi_major_axis * unit_cos
             local_y = semi_minor_axis * unit_sin
             world_x = center_x + local_x * cos_angle - local_y * sin_angle
             world_y = center_y + local_x * sin_angle + local_y * cos_angle
+            if filter_by_opening and not self._is_world_point_inside_antenna_opening(
+                origin=antenna_origin,
+                yaw=float(antenna_yaw),
+                target=(world_x, world_y),
+                half_angle_rad=float(antenna_half_angle_rad),
+            ):
+                preview_points.extend((math.nan, math.nan))
+                continue
             map_pixel = self._world_to_map_pixel(x=world_x, y=world_y, image_height=image_height)
             if map_pixel is None:
+                if filter_by_opening:
+                    preview_points.extend((math.nan, math.nan))
                 continue
             preview_points.extend(
                 (
                     map_pixel[0] * scale_x + offset_x,
                     map_pixel[1] * scale_y + offset_y,
                 )
-        )
-        if len(preview_points) < 6:
+            )
+        if sum(1 for value in preview_points if math.isfinite(value)) < 6:
             return (None, 1)
         return (preview_points, ECHO_OVERLAY_LINE_WIDTH_PX)
 
@@ -3009,23 +3037,52 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         measurement_position: tuple[float, float],
         echo_distance_m: float,
         color: str,
+        antenna_origin: tuple[float, float] | None = None,
+        antenna_yaw: float | None = None,
+        antenna_half_angle_rad: float | None = None,
     ) -> int | None:
         preview_points, line_width = self._build_echo_overlay_preview_points(
             rx_position=rx_position,
             measurement_position=measurement_position,
             echo_distance_m=echo_distance_m,
+            antenna_origin=antenna_origin,
+            antenna_yaw=antenna_yaw,
+            antenna_half_angle_rad=antenna_half_angle_rad,
         )
         if preview_points is None:
             return None
-        return int(
-            self.map_preview_canvas.create_line(
-                *preview_points,
-                fill=color,
-                width=line_width,
-                smooth=True,
-                dash=(4, 4),
+        created_item_id: int | None = None
+        segment: list[float] = []
+        for px, py in zip(preview_points[0::2], preview_points[1::2]):
+            if math.isfinite(px) and math.isfinite(py):
+                segment.extend((px, py))
+                continue
+            if len(segment) >= 4:
+                item_id = int(
+                    self.map_preview_canvas.create_line(
+                        *segment,
+                        fill=color,
+                        width=line_width,
+                        smooth=True,
+                        dash=(4, 4),
+                    )
+                )
+                if created_item_id is None:
+                    created_item_id = item_id
+            segment = []
+        if len(segment) >= 4:
+            item_id = int(
+                self.map_preview_canvas.create_line(
+                    *segment,
+                    fill=color,
+                    width=line_width,
+                    smooth=True,
+                    dash=(4, 4),
+                )
             )
-        )
+            if created_item_id is None:
+                created_item_id = item_id
+        return created_item_id
 
     def _ellipse_unit_circle_points(self, *, samples: int) -> tuple[tuple[float, float], ...]:
         if samples < 3:


### PR DESCRIPTION
### Motivation
- Ensure echo-overlay ellipses on the map only show the portions that fall inside the configured antenna opening angle and avoid drawing connecting lines across the hidden sections.
- Improve readability of multi-selection overlays by splitting clipped ellipse contours into visible segments rather than one continuous (and partially invisible) polyline.

### Description
- Pass per-measurement antenna clipping parameters through ` _selected_record_overlay_point` into the overlay flow and call ` _draw_echo_ellipse_for_overlay` with `antenna_origin`, `antenna_yaw` and `antenna_half_angle_rad` when available.
- Extend ` _build_echo_overlay_preview_points` with optional parameters `antenna_origin`, `antenna_yaw`, `antenna_half_angle_rad` and mark points outside the opening (or unmapped points) by inserting `math.nan` placeholders instead of dropping them.
- Change ` _draw_echo_ellipse_for_overlay` to split the preview point list on `NaN` pairs and draw each contiguous visible segment with `create_line`, returning the first created item id.
- Add unit tests to `tests/test_mission_workflow_ui.py`: `test_build_echo_overlay_preview_points_clips_to_antenna_opening` and `test_draw_echo_ellipse_for_overlay_splits_clipped_segments` that validate clipping behavior and segmented drawing.

### Testing
- Ran `python -m py_compile transceiver/mission_workflow_ui.py`, which succeeded.
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -q`, which succeeded and the new tests passed.
- Ran the full test suite with `PYTHONPATH=. pytest -q`, which failed during collection due to unrelated pre-existing issues (missing `_suppress_nearby_candidates` import and a `__mro_entries__` TypeError in `transceiver/__main__.py`), so full-suite pass is blocked by those unrelated errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19a0ca5988832180ea08dec8dc94d1)