### PR TITLE
Keep map overlay controls visible

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1389,6 +1389,35 @@ def test_lidar_overlay_beam_angle_compensates_left_rotated_scanner() -> None:
     assert angle == pytest.approx(math.pi / 2.0)
 
 
+def test_draw_static_map_layer_keeps_overlay_settings_visible_without_selection() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    original = SimpleNamespace(width=lambda: 200, height=lambda: 100)
+    preview = SimpleNamespace(width=lambda: 100, height=lambda: 50)
+    window._map_image_original = original
+    window._resize_photo_to_contain = lambda *_args, **_kwargs: preview
+    window.map_preview_canvas = SimpleNamespace(
+        delete=lambda *_args, **_kwargs: None,
+        create_image=lambda *_args, **_kwargs: 1,
+    )
+    window._live_overlay_item_ids = {}
+    window._hide_echo_heatmap_settings_overlay = lambda: None
+    window._invalidate_live_echo_geometry_cache = lambda: None
+    window._draw_mission_markers = lambda: None
+    window._draw_pending_nav2point_marker = lambda: None
+    window._draw_pending_waypoint_marker = lambda: None
+    window._draw_rx_antenna_marker = lambda: None
+    window._draw_measurement_overlay = lambda: None
+    window._draw_selected_echo_overlay = lambda: False
+    window._draw_selected_lidar_reference_overlay = lambda: None
+    window._raise_selected_echo_probability_overlay = lambda: None
+    visible_calls: list[bool] = []
+    window._sync_echo_heatmap_settings_overlay = lambda *, visible: visible_calls.append(visible)
+
+    window._draw_static_map_layer(canvas_width=100, canvas_height=80)
+
+    assert visible_calls == [True]
+
+
 def test_draw_lidar_scan_overlay_filters_points_by_tx_opening_angle() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._map_image_original = SimpleNamespace(width=lambda: 200, height=lambda: 120)

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -659,7 +659,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             highlightcolor="#5f6b7a",
         )
         label_kwargs = {"bg": "#20242a", "fg": "#f5f5f5", "anchor": "w"}
-        tk.Label(frame, text="Echo-Heatmap", font=("TkDefaultFont", 9, "bold"), **label_kwargs).grid(
+        tk.Label(frame, text="Overlay", font=("TkDefaultFont", 9, "bold"), **label_kwargs).grid(
             row=0, column=0, columnspan=2, sticky="ew", padx=8, pady=(6, 2)
         )
         checkbutton_kwargs = {
@@ -672,14 +672,14 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         }
         tk.Checkbutton(
             frame,
-            text="Auswertung anzeigen",
+            text="Auswertung",
             variable=self.echo_heatmap_evaluation_visible_var,
             command=self._on_echo_heatmap_settings_changed,
             **checkbutton_kwargs,
         ).grid(row=1, column=0, columnspan=2, sticky="ew", padx=8, pady=(2, 0))
         tk.Checkbutton(
             frame,
-            text="Ellipsen anzeigen",
+            text="Ellipsen",
             variable=self.echo_heatmap_ellipses_visible_var,
             command=self._on_echo_heatmap_settings_changed,
             **checkbutton_kwargs,
@@ -1902,11 +1902,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._draw_rx_antenna_marker()
         self._draw_measurement_overlay()
         self._last_visible_red_echo_probability_world_points = []
-        echo_heatmap_active = self._draw_selected_echo_overlay()
+        self._draw_selected_echo_overlay()
         self._draw_selected_lidar_reference_overlay()
-        settings_overlay_active = echo_heatmap_active or len(self._selected_record_payloads()) > 1
         self._raise_selected_echo_probability_overlay()
-        self._sync_echo_heatmap_settings_overlay(visible=settings_overlay_active)
+        self._sync_echo_heatmap_settings_overlay(visible=True)
 
     def _draw_live_overlay_layer(self) -> None:
         self._draw_live_echo_preview_overlay()


### PR DESCRIPTION
### Motivation
- The overlay/settings window for map echo visualization should be visible by default instead of being shown only when multiple results are selected or the heatmap is active. 
- Labels in the overlay were verbose and should be shortened for clarity.

### Description
- Rename the overlay heading in `MissionWorkflowWindow._build_echo_heatmap_settings_overlay` from `"Echo-Heatmap"` to `"Overlay"` and update the checkbutton texts from `"Auswertung anzeigen"`/`"Ellipsen anzeigen"` to `"Auswertung"`/`"Ellipsen"` in `transceiver/mission_workflow_ui.py`.
- Make the overlay window always shown when the static map layer is drawn by calling `self._sync_echo_heatmap_settings_overlay(visible=True)` unconditionally in the static map draw path instead of gating it on echo-heatmap activity or multiple selection.
- Add a regression unit test `test_draw_static_map_layer_keeps_overlay_settings_visible_without_selection` in `tests/test_mission_workflow_ui.py` to assert the overlay sync is invoked when drawing the static map layer.

### Testing
- Ran `pytest tests/test_mission_workflow_ui.py` which initially failed due to import path issues (`ModuleNotFoundError` when `PYTHONPATH` was not set). 
- Re-ran with `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py` and all tests in that file passed (`110 passed in 2.20s`).
- Ran `git diff --check` and there were no whitespace or diff check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d65c3b330832180d1944769013f19)