### PR TITLE
Filter LiDAR reference overlay points by configured TX opening angle

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1180,6 +1180,42 @@ def test_lidar_overlay_beam_angle_compensates_left_rotated_scanner() -> None:
     assert angle == pytest.approx(math.pi / 2.0)
 
 
+def test_draw_lidar_scan_overlay_filters_points_by_tx_opening_angle() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._map_image_original = SimpleNamespace(width=lambda: 200, height=lambda: 120)
+    window._map_preview_scale = (1.0, 1.0)
+    window._map_preview_offset = (0.0, 0.0)
+    window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
+    window._is_pixel_inside_map = lambda *_args, **_kwargs: True
+    window.echo_heatmap_antenna_opening_angle_deg_var = SimpleNamespace(get=lambda: "90")
+    lidar_point_calls: list[tuple[tuple[float, ...], dict[str, object]]] = []
+    messages: list[str] = []
+
+    def create_oval(*args, **kwargs):
+        if kwargs.get("fill") == "#fff176":
+            lidar_point_calls.append((args, kwargs))
+
+    window.map_preview_canvas = SimpleNamespace(create_oval=create_oval)
+    window._append_validation = messages.append
+
+    window._draw_lidar_scan_overlay_for_point(
+        point=MeasurementPoint(id="p1", name="P1", x=0.0, y=0.0, yaw=0.0),
+        scan={"angle_min": -math.pi / 2.0, "angle_increment": math.pi / 2.0, "ranges": [10.0] * 4},
+    )
+
+    assert len(lidar_point_calls) == 1
+    coords, _kwargs = lidar_point_calls[0]
+    center_x = (coords[0] + coords[2]) / 2.0
+    center_y = (coords[1] + coords[3]) / 2.0
+    assert center_x == pytest.approx(10.0)
+    assert center_y == pytest.approx(0.0)
+    assert messages == [
+        "ℹ️ LiDAR-Overlay: gültige Ranges=1, Öffnungswinkel übersprungen=3, "
+        "Stride übersprungen=0, Zellfilter übersprungen=0, Punkte gezeichnet=1, "
+        "Zellgröße=1.05px, Stride=1"
+    ]
+
+
 def test_draw_lidar_scan_overlay_deduplicates_dense_endpoints() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._map_image_original = SimpleNamespace(width=lambda: 200, height=lambda: 120)

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3246,9 +3246,32 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         angle_min = float(scan["angle_min"])
         angle_increment = float(scan["angle_increment"])
         ranges = scan["ranges"]
-        finite_positive_beam_count = sum(
-            1 for distance in ranges if isinstance(distance, (int, float)) and math.isfinite(distance) and distance > 0.0
-        )
+        opening_half_angle_rad = math.radians(self._echo_heatmap_antenna_opening_angle_deg() / 2.0)
+        filter_by_opening = math.isfinite(opening_half_angle_rad) and opening_half_angle_rad < math.pi
+        drawable_beams: list[tuple[int, float, float, float, float]] = []
+        skipped_by_opening_count = 0
+        for idx, distance in enumerate(ranges):
+            if not isinstance(distance, (int, float)) or not math.isfinite(distance) or distance <= 0.0:
+                continue
+            numeric_distance = float(distance)
+            beam_angle = self._lidar_overlay_beam_angle(
+                point_yaw=point.yaw,
+                angle_min=angle_min,
+                angle_increment=angle_increment,
+                beam_index=idx,
+            )
+            end_world_x = point.x + math.cos(beam_angle) * numeric_distance
+            end_world_y = point.y + math.sin(beam_angle) * numeric_distance
+            if filter_by_opening and not self._is_world_point_inside_antenna_opening(
+                origin=(point.x, point.y),
+                yaw=point.yaw,
+                target=(end_world_x, end_world_y),
+                half_angle_rad=opening_half_angle_rad,
+            ):
+                skipped_by_opening_count += 1
+                continue
+            drawable_beams.append((idx, numeric_distance, beam_angle, end_world_x, end_world_y))
+        finite_positive_beam_count = len(drawable_beams)
         beam_stride = max(1, finite_positive_beam_count // LIDAR_OVERLAY_MAX_DRAWN_BEAMS)
         density_factor = max(1.0, math.sqrt(finite_positive_beam_count / float(LIDAR_OVERLAY_MAX_DRAWN_BEAMS)))
         preview_width = original.width() * scale_x
@@ -3269,20 +3292,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         skipped_by_cell_filter_count = 0
         drawn_beam_count = 0
         drawn_beam_cells: dict[tuple[int, int], int] = {}
-        for idx, distance in enumerate(ranges):
-            if not isinstance(distance, (int, float)) or not math.isfinite(distance) or distance <= 0.0:
-                continue
-            if idx % beam_stride != 0:
+        for candidate_idx, (_beam_index, _distance, _beam_angle, end_world_x, end_world_y) in enumerate(drawable_beams):
+            if candidate_idx % beam_stride != 0:
                 skipped_by_stride_count += 1
                 continue
-            beam_angle = self._lidar_overlay_beam_angle(
-                point_yaw=point.yaw,
-                angle_min=angle_min,
-                angle_increment=angle_increment,
-                beam_index=idx,
-            )
-            end_world_x = point.x + math.cos(beam_angle) * distance
-            end_world_y = point.y + math.sin(beam_angle) * distance
             end_map_pixel = self._world_to_map_pixel(x=end_world_x, y=end_world_y, image_height=original.height())
             if end_map_pixel is None:
                 continue
@@ -3307,9 +3320,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 width=1,
             )
             drawn_beam_count += 1
+        opening_filter_summary = (
+            f"Öffnungswinkel übersprungen={skipped_by_opening_count}, " if filter_by_opening else ""
+        )
         self._append_validation(
             "ℹ️ LiDAR-Overlay: "
             f"gültige Ranges={finite_positive_beam_count}, "
+            f"{opening_filter_summary}"
             f"Stride übersprungen={skipped_by_stride_count}, "
             f"Zellfilter übersprungen={skipped_by_cell_filter_count}, "
             f"Punkte gezeichnet={drawn_beam_count}, "


### PR DESCRIPTION
### Motivation
- Apply the configured TX opening angle to LiDAR reference endpoints in the map overlay so only points inside the TX sector are considered for rendering and thinning.

### Description
- In `transceiver/mission_workflow_ui.py` compute `opening_half_angle_rad` from the UI `echo_heatmap_antenna_opening_angle_deg` and skip LiDAR endpoints outside the antenna opening using `_is_world_point_inside_antenna_opening` before stride/cell thinning.
- Build a filtered `drawable_beams` list and run the existing stride/cell deduplication and drawing on that reduced set so thinning operates on already-filtered points.
- Add `skipped_by_opening_count` and include an "Öffnungswinkel übersprungen" summary fragment in the LiDAR overlay validation message when the opening-angle filter is active.
- Add a unit test `test_draw_lidar_scan_overlay_filters_points_by_tx_opening_angle` in `tests/test_mission_workflow_ui.py` to verify a 90° TX opening angle filters LiDAR points as expected.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k "lidar_scan_overlay or lidar_overlay_beam_angle"` and the targeted tests passed (`4 passed, 98 deselected`).
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` and the full file passed (`102 passed`).
- Ran the whole test suite with `PYTHONPATH=. pytest -q` and collection failed due to unrelated pre-existing issues in other modules (import and MRO errors), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19a388daa083218e9462245e842897)