### PR TITLE
Standardabweichung sichtbarer roter LiDAR-Punkte zur Wand ausgeben

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -9,6 +9,7 @@ from transceiver.measurement_mission import MeasurementMission, MeasurementPoint
 from transceiver.navigation_adapter import NavigationPoint
 from transceiver.mission_workflow_ui import (
     RESULTS_TABLE_EMPTY_ROW_IID,
+    LidarWallEstimate,
     MissionWorkflowWindow,
     _compute_bistatic_echo_ellipse_axes,
     _estimate_lower_horizontal_lidar_wall,
@@ -615,6 +616,70 @@ def test_draw_selected_lidar_reference_overlay_draws_multiple_selected_results()
         (7.0, -2.0),
         (8.0, -1.0),
     ]
+
+
+
+def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation() -> None:
+    class FakeCanvas:
+        def create_line(self, *_coords: float, **_kwargs: object) -> int:
+            return 1
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._map_image_original = SimpleNamespace(height=lambda: 100)
+    window._map_preview_scale = (1.0, 1.0)
+    window._map_preview_offset = (0.0, 0.0)
+    window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
+    window.map_preview_canvas = FakeCanvas()
+    window._last_visible_red_echo_probability_world_points = [(0.0, 1.0), (1.0, -1.0)]
+    messages: list[str] = []
+    window._append_validation = messages.append
+    estimate = LidarWallEstimate(
+        slope=0.0,
+        intercept=0.0,
+        start=(0.0, 0.0),
+        end=(1.0, 0.0),
+        point_count=8,
+        residual_mean_m=0.01,
+        residual_std_m=0.02,
+        residual_rms_m=0.03,
+    )
+
+    window._draw_lidar_wall_estimate(estimate)
+
+    assert messages
+    assert "σ sichtbare rote Punkte=100.0cm (2 Punkte)" in messages[0]
+
+
+def test_draw_selected_echo_probability_overlay_tracks_visible_red_world_points() -> None:
+    class FakeCanvas:
+        def __init__(self) -> None:
+            self.ovals: list[tuple[tuple[float, ...], dict[str, object]]] = []
+
+        def create_oval(self, *coords: float, **kwargs: object) -> int:
+            self.ovals.append((coords, kwargs))
+            return len(self.ovals)
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission = SimpleNamespace(map_config=SimpleNamespace(resolution=1.0))
+    window._map_image_original = SimpleNamespace(height=lambda: 100)
+    window.map_preview_canvas = FakeCanvas()
+    window.echo_heatmap_min_visible_overlap_var = SimpleNamespace(get=lambda: "1")
+    window.echo_heatmap_imaginary_line_width_var = SimpleNamespace(get=lambda: "4")
+    window._append_validation = lambda _message: None
+    window._preview_pixel_to_world = lambda *, preview_x, preview_y: (preview_x / 10.0, preview_y / 10.0)
+    window._build_echo_overlay_preview_points = lambda **_kwargs: ([10.0, 20.0], 1)
+    records = [
+        {
+            "live_position_at_measurement": {"x": float(index), "y": 0.0},
+            "measurement": {"result": {"echo_delays": [{"distance_m": 1.0}]}},
+        }
+        for index in range(2)
+    ]
+
+    drawn = window._draw_selected_echo_probability_overlay(rx_position=(0.0, 0.0), records=records)
+
+    assert drawn is True
+    assert window._last_visible_red_echo_probability_world_points == [(1.0, 2.0)]
 
 
 def test_resolve_cmd_vel_topic_uses_namespace_when_present() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -890,6 +890,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._lidar_reference_scan_cache: dict[str, dict[str, Any] | None] = {}
         self._ellipse_unit_circle_cache: dict[int, tuple[tuple[float, float], ...]] = {}
         self._live_echo_geometry_cache: dict[str, dict[str, Any]] = {}
+        self._last_visible_red_echo_probability_world_points: list[tuple[float, float]] = []
         self._last_live_diagnosis_key: str | None = None
         self._emit_live_diagnostics_to_validation = True
         self._rx_antenna_global_position: tuple[float, float] | None = None
@@ -1872,6 +1873,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._draw_pending_waypoint_marker()
         self._draw_rx_antenna_marker()
         self._draw_measurement_overlay()
+        self._last_visible_red_echo_probability_world_points = []
         echo_heatmap_active = self._draw_selected_echo_overlay()
         self._draw_selected_lidar_reference_overlay()
         self._raise_selected_echo_probability_overlay()
@@ -2786,6 +2788,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         resolution = mission.map_config.resolution
         if not math.isfinite(resolution) or resolution <= 0.0:
             return False
