### PR TITLE
Add LiDAR overlay visibility toggles

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -534,6 +534,8 @@ def test_workflow_state_payload_persists_echo_heatmap_settings() -> None:
     window.echo_heatmap_min_visible_overlap_var = SimpleNamespace(get=lambda: "7")
     window.echo_heatmap_evaluation_visible_var = SimpleNamespace(get=lambda: False)
     window.echo_heatmap_ellipses_visible_var = SimpleNamespace(get=lambda: True)
+    window.echo_heatmap_lidar_points_visible_var = SimpleNamespace(get=lambda: False)
+    window.echo_heatmap_lidar_reference_line_visible_var = SimpleNamespace(get=lambda: True)
     window._records = []
 
     payload = window._build_workflow_state_payload()
@@ -542,6 +544,8 @@ def test_workflow_state_payload_persists_echo_heatmap_settings() -> None:
     assert payload["echo_heatmap_min_visible_overlap"] == 7
     assert payload["echo_heatmap_evaluation_visible"] is False
     assert payload["echo_heatmap_ellipses_visible"] is True
+    assert payload["echo_heatmap_lidar_points_visible"] is False
+    assert payload["echo_heatmap_lidar_reference_line_visible"] is True
 
 
 def test_selected_record_overlay_point_prefers_live_yaw() -> None:
@@ -616,6 +620,44 @@ def test_draw_selected_lidar_reference_overlay_draws_multiple_selected_results()
         (7.0, -2.0),
         (8.0, -1.0),
     ]
+
+
+def test_draw_selected_lidar_reference_overlay_respects_lidar_visibility_toggles() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._selected_result_index = 0
+    window._selected_result_indices = (0, 1)
+    window._records = [
+        {
+            "point_index": 0,
+            "live_position_at_measurement": {"x": 7.0, "y": -2.0, "yaw": 0.25},
+            "measurement": {"result": {"lidar_reference": {"output_file": "scan.yaml"}}},
+        },
+    ]
+    window._mission_points = [MeasurementPoint(id="p0", name="P0", x=50.0, y=50.0, yaw=0.0)]
+    window.echo_heatmap_lidar_points_visible_var = SimpleNamespace(get=lambda: False)
+    window.echo_heatmap_lidar_reference_line_visible_var = SimpleNamespace(get=lambda: True)
+    window._load_lidar_scan_for_overlay = lambda _path: {"angle_min": 0.0, "angle_increment": 0.1, "ranges": [1.0]}
+    scan_calls: list[dict[str, object]] = []
+    line_calls: list[LidarWallEstimate] = []
+    window._draw_lidar_scan_overlay_for_point = lambda **kwargs: scan_calls.append(kwargs)
+    window._lidar_scan_world_points_for_point = lambda **_kwargs: [
+        (x / 10.0, -1.0 + (0.005 if x % 2 else -0.005)) for x in range(0, 31)
+    ]
+    window._draw_lidar_wall_estimate = lambda estimate: line_calls.append(estimate)
+
+    window._draw_selected_lidar_reference_overlay()
+
+    assert scan_calls == []
+    assert len(line_calls) == 1
+
+
+def test_draw_selected_lidar_reference_overlay_can_hide_all_lidar_layers() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.echo_heatmap_lidar_points_visible_var = SimpleNamespace(get=lambda: False)
+    window.echo_heatmap_lidar_reference_line_visible_var = SimpleNamespace(get=lambda: False)
+    window._selected_record_payloads = lambda: (_ for _ in ()).throw(AssertionError("records should not be read"))
+
+    window._draw_selected_lidar_reference_overlay()
 
 
 

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -553,6 +553,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         )
         self.echo_heatmap_evaluation_visible_var = tk.BooleanVar(value=True)
         self.echo_heatmap_ellipses_visible_var = tk.BooleanVar(value=False)
+        self.echo_heatmap_lidar_points_visible_var = tk.BooleanVar(value=True)
+        self.echo_heatmap_lidar_reference_line_visible_var = tk.BooleanVar(value=True)
         self._echo_heatmap_settings_trace_pending = False
         self._live_pose_stream_active = False
 
