### PR TITLE
Show LiDAR overlays for multi-result selections

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -561,7 +561,7 @@ def test_draw_selected_lidar_reference_overlay_uses_live_measurement_position() 
     assert point.y == -2.0
 
 
-def test_draw_selected_lidar_reference_overlay_skips_multiple_selected_results() -> None:
+def test_draw_selected_lidar_reference_overlay_draws_multiple_selected_results() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._selected_result_index = 0
     window._selected_result_indices = (0, 1)
@@ -587,7 +587,13 @@ def test_draw_selected_lidar_reference_overlay_skips_multiple_selected_results()
 
     window._draw_selected_lidar_reference_overlay()
 
-    assert calls == []
+    assert len(calls) == 2
+    points = [call["point"] for call in calls]
+    assert all(isinstance(point, MeasurementPoint) for point in points)
+    assert [(point.x, point.y) for point in points if isinstance(point, MeasurementPoint)] == [
+        (7.0, -2.0),
+        (8.0, -1.0),
+    ]
 
 
 def test_resolve_cmd_vel_topic_uses_namespace_when_present() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3096,34 +3096,29 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         return points
 
     def _draw_selected_lidar_reference_overlay(self) -> None:
-        selected_indices = getattr(self, "_selected_result_indices", ())
-        if len(selected_indices) > 1:
-            return
-        record = self._selected_record_payload()
-        if record is None:
-            return
-        measurement_position = self._selected_record_measurement_position(record)
-        if measurement_position is None:
-            return
-        measurement = record.get("measurement")
-        if not isinstance(measurement, dict):
-            return
-        result = measurement.get("result")
-        if not isinstance(result, dict):
-            return
-        lidar_reference = result.get("lidar_reference")
-        if not isinstance(lidar_reference, dict):
-            return
-        lidar_file = lidar_reference.get("output_file")
-        if not isinstance(lidar_file, str) or not lidar_file.strip():
-            return
-        scan = self._load_lidar_scan_for_overlay(lidar_file)
-        if scan is None:
-            return
-        overlay_point = self._selected_record_overlay_point(record, measurement_position=measurement_position)
-        if overlay_point is None:
-            return
-        self._draw_lidar_scan_overlay_for_point(point=overlay_point, scan=scan)
+        for record in self._selected_record_payloads():
+            measurement_position = self._selected_record_measurement_position(record)
+            if measurement_position is None:
+                continue
+            measurement = record.get("measurement")
+            if not isinstance(measurement, dict):
+                continue
+            result = measurement.get("result")
+            if not isinstance(result, dict):
+                continue
+            lidar_reference = result.get("lidar_reference")
+            if not isinstance(lidar_reference, dict):
+                continue
+            lidar_file = lidar_reference.get("output_file")
+            if not isinstance(lidar_file, str) or not lidar_file.strip():
+                continue
+            scan = self._load_lidar_scan_for_overlay(lidar_file)
+            if scan is None:
+                continue
+            overlay_point = self._selected_record_overlay_point(record, measurement_position=measurement_position)
+            if overlay_point is None:
+                continue
+            self._draw_lidar_scan_overlay_for_point(point=overlay_point, scan=scan)
 
     def _selected_record_payload(self) -> dict[str, Any] | None:
         selected_idx = self._selected_result_index


### PR DESCRIPTION
### Motivation
- When multiple results are selected in the mission workflow summary view, LiDAR reference points should still be shown in the overlay for each selected result instead of being suppressed.

### Description
- Update `_draw_selected_lidar_reference_overlay` in `transceiver/mission_workflow_ui.py` to iterate over `self._selected_record_payloads()` and draw a LiDAR overlay for each valid selected result instead of returning early for multi-selection. 
- Adjusted `tests/test_mission_workflow_ui.py` to expect and verify that overlays are drawn for each selected result using their live measurement positions.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -q`, which exercised the updated UI tests and succeeded for that test module.
- Ran `PYTHONPATH=. pytest -q` which fails during collection due to unrelated import/type errors in other modules (errors during test collection: missing symbol in `transceiver.helpers.correlation_utils` and a `__mro_entries__` TypeError), so the full test-suite run could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19a5b4951c832192dd360e042f59d4)