+        self._last_visible_red_echo_probability_world_points = []
         ellipse_point_cells: dict[tuple[int, int], dict[str, Any]] = {}
         imaginary_line_width_cm = self._echo_heatmap_imaginary_line_width_cm()
         if not math.isfinite(imaginary_line_width_cm) or imaginary_line_width_cm <= 0.0:
@@ -2901,6 +2904,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 outline="",
                 tags=("selected_echo_probability_dot",),
             )
+            if color == MULTI_SELECTION_ECHO_DOT_OVERLAP_COLOR:
+                try:
+                    world_point = self._preview_pixel_to_world(preview_x=center_x, preview_y=center_y)
+                except Exception:
+                    world_point = None
+                if world_point is not None:
+                    self._last_visible_red_echo_probability_world_points.append(world_point)
             drawn_points += 1
         if MULTI_SELECTION_PROBABILITY_DEBUG_LOG:
             self._append_validation(
@@ -3408,6 +3418,28 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             world_points.append((end_world_x, end_world_y))
         return world_points
 
+    @staticmethod
+    def _line_residual_std_m(
+        points: list[tuple[float, float]],
+        *,
+        slope: float,
+        intercept: float,
+    ) -> float | None:
+        finite_points = [
+            (float(x), float(y))
+            for x, y in points
+            if math.isfinite(float(x)) and math.isfinite(float(y))
+        ]
+        if not finite_points:
+            return None
+        residuals = _lidar_line_residuals(finite_points, slope=slope, intercept=intercept)
+        if residuals.size == 0:
+            return None
+        finite_residuals = residuals[np.isfinite(residuals)]
+        if finite_residuals.size == 0:
+            return None
+        return float(np.std(finite_residuals))
+
     def _draw_lidar_wall_estimate(self, estimate: LidarWallEstimate) -> None:
         original = self._map_image_original
         if original is None:
@@ -3438,6 +3470,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             fill=LIDAR_WALL_LINE_COLOR,
             width=LIDAR_WALL_LINE_WIDTH_PX,
         )
+        red_points = getattr(self, "_last_visible_red_echo_probability_world_points", [])
+        red_points_std_m = self._line_residual_std_m(
+            red_points,
+            slope=estimate.slope,
+            intercept=estimate.intercept,
+        )
+        red_points_summary = ""
+        if red_points_std_m is not None:
+            red_points_summary = (
+                f", σ sichtbare rote Punkte={red_points_std_m * 100.0:.1f}cm "
+                f"({len(red_points)} Punkte)"
+            )
         self._append_validation(
             "ℹ️ LiDAR-Wand: "
             f"{estimate.point_count} Punkte, "
@@ -3445,6 +3489,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             f"σ={estimate.residual_std_m * 100.0:.1f}cm, "
             f"mittl. |Abweichung|={estimate.residual_mean_m * 100.0:.1f}cm, "
             f"RMS={estimate.residual_rms_m * 100.0:.1f}cm"
+            f"{red_points_summary}"
         )
 
     def _draw_lidar_scan_overlay_for_point(self, *, point: MeasurementPoint, scan: dict[str, Any]) -> None:


### PR DESCRIPTION
### Motivation
- Bei der Zusammenfassung der Mission soll neben der blauen Wandlinie und deren Statistik auch die Standardabweichung der aktuell sichtbaren roten Messpunkte zur berechneten Wandlinie ausgegeben werden, damit Abweichungen zwischen Heatmap-Overlaps und der LiDAR-Referenzlinie sichtbar werden.

### Description
- Trackt sichtbare rote Echo-Heatmap-Punkte in Weltkoordinaten während des Renderns und speichert sie in `self._last_visible_red_echo_probability_world_points` (Datei: `transceiver/mission_workflow_ui.py`).
- Setzt die Liste bei jedem statischen Karten-Redraw und vor dem Aufbau der Echo-Heatmap zurück, sodass nur aktuelle Punkte verwendet werden.
- Beim Zeichnen roter Überlappungspunkte werden deren Weltkoordinaten gesammelt und nach Bildung der blauen Wandlinie die Standardabweichung dieser roten Punkte zur Linie mittels der neuen Helferfunktion `_line_residual_std_m` berechnet und als zusätzliche Diagnose angehängt.
- Fügt Tests hinzu, die das Tracking sichtbarer roter Punkte und die Ausgabe der Standardabweichung prüfen (Datei: `tests/test_mission_workflow_ui.py`).

### Testing
- `python -m py_compile transceiver/mission_workflow_ui.py` wurde ausgeführt und erfolgreich kompiliert.
- `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` wurde ausgeführt und alle Tests bestanden (`104 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19add8de0083219eeb581c384fa449)