@@ -635,6 +637,18 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             return False
         return bool(variable.get())
 
+    def _echo_heatmap_lidar_points_visible(self) -> bool:
+        variable = getattr(self, "echo_heatmap_lidar_points_visible_var", None)
+        if variable is None:
+            return True
+        return bool(variable.get())
+
+    def _echo_heatmap_lidar_reference_line_visible(self) -> bool:
+        variable = getattr(self, "echo_heatmap_lidar_reference_line_visible_var", None)
+        if variable is None:
+            return True
+        return bool(variable.get())
+
     def _build_echo_heatmap_settings_overlay(self) -> tk.Frame:
         frame = tk.Frame(
             self.map_preview_canvas,
@@ -669,7 +683,21 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             variable=self.echo_heatmap_ellipses_visible_var,
             command=self._on_echo_heatmap_settings_changed,
             **checkbutton_kwargs,
-        ).grid(row=2, column=0, columnspan=2, sticky="ew", padx=8, pady=(0, 6))
+        ).grid(row=2, column=0, columnspan=2, sticky="ew", padx=8, pady=(0, 0))
+        tk.Checkbutton(
+            frame,
+            text="LiDAR-Messpunkte",
+            variable=self.echo_heatmap_lidar_points_visible_var,
+            command=self._on_echo_heatmap_settings_changed,
+            **checkbutton_kwargs,
+        ).grid(row=3, column=0, columnspan=2, sticky="ew", padx=8, pady=(0, 0))
+        tk.Checkbutton(
+            frame,
+            text="LiDAR-Referenzlinie",
+            variable=self.echo_heatmap_lidar_reference_line_visible_var,
+            command=self._on_echo_heatmap_settings_changed,
+            **checkbutton_kwargs,
+        ).grid(row=4, column=0, columnspan=2, sticky="ew", padx=8, pady=(0, 6))
         return frame
 
     def _sync_echo_heatmap_settings_overlay(self, *, visible: bool) -> None:
@@ -828,6 +856,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "write", lambda *_args: self._on_echo_heatmap_settings_changed()
         )
         self.echo_heatmap_ellipses_visible_var.trace_add(
+            "write", lambda *_args: self._on_echo_heatmap_settings_changed()
+        )
+        self.echo_heatmap_lidar_points_visible_var.trace_add(
+            "write", lambda *_args: self._on_echo_heatmap_settings_changed()
+        )
+        self.echo_heatmap_lidar_reference_line_visible_var.trace_add(
             "write", lambda *_args: self._on_echo_heatmap_settings_changed()
         )
         self._map_image_original: tk.PhotoImage | None = None
@@ -1831,6 +1865,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._echo_heatmap_min_visible_overlap(),
             self._echo_heatmap_evaluation_visible(),
             self._echo_heatmap_ellipses_visible(),
+            self._echo_heatmap_lidar_points_visible(),
+            self._echo_heatmap_lidar_reference_line_visible(),
             self._pending_nav2point_world_position,
             self._pending_nav2point_yaw_radians,
             self._pending_waypoint_world_position,
@@ -1868,8 +1904,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._last_visible_red_echo_probability_world_points = []
         echo_heatmap_active = self._draw_selected_echo_overlay()
         self._draw_selected_lidar_reference_overlay()
+        settings_overlay_active = echo_heatmap_active or len(self._selected_record_payloads()) > 1
         self._raise_selected_echo_probability_overlay()
-        self._sync_echo_heatmap_settings_overlay(visible=echo_heatmap_active)
+        self._sync_echo_heatmap_settings_overlay(visible=settings_overlay_active)
 
     def _draw_live_overlay_layer(self) -> None:
         self._draw_live_echo_preview_overlay()
@@ -3334,6 +3371,11 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         return points
 
     def _draw_selected_lidar_reference_overlay(self) -> None:
+        lidar_points_visible = self._echo_heatmap_lidar_points_visible()
+        lidar_reference_line_visible = self._echo_heatmap_lidar_reference_line_visible()
+        if not lidar_points_visible and not lidar_reference_line_visible:
+            return
+
         wall_points: list[tuple[float, float]] = []
         for record in self._selected_record_payloads():
             measurement_position = self._selected_record_measurement_position(record)
