### PR TITLE
Rename measurement map button to 'ruler'

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -2411,7 +2411,7 @@ def test_set_measurement_map_pick_mode_clears_overlay_when_disabled() -> None:
     assert window._measurement_map_pick_mode_enabled is False
     assert window._measurement_start_world_position is None
     assert window._measurement_end_world_position is None
-    assert window.measurement_map_pick_mode_btn.text == "measurement"
+    assert window.measurement_map_pick_mode_btn.text == "ruler"
 
 
 def test_manual_measurement_point_context_prefers_selected_enabled_point() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -839,7 +839,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         )
         self.measurement_map_pick_mode_btn = ctk.CTkButton(
             map_top_controls,
-            text="measurement",
+            text="ruler",
             command=self._toggle_measurement_map_pick_mode,
             width=110,
         )
@@ -1649,7 +1649,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._measurement_end_world_position = None
             measurement_button = getattr(self, "measurement_map_pick_mode_btn", None)
             if measurement_button is not None:
-                measurement_button.configure(text="measurement")
+                measurement_button.configure(text="ruler")
             self._nav2point_map_pick_mode_enabled = False
             nav2point_button = getattr(self, "nav2point_map_pick_mode_btn", None)
             if nav2point_button is not None:
@@ -1807,7 +1807,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._measurement_end_world_position = None
         measurement_button = getattr(self, "measurement_map_pick_mode_btn", None)
         if measurement_button is not None:
-            measurement_button.configure(text="✕" if enabled else "measurement")
+            measurement_button.configure(text="✕" if enabled else "ruler")
         self._update_map_canvas_cursor()
         self._draw_map_preview()
 


### PR DESCRIPTION
### Motivation
- Clarify the mission workflow map-pick control by renaming the measurement map button label from `measurement` to `ruler` so the UI better reflects its purpose.

### Description
- Change the default button label text in `transceiver/mission_workflow_ui.py` from `measurement` to `ruler` and update the code paths that reset the button text to use `ruler`.
- Update the unit test expectation in `tests/test_mission_workflow_ui.py` to assert the renamed label.

### Testing
- Running `pytest tests/test_mission_workflow_ui.py -q` without `PYTHONPATH` failed during collection due to `ModuleNotFoundError` for the package import (environment setup issue).
- Running `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` succeeded with `113 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d8266678483219cb29e537a28dbf6)