### PR TITLE
Use full map for LiDAR lower-wall estimation when measurement area is unset; update tests

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -31,7 +31,18 @@ def test_estimate_lower_horizontal_lidar_wall_ignores_upper_walls_and_columns() 
     assert estimate.residual_std_m == pytest.approx(0.01, abs=0.004)
 
 
-def test_estimate_lower_horizontal_lidar_wall_uses_measurement_area_instead_of_lower_half() -> None:
+def test_estimate_lower_horizontal_lidar_wall_uses_whole_map_without_measurement_area() -> None:
+    sparse_lower_wall = [(x / 10.0, 1.0 + (0.01 if x % 2 else -0.01)) for x in range(0, 16)]
+    dense_upper_wall = [(x / 10.0, 3.0 + (0.01 if x % 2 else -0.01)) for x in range(0, 31)]
+
+    estimate = _estimate_lower_horizontal_lidar_wall(sparse_lower_wall + dense_upper_wall)
+
+    assert estimate is not None
+    assert estimate.point_count >= len(dense_upper_wall) - 2
+    assert estimate.intercept == pytest.approx(3.0, abs=0.03)
+
+
+def test_estimate_lower_horizontal_lidar_wall_uses_measurement_area() -> None:
     lower_wall = [(x / 10.0, 1.0 + (0.01 if x % 2 else -0.01)) for x in range(0, 31)]
     selected_upper_wall = [(x / 10.0, 3.0 + (0.01 if x % 2 else -0.01)) for x in range(0, 31)]
     measurement_area = LidarMeasurementArea(min_x=-0.1, min_y=2.8, max_x=3.1, max_y=3.2)

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -229,12 +229,10 @@ def _estimate_lower_horizontal_lidar_wall(
 ) -> LidarWallEstimate | None:
     """Estimate the lower map wall from LiDAR hit points and ignore other structures.
 
-    The map coordinate system used by ROS occupancy grids has increasing world ``y``
-    upwards.  If no explicit measurement area is configured, the lower wall in
-    the map preview therefore has a small world ``y`` value and we keep only that
-    lower half.  With a measurement area, only points inside that rectangle are
-    considered.  From the selected points we choose the densest horizontal ``y``
-    band and then refine a line with two residual-based rejections.
+    If an explicit measurement area is configured, only points inside that
+    rectangle are considered.  Otherwise the full map is considered.  From the
+    selected points we choose the densest horizontal ``y`` band and then refine a
+    line with two residual-based rejections.
     """
 
     finite_points = [
@@ -252,18 +250,11 @@ def _estimate_lower_horizontal_lidar_wall(
     if len(finite_points) < min_points:
         return None
 
-    if measurement_area is None:
-        y_values = np.asarray([point[1] for point in finite_points], dtype=float)
-        lower_cutoff = float(np.median(y_values))
-        lower_points = [point for point in finite_points if point[1] <= lower_cutoff]
-        if len(lower_points) < min_points:
-            lower_points = finite_points
-    else:
-        lower_points = finite_points
+    selected_points = finite_points
 
     safe_bin_size = bin_size_m if math.isfinite(bin_size_m) and bin_size_m > 0.0 else LIDAR_WALL_BIN_SIZE_M
     band_buckets: dict[int, list[tuple[float, float]]] = {}
-    for point in lower_points:
+    for point in selected_points:
         band_buckets.setdefault(int(math.floor(point[1] / safe_bin_size)), []).append(point)
     if not band_buckets:
         return None


### PR DESCRIPTION
### Motivation
- Simplify and correct the behavior of the LiDAR wall estimator so that when no explicit measurement area is configured the full map is considered instead of heuristically taking the lower half.
- Make tests reflect the updated selection behavior and ensure measurement-area filtering still works.

### Description
- Changed `_estimate_lower_horizontal_lidar_wall` to always consider all finite points by default and only apply `measurement_area` clipping when provided, removing the previous median-based lower-half selection logic. 
- Renamed and split an existing test into `test_estimate_lower_horizontal_lidar_wall_uses_whole_map_without_measurement_area` and `test_estimate_lower_horizontal_lidar_wall_uses_measurement_area`, and adjusted expectations to match the new behavior. 
- Minor docstring cleanup to reflect the new selection semantics.

### Testing
- Ran `pytest tests/test_mission_workflow_ui.py` which executed the updated tests in that file including `test_estimate_lower_horizontal_lidar_wall_ignores_upper_walls_and_columns`, `test_estimate_lower_horizontal_lidar_wall_uses_whole_map_without_measurement_area`, `test_estimate_lower_horizontal_lidar_wall_uses_measurement_area`, and related edge-case tests, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d861309c083218885e825221a548d)