@@ -3357,11 +3399,14 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             overlay_point = self._selected_record_overlay_point(record, measurement_position=measurement_position)
             if overlay_point is None:
                 continue
-            self._draw_lidar_scan_overlay_for_point(point=overlay_point, scan=scan)
-            wall_points.extend(self._lidar_scan_world_points_for_point(point=overlay_point, scan=scan))
-        estimate = _estimate_lower_horizontal_lidar_wall(wall_points)
-        if estimate is not None:
-            self._draw_lidar_wall_estimate(estimate)
+            if lidar_points_visible:
+                self._draw_lidar_scan_overlay_for_point(point=overlay_point, scan=scan)
+            if lidar_reference_line_visible:
+                wall_points.extend(self._lidar_scan_world_points_for_point(point=overlay_point, scan=scan))
+        if lidar_reference_line_visible:
+            estimate = _estimate_lower_horizontal_lidar_wall(wall_points)
+            if estimate is not None:
+                self._draw_lidar_wall_estimate(estimate)
 
     def _selected_record_payload(self) -> dict[str, Any] | None:
         selected_idx = self._selected_result_index
@@ -4243,6 +4288,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "echo_heatmap_antenna_opening_angle_deg": self._echo_heatmap_antenna_opening_angle_deg(),
             "echo_heatmap_evaluation_visible": self._echo_heatmap_evaluation_visible(),
             "echo_heatmap_ellipses_visible": self._echo_heatmap_ellipses_visible(),
+            "echo_heatmap_lidar_points_visible": self._echo_heatmap_lidar_points_visible(),
+            "echo_heatmap_lidar_reference_line_visible": self._echo_heatmap_lidar_reference_line_visible(),
             "records": self._records,
         }
 
@@ -4363,6 +4410,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             )
             self.echo_heatmap_ellipses_visible_var.set(
                 bool(payload.get("echo_heatmap_ellipses_visible", False))
+            )
+            self.echo_heatmap_lidar_points_visible_var.set(
+                bool(payload.get("echo_heatmap_lidar_points_visible", True))
+            )
+            self.echo_heatmap_lidar_reference_line_visible_var.set(
+                bool(payload.get("echo_heatmap_lidar_reference_line_visible", True))
             )
             self._refresh_points_table()
             self._refresh_map_section()


### PR DESCRIPTION
### Motivation
- Provide independent visibility control for LiDAR measurement points and the LiDAR reference line in the multi-selection map overlay so users can show/hide those layers separately from echo evaluation/ellipses.

### Description
- Added two persisted boolean controls `echo_heatmap_lidar_points_visible_var` and `echo_heatmap_lidar_reference_line_visible_var` with getters `_echo_heatmap_lidar_points_visible()` and `_echo_heatmap_lidar_reference_line_visible()` and tied them into the existing echo-heatmap settings UI via `tk.Checkbutton` entries.
- Updated `_build_echo_heatmap_settings_overlay` to include the two new checkboxes and added `trace_add` hooks to call `_on_echo_heatmap_settings_changed()` when they change.
- Modified map redraw/signature and overlay logic to account for the new toggles by adding the values to `_build_static_map_layer_signature`, changing the settings overlay visibility condition, and making `_draw_selected_lidar_reference_overlay` respect the toggles: points are drawn only when LiDAR-points visible and the reference line (wall estimate) is computed/drawn only when the reference-line toggle is enabled.
- Persisted the new toggles in `_build_workflow_state_payload` and restored them in `_restore_workflow_state`; added unit tests exercising payload persistence and overlay visibility behavior in `tests/test_mission_workflow_ui.py`.

### Testing
- Ran the modified unit tests with `python -m pytest tests/test_mission_workflow_ui.py -q`, which passed (`109 passed`).
- Ran the full test suite with `python -m pytest -q`; collection failed with unrelated existing errors (an `ImportError` for `_suppress_nearby_candidates` and a `TypeError: __mro_entries__ must return a tuple` in `transceiver/__main__.py`) that are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d5ebcd53c832182528457bbd48651)