### PR TITLE
Improve mission result list interactions

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -782,8 +782,14 @@ class _TreeviewSelectionStub:
     def selection(self) -> tuple[str, ...]:
         return self._selected
 
-    def selection_set(self, item_id: str) -> None:
-        self._selected = (item_id,)
+    def selection_set(self, *item_ids: str) -> None:
+        self._selected = tuple(item_ids)
+
+    def selection_add(self, *item_ids: str) -> None:
+        self._selected = tuple(dict.fromkeys((*self._selected, *item_ids)))
+
+    def focus(self, _item_id: str) -> None:
+        return None
 
     def selection_remove(self, *item_ids: str) -> None:
         self._selected = tuple(selected for selected in self._selected if selected not in item_ids)
@@ -937,12 +943,55 @@ def test_on_results_table_click_ignores_table_chrome_without_clearing_selection(
     assert window._selected_result_index == 0
 
 
+def test_on_results_table_control_click_adds_unselected_row_to_multiselect() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    table = _TreeviewSelectionStub()
+    table._selected = ("row-a",)
+    table._indices = {"row-a": 0, "row-b": 1, "row-c": 2}
+    table._row_id = "row-c"
+    window.results_table = table
+    window.results_selection_diagnostics_var = _StringVarStub()
+    draw_calls: list[str] = []
+    window._draw_map_preview = lambda: draw_calls.append("draw")
+
+    result = window._on_results_table_control_click(SimpleNamespace(x=5, y=5))
+
+    assert result == "break"
+    assert table.selection() == ("row-a", "row-c")
+    assert window._selected_result_indices == (0, 2)
+    assert window._selected_result_index == 0
+    assert window.results_selection_diagnostics_var.value == "Auswahl: 2 Zeilen"
+    assert draw_calls == ["draw"]
+
+
+def test_on_results_table_control_click_removes_selected_row_from_multiselect() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    table = _TreeviewSelectionStub()
+    table._selected = ("row-a", "row-b")
+    table._indices = {"row-a": 0, "row-b": 1, "row-c": 2}
+    table._row_id = "row-a"
+    window.results_table = table
+    window.results_selection_diagnostics_var = _StringVarStub()
+    draw_calls: list[str] = []
+    window._draw_map_preview = lambda: draw_calls.append("draw")
+
+    result = window._on_results_table_control_click(SimpleNamespace(x=5, y=5))
+
+    assert result == "break"
+    assert table.selection() == ("row-b",)
+    assert window._selected_result_indices == (1,)
+    assert window._selected_result_index == 1
+    assert window.results_selection_diagnostics_var.value == "Auswahl: 1 Zeilen"
+    assert draw_calls == ["draw"]
+
+
 class _ResultsContextMenuStub:
     def __init__(self) -> None:
         self.labels: list[str] = []
         self.states: list[str | None] = []
         self.popup_calls: list[tuple[int, int]] = []
         self.release_count = 0
+        self.unpost_count = 0
 
     def entryconfigure(self, _index: int, *, label: str, state: str | None = None) -> None:
         self.labels.append(label)
@@ -953,6 +1002,32 @@ class _ResultsContextMenuStub:
 
     def grab_release(self) -> None:
         self.release_count += 1
+
+    def unpost(self) -> None:
+        self.unpost_count += 1
+
+
+def test_dismiss_results_context_menu_unposts_menu_and_removes_bindings() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    menu = _ResultsContextMenuStub()
+    unbound: list[tuple[str, str]] = []
+
+    class _WidgetStub:
+        def unbind(self, sequence: str, binding_id: str) -> None:
+            unbound.append((sequence, binding_id))
+
+    widget = _WidgetStub()
+    window.results_table_context_menu = menu
+    window._results_context_menu_dismiss_bindings = (
+        (widget, "<ButtonPress-1>", "bind-1"),
+        (widget, "<KeyPress-Escape>", "bind-2"),
+    )
+
+    window._dismiss_results_context_menu(SimpleNamespace())
+
+    assert menu.unpost_count == 1
+    assert window._results_context_menu_dismiss_bindings == ()
+    assert unbound == [("<ButtonPress-1>", "bind-1"), ("<KeyPress-Escape>", "bind-2")]
 
 
 def test_on_results_table_context_menu_keeps_existing_multiselect_for_selected_row() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -1153,9 +1153,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._ensure_results_table_empty_row()
         self.results_table.bind("<<TreeviewSelect>>", self._on_results_table_select)
         self.results_table.bind("<Button-1>", self._on_results_table_click, add="+")
+        self.results_table.bind("<Control-Button-1>", self._on_results_table_control_click, add="+")
         self.results_table.bind("<Double-1>", self._on_results_table_double_click, add="+")
         self.results_table.bind("<Button-3>", self._on_results_table_context_menu, add="+")
-        self.results_table.bind("<Control-Button-1>", self._on_results_table_context_menu, add="+")
         self.results_table_context_menu = tk.Menu(self.results_table, tearoff=False)
         self._results_context_review_index = 0
         self.results_table_context_menu.add_command(
@@ -2175,6 +2175,24 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             return None
         return self._clear_results_table_selection(event)
 
+    def _on_results_table_control_click(self, event: tk.Event) -> str | None:
+        row_id = self.results_table.identify_row(event.y)
+        if not row_id or row_id == RESULTS_TABLE_EMPTY_ROW_IID:
+            return None
+        selected_items = tuple(self.results_table.selection())
+        if row_id in selected_items:
+            self.results_table.selection_remove(row_id)
+        else:
+            if hasattr(self.results_table, "selection_add"):
+                self.results_table.selection_add(row_id)
+            else:
+                current_selection = tuple(self.results_table.selection())
+                self.results_table.selection_set(*(current_selection + (row_id,)))
+        if hasattr(self.results_table, "focus"):
+            self.results_table.focus(row_id)
+        self._on_results_table_select(event)
+        return "break"
+
     def _on_results_table_double_click(self, event: tk.Event) -> str | None:
         row_id = self.results_table.identify_row(event.y)
         if not row_id or row_id == RESULTS_TABLE_EMPTY_ROW_IID:
@@ -2230,9 +2248,67 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         )
         try:
             menu.tk_popup(event.x_root, event.y_root)
+            self._install_results_context_menu_dismiss_handlers()
         finally:
             menu.grab_release()
         return "break"
+
+    def _install_results_context_menu_dismiss_handlers(self) -> None:
+        self._remove_results_context_menu_dismiss_handlers()
+        try:
+            top_level = self.winfo_toplevel()
+        except Exception:
+            return
+
+        def install() -> None:
+            try:
+                button_binding_id = top_level.bind(
+                    "<ButtonPress-1>",
+                    self._dismiss_results_context_menu,
+                    add="+",
+                )
+                secondary_button_binding_id = top_level.bind(
+                    "<ButtonPress-2>",
+                    self._dismiss_results_context_menu,
+                    add="+",
+                )
+                escape_binding_id = top_level.bind(
+                    "<KeyPress-Escape>",
+                    self._dismiss_results_context_menu,
+                    add="+",
+                )
+            except Exception:
+                return
+            self._results_context_menu_dismiss_bindings = (
+                (top_level, "<ButtonPress-1>", button_binding_id),
+                (top_level, "<ButtonPress-2>", secondary_button_binding_id),
+                (top_level, "<KeyPress-Escape>", escape_binding_id),
+            )
+
+        try:
+            top_level.after_idle(install)
+        except Exception:
+            install()
+
+    def _dismiss_results_context_menu(self, _event: tk.Event | None = None) -> None:
+        menu = getattr(self, "results_table_context_menu", None)
+        if menu is not None:
+            try:
+                menu.unpost()
+            except Exception:
+                pass
+        self._remove_results_context_menu_dismiss_handlers()
+
+    def _remove_results_context_menu_dismiss_handlers(self) -> None:
+        bindings = getattr(self, "_results_context_menu_dismiss_bindings", ())
+        self._results_context_menu_dismiss_bindings = ()
+        for widget, sequence, binding_id in bindings:
+            if not binding_id:
+                continue
+            try:
+                widget.unbind(sequence, binding_id)
+            except Exception:
+                pass
 
     @staticmethod
     def _auto_detect_results_context_label(selected_count: int) -> str:


### PR DESCRIPTION
### Motivation
- Users expect file-explorer style interactions: `Ctrl+Click` should toggle individual rows in the mission results list without disturbing multi-selection, and a right-click context menu should be dismissed when clicking elsewhere or pressing `Escape`.

### Description
- Add a dedicated `Ctrl+Click` handler ` _on_results_table_control_click` and bind it to `<Control-Button-1>` to toggle single row selection while preserving existing multi-selection behavior in `transceiver/mission_workflow_ui.py`.
- Replace the previous `Ctrl+Click` context-menu binding so right-click still opens the menu but `Ctrl+Click` toggles selection instead.
- Install temporary dismissal handlers when the context menu opens via `_install_results_context_menu_dismiss_handlers`, and implement `_dismiss_results_context_menu` and `_remove_results_context_menu_dismiss_handlers` to unpost the menu and remove bindings on click/Escape.
- Extend `tests/test_mission_workflow_ui.py` with updated `Treeview` stub methods (`selection_set`, `selection_add`, `focus`) and add tests for `Ctrl+Click` add/remove behavior and for context-menu dismissal cleanup.

### Testing
- Ran `python -m py_compile transceiver/mission_workflow_ui.py tests/test_mission_workflow_ui.py` successfully.
- Ran `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` which completed successfully (unit tests for the modified UI file passed).
- Ran `PYTHONPATH=. pytest -q` which fails during collection in unrelated modules (issues: missing `_suppress_nearby_candidates` import in `transceiver.helpers.correlation_utils` and `TypeError: __mro_entries__ must return a tuple` when importing `transceiver.__main__`), so full suite is blocked by preexisting unrelated errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d5ad7c2e883218d7de7d8cb7f4676)