### PR TITLE
Show RMS for visible red mission points

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -619,7 +619,7 @@ def test_draw_selected_lidar_reference_overlay_draws_multiple_selected_results()
 
 
 
-def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation() -> None:
+def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation_and_rms() -> None:
     class FakeCanvas:
         def create_line(self, *_coords: float, **_kwargs: object) -> int:
             return 1
@@ -647,7 +647,7 @@ def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation() -> N
     window._draw_lidar_wall_estimate(estimate)
 
     assert messages
-    assert "σ sichtbare rote Punkte=100.0cm (2 Punkte)" in messages[0]
+    assert "σ sichtbare rote Punkte=100.0cm, RMS sichtbare rote Punkte=100.0cm (2 Punkte)" in messages[0]
 
 
 def test_draw_selected_echo_probability_overlay_tracks_visible_red_world_points() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3419,12 +3419,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         return world_points
 
     @staticmethod
-    def _line_residual_std_m(
+    def _line_residual_std_and_rms_m(
         points: list[tuple[float, float]],
         *,
         slope: float,
         intercept: float,
-    ) -> float | None:
+    ) -> tuple[float, float] | None:
         finite_points = [
             (float(x), float(y))
             for x, y in points
@@ -3438,7 +3438,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         finite_residuals = residuals[np.isfinite(residuals)]
         if finite_residuals.size == 0:
             return None
-        return float(np.std(finite_residuals))
+        residual_std_m = float(np.std(finite_residuals))
+        residual_rms_m = float(math.sqrt(np.mean(finite_residuals * finite_residuals)))
+        return (residual_std_m, residual_rms_m)
 
     def _draw_lidar_wall_estimate(self, estimate: LidarWallEstimate) -> None:
         original = self._map_image_original
@@ -3471,15 +3473,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             width=LIDAR_WALL_LINE_WIDTH_PX,
         )
         red_points = getattr(self, "_last_visible_red_echo_probability_world_points", [])
-        red_points_std_m = self._line_residual_std_m(
+        red_points_stats_m = self._line_residual_std_and_rms_m(
             red_points,
             slope=estimate.slope,
             intercept=estimate.intercept,
         )
         red_points_summary = ""
-        if red_points_std_m is not None:
+        if red_points_stats_m is not None:
+            red_points_std_m, red_points_rms_m = red_points_stats_m
             red_points_summary = (
-                f", σ sichtbare rote Punkte={red_points_std_m * 100.0:.1f}cm "
+                f", σ sichtbare rote Punkte={red_points_std_m * 100.0:.1f}cm, "
+                f"RMS sichtbare rote Punkte={red_points_rms_m * 100.0:.1f}cm "
                 f"({len(red_points)} Punkte)"
             )
         self._append_validation(


### PR DESCRIPTION
### Motivation
- Improve the mission workflow LiDAR-wall diagnostics by reporting the RMS of visible red echo-probability points in addition to the already-reported standard deviation.
- RMS gives an alternative residual metric alongside σ to help interpret red-point agreement with the fitted wall.

### Description
- Replace the old helper with `def _line_residual_std_and_rms_m(...) -> tuple[float, float] | None` which computes both standard deviation and RMS from the line residuals. 
- Update `_draw_lidar_wall_estimate` to call `_line_residual_std_and_rms_m` and include `RMS sichtbare rote Punkte` in the validation message next to the σ value. 
- Update the unit test `tests/test_mission_workflow_ui.py` to expect the combined σ and RMS text in the LiDAR-wall validation output.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` and the test suite completed successfully (`104 passed`).
- Ran `python -m py_compile transceiver/mission_workflow_ui.py` to verify syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19b074b4fc83218184b81a41742377)