### PR TITLE
Keep selected measurement markers visible

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -684,6 +684,35 @@ def test_draw_selected_lidar_reference_overlay_can_hide_all_lidar_layers() -> No
     window._draw_selected_lidar_reference_overlay()
 
 
+def test_draw_selected_measurement_position_markers_ignore_lidar_points_toggle() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._map_image_original = SimpleNamespace(width=lambda: 200, height=lambda: 120)
+    window._map_preview_scale = (1.0, 1.0)
+    window._map_preview_offset = (0.0, 0.0)
+    window._selected_result_index = 0
+    window._selected_result_indices = (0,)
+    window._records = [
+        {
+            "point_index": 0,
+            "live_position_at_measurement": {"x": 7.0, "y": -2.0, "yaw": 0.25},
+        }
+    ]
+    window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
+    window._is_pixel_inside_map = lambda *_args, **_kwargs: True
+    marker_calls: list[tuple[tuple[float, ...], dict[str, object]]] = []
+    window.map_preview_canvas = SimpleNamespace(
+        create_oval=lambda *coords, **kwargs: marker_calls.append((coords, kwargs)) or 1
+    )
+    window.echo_heatmap_lidar_points_visible_var = SimpleNamespace(get=lambda: False)
+
+    window._draw_selected_measurement_position_markers()
+
+    assert len(marker_calls) == 1
+    coords, kwargs = marker_calls[0]
+    assert coords == pytest.approx((2.0, -7.0, 12.0, 3.0))
+    assert kwargs["fill"] == "#212121"
+
+
 
 def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation_and_rms() -> None:
     class FakeCanvas:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -2122,6 +2122,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._last_visible_red_echo_probability_world_points = []
         self._draw_selected_echo_overlay()
         self._draw_selected_lidar_reference_overlay()
+        self._draw_selected_measurement_position_markers()
         self._draw_lidar_measurement_area_overlay()
         self._raise_selected_echo_probability_overlay()
         self._sync_echo_heatmap_settings_overlay(visible=True)
@@ -3588,6 +3589,44 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._ellipse_unit_circle_cache[samples] = points
         return points
 
+    def _draw_selected_measurement_position_markers(self) -> None:
+        original = self._map_image_original
+        if original is None:
+            return
+        scale_x, scale_y = getattr(self, "_map_preview_scale", (1.0, 1.0))
+        offset_x, offset_y = self._map_preview_offset
+        if not hasattr(self, "_selected_result_index") or not hasattr(self, "_records"):
+            return
+        for record in self._selected_record_payloads():
+            measurement_position = self._selected_record_measurement_position(record)
+            if measurement_position is None:
+                continue
+            map_pixel = self._world_to_map_pixel(
+                x=measurement_position[0],
+                y=measurement_position[1],
+                image_height=original.height(),
+            )
+            if map_pixel is None:
+                continue
+            if not self._is_pixel_inside_map(
+                map_pixel[0],
+                map_pixel[1],
+                width=original.width(),
+                height=original.height(),
+            ):
+                continue
+            marker_x = map_pixel[0] * scale_x + offset_x
+            marker_y = map_pixel[1] * scale_y + offset_y
+            self.map_preview_canvas.create_oval(
+                marker_x - 5,
+                marker_y - 5,
+                marker_x + 5,
+                marker_y + 5,
+                fill="#212121",
+                outline="#ffffff",
+                width=2,
+            )
+
     def _draw_selected_lidar_reference_overlay(self) -> None:
         lidar_points_visible = self._echo_heatmap_lidar_points_visible()
         lidar_reference_line_visible = self._echo_heatmap_lidar_reference_line_visible()
@@ -3845,15 +3884,6 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         start_y = start_map_pixel[1] * scale_y + offset_y
         preview_scale = max(scale_x, scale_y)
         lidar_hit_marker_radius = max(2.0, min(4.0, 2.5 * max(1.0, preview_scale)))
-        self.map_preview_canvas.create_oval(
-            start_x - 5,
-            start_y - 5,
-            start_x + 5,
-            start_y + 5,
-            fill="#212121",
-            outline="#ffffff",
-            width=2,
-        )
         angle_min = float(scan["angle_min"])
         angle_increment = float(scan["angle_increment"])
         ranges = scan["ranges"]


### PR DESCRIPTION
### Motivation
- Selected measurement-position markers (schwarze Punkte) were tied to the LiDAR point renderer, so disabling LiDAR points hid the measurement markers as well.

### Description
- Draw selected measurement-position markers in a dedicated overlay via a new method `_draw_selected_measurement_position_markers()` and call it from the static map drawing path so markers remain visible independently of LiDAR point visibility.
- Remove the hard-coded black marker draw from `_draw_lidar_scan_overlay_for_point()` so marker visibility is no longer coupled to LiDAR point rendering.
- Add a defensive check to avoid referencing attributes when the window object is partially constructed.
- Modified `tests/test_mission_workflow_ui.py` to add `test_draw_selected_measurement_position_markers_ignore_lidar_points_toggle()` which verifies markers are drawn even when `echo_heatmap_lidar_points_visible_var` is disabled.

### Testing
- Compiled the modified module with `python -m py_compile transceiver/mission_workflow_ui.py` which succeeded.
- Ran `python -m pytest tests/test_mission_workflow_ui.py` and the file-level test run passed (`113 passed`).
- Running the entire test suite with `python -m pytest` still fails during collection in this environment due to unrelated import/collection issues (missing internal symbol and `__mro_entries__` TypeError in other modules), not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d805045c88321b4cc2046a7c8d186)