### PR TITLE
Rename measurement map button to 'lineal'

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -839,7 +839,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         )
         self.measurement_map_pick_mode_btn = ctk.CTkButton(
             map_top_controls,
-            text="measurement",
+            text="lineal",
             command=self._toggle_measurement_map_pick_mode,
             width=110,
         )
@@ -1649,7 +1649,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._measurement_end_world_position = None
             measurement_button = getattr(self, "measurement_map_pick_mode_btn", None)
             if measurement_button is not None:
-                measurement_button.configure(text="measurement")
+                measurement_button.configure(text="lineal")
             self._nav2point_map_pick_mode_enabled = False
             nav2point_button = getattr(self, "nav2point_map_pick_mode_btn", None)
             if nav2point_button is not None:
@@ -1807,7 +1807,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._measurement_end_world_position = None
         measurement_button = getattr(self, "measurement_map_pick_mode_btn", None)
         if measurement_button is not None:
-            measurement_button.configure(text="✕" if enabled else "measurement")
+            measurement_button.configure(text="✕" if enabled else "lineal")
         self._update_map_canvas_cursor()
         self._draw_map_preview()
 


### PR DESCRIPTION
### Motivation
- Change the map pick-mode button label in the mission workflow from `measurement` to `lineal` so the UI reflects the requested label.

### Description
- Modified `transceiver/mission_workflow_ui.py` to initialize `measurement_map_pick_mode_btn` with `text="lineal"` and replaced occurrences that reset or configure the button label to use `"lineal"` instead of `"measurement"`.

### Testing
- Compiled the modified file with `python -m compileall transceiver/mission_workflow_ui.py`, which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d81d44c248321a2e287baea4efc59)