### PR TITLE
Raise summarized echo probability dots above map overlays

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1874,12 +1874,20 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._draw_measurement_overlay()
         echo_heatmap_active = self._draw_selected_echo_overlay()
         self._draw_selected_lidar_reference_overlay()
+        self._raise_selected_echo_probability_overlay()
         self._sync_echo_heatmap_settings_overlay(visible=echo_heatmap_active)
 
     def _draw_live_overlay_layer(self) -> None:
         self._draw_live_echo_preview_overlay()
         self._draw_live_marker()
         self._draw_live_position_info_overlay()
+        self._raise_selected_echo_probability_overlay()
+
+    def _raise_selected_echo_probability_overlay(self) -> None:
+        try:
+            self.map_preview_canvas.tag_raise("selected_echo_probability_dot")
+        except tk.TclError:
+            pass
 
     def _clear_live_overlay_layer(
         self,
@@ -2891,6 +2899,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 center_y + radius,
                 fill=color,
                 outline="",
+                tags=("selected_echo_probability_dot",),
             )
             drawn_points += 1
         if MULTI_SELECTION_PROBABILITY_DEBUG_LOG:


### PR DESCRIPTION
### Motivation
- Summarized echo/heatmap dots must always appear on top of the map so the red dots are visible and not occluded by other overlays.

### Description
- Add a canvas tag `"selected_echo_probability_dot"` to the summarized echo probability ovals drawn in `transceiver/mission_workflow_ui.py` so they can be raised independently. 
- Introduce `_raise_selected_echo_probability_overlay()` which calls `self.map_preview_canvas.tag_raise("selected_echo_probability_dot")` inside a `try/except` to tolerate canvas errors. 
- Call `_raise_selected_echo_probability_overlay()` after the static map layer rendering in `_draw_static_map_layer` and after live overlay updates in `_draw_live_overlay_layer` so the dots stay above other elements. 
- All edits are contained in `transceiver/mission_workflow_ui.py`.

### Testing
- Ran `python -m py_compile transceiver/mission_workflow_ui.py` and it completed without syntax errors (success). 
- Ran `git diff --check` to validate whitespace/diff issues and it reported no problems (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19abb194848321a12e7c00413455bf)