### PR TITLE
Messwand: Häkchen-Button & Click-to-clear Messbereich

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -2006,6 +2006,49 @@ def test_on_map_canvas_drag_updates_pending_nav2point_yaw() -> None:
     assert window._pending_nav2point_yaw_radians == 0.0
 
 
+def test_lidar_measurement_area_button_uses_checkmark_when_active() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    configured: list[str] = []
+    window.lidar_measurement_area_btn = SimpleNamespace(
+        configure=lambda **kwargs: configured.append(kwargs["text"])
+    )
+    window._set_waypoint_map_pick_mode = lambda _enabled: None
+    window._set_rx_antenna_map_pick_mode = lambda _enabled: None
+    window._set_measurement_map_pick_mode = lambda _enabled: None
+    window._set_nav2point_map_pick_mode = lambda _enabled: None
+    window._update_map_canvas_cursor = lambda: None
+    window._draw_map_preview = lambda: None
+
+    window._set_lidar_measurement_area_edit_mode(True)
+
+    assert configured == ["✓"]
+
+
+def test_lidar_measurement_area_click_without_drag_clears_area() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._lidar_measurement_area_edit_enabled = True
+    window._lidar_measurement_area = LidarMeasurementArea(min_x=0.0, min_y=1.0, max_x=2.0, max_y=3.0)
+    window._lidar_measurement_area_drag_start_world = (1.0, 2.0)
+    window._lidar_measurement_area_drag_current_world = (1.0, 2.0)
+    window._static_map_layer_signature = object()
+    draw_calls: list[str] = []
+    persist_calls: list[str] = []
+    messages: list[str] = []
+    window._draw_map_preview = lambda: draw_calls.append("draw")
+    window._persist_workflow_state = lambda: persist_calls.append("persist")
+    window._append_validation = messages.append
+
+    window._on_map_canvas_release(SimpleNamespace(x=10, y=20))
+
+    assert window._lidar_measurement_area is None
+    assert window._lidar_measurement_area_drag_start_world is None
+    assert window._lidar_measurement_area_drag_current_world is None
+    assert window._static_map_layer_signature is None
+    assert draw_calls == ["draw"]
+    assert persist_calls == ["persist"]
+    assert messages == ["✅ LiDAR-Messwand entfernt."]
+
+
 def test_on_map_canvas_release_creates_waypoint_and_disables_pick_mode() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._waypoint_map_pick_mode_enabled = True

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -932,6 +932,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._lidar_measurement_area_edit_enabled = False
         self._lidar_measurement_area_drag_start_world: tuple[float, float] | None = None
         self._lidar_measurement_area_drag_current_world: tuple[float, float] | None = None
+        self._lidar_measurement_area_drag_active = False
         self._manual_drive_lock = threading.Lock()
         self._pending_nav2point_world_position: tuple[float, float] | None = None
         self._pending_nav2point_yaw_radians = 0.0
@@ -1424,6 +1425,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 return
             self._lidar_measurement_area_drag_start_world = world_position
             self._lidar_measurement_area_drag_current_world = world_position
+            self._lidar_measurement_area_drag_active = False
             self._draw_map_preview()
             return
         if getattr(self, "_nav2point_map_pick_mode_enabled", False):
@@ -1476,6 +1478,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             if world_position is None:
                 return
             self._lidar_measurement_area_drag_current_world = world_position
+            self._lidar_measurement_area_drag_active = True
             self._draw_map_preview()
             return
         if getattr(self, "_nav2point_map_pick_mode_enabled", False):
@@ -1507,13 +1510,19 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if getattr(self, "_lidar_measurement_area_edit_enabled", False):
             start = self._lidar_measurement_area_drag_start_world
             current = self._lidar_measurement_area_drag_current_world
+            drag_active = getattr(self, "_lidar_measurement_area_drag_active", False)
             self._lidar_measurement_area_drag_start_world = None
             self._lidar_measurement_area_drag_current_world = None
+            self._lidar_measurement_area_drag_active = False
             if start is None or current is None:
                 return
             area = self._normalize_lidar_measurement_area(start, current)
             if area is None:
-                self._draw_map_preview()
+                if drag_active:
+                    self._draw_map_preview()
+                else:
+                    self._clear_lidar_measurement_area()
+                    self._append_validation("✅ LiDAR-Messwand entfernt.")
                 return
             self._set_lidar_measurement_area(area)
             self._append_validation(
@@ -1620,6 +1629,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._lidar_measurement_area_edit_enabled = False
             self._lidar_measurement_area_drag_start_world = None
             self._lidar_measurement_area_drag_current_world = None
+            self._lidar_measurement_area_drag_active = False
             lidar_area_button = getattr(self, "lidar_measurement_area_btn", None)
             if lidar_area_button is not None:
                 lidar_area_button.configure(text="Messwand")
@@ -1648,6 +1658,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._lidar_measurement_area_edit_enabled = False
             self._lidar_measurement_area_drag_start_world = None
             self._lidar_measurement_area_drag_current_world = None
+            self._lidar_measurement_area_drag_active = False
             lidar_area_button = getattr(self, "lidar_measurement_area_btn", None)
             if lidar_area_button is not None:
                 lidar_area_button.configure(text="Messwand")
@@ -1664,6 +1675,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._lidar_measurement_area_edit_enabled = enabled
         self._lidar_measurement_area_drag_start_world = None
         self._lidar_measurement_area_drag_current_world = None
+        self._lidar_measurement_area_drag_active = False
         if enabled:
             self._set_waypoint_map_pick_mode(False)
             self._set_rx_antenna_map_pick_mode(False)
@@ -1672,7 +1684,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._lidar_measurement_area_edit_enabled = True
         button = getattr(self, "lidar_measurement_area_btn", None)
         if button is not None:
-            button.configure(text="✕" if enabled else "Messwand")
+            button.configure(text="✓" if enabled else "Messwand")
         self._update_map_canvas_cursor()
         self._draw_map_preview()
 
@@ -1707,6 +1719,13 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
 
     def _set_lidar_measurement_area(self, area: LidarMeasurementArea, *, persist: bool = True) -> None:
         self._lidar_measurement_area = area
+        self._static_map_layer_signature = None
+        self._draw_map_preview()
+        if persist:
+            self._persist_workflow_state()
+
+    def _clear_lidar_measurement_area(self, *, persist: bool = True) -> None:
+        self._lidar_measurement_area = None
         self._static_map_layer_signature = None
         self._draw_map_preview()
         if persist:
@@ -1790,6 +1809,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._lidar_measurement_area_edit_enabled = False
             self._lidar_measurement_area_drag_start_world = None
             self._lidar_measurement_area_drag_current_world = None
+            self._lidar_measurement_area_drag_active = False
             lidar_area_button = getattr(self, "lidar_measurement_area_btn", None)
             if lidar_area_button is not None:
                 lidar_area_button.configure(text="Messwand")
@@ -1814,6 +1834,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._lidar_measurement_area_edit_enabled = False
             self._lidar_measurement_area_drag_start_world = None
             self._lidar_measurement_area_drag_current_world = None
+            self._lidar_measurement_area_drag_active = False
             lidar_area_button = getattr(self, "lidar_measurement_area_btn", None)
             if lidar_area_button is not None:
                 lidar_area_button.configure(text="Messwand")


### PR DESCRIPTION
### Motivation
- Verbesserung der Benutzeroberfläche: der `Messwand`-Button soll im aktiven Bearbeitungsmodus ein Häkchen statt eines X anzeigen. 
- Ergonomie: ein einfacher Klick (ohne Ziehen) im Kartenbereich soll den bestehenden Messbereich entfernen können. 
- Robustheit: das Verhalten muss zwischen Klick und Drag unterschieden und entsprechend persistiert oder nur visuell zurückgesetzt werden. 

### Description
- Ersetzt die aktive Beschriftung des LiDAR-Messwand-Buttons von `✕` auf `✓` in `transceiver/mission_workflow_ui.py` (siehe `_set_lidar_measurement_area_edit_mode`).
- Fügt ein Flag `self._lidar_measurement_area_drag_active` hinzu und setzt es bei Klick/Drag, um zwischen Klick- und Drag-Flows zu unterscheiden.
- Anpassung von `_on_map_canvas_click`, `_on_map_canvas_drag` und `_on_map_canvas_release` so dass ein Klick ohne vorheriges Ziehen die persistierte Messwand löscht via neuer Hilfsfunktion `_clear_lidar_measurement_area` und eine entsprechende Validierungsnachricht ausgibt.
- Ergänzt zwei Regressionstests in `tests/test_mission_workflow_ui.py`: `test_lidar_measurement_area_button_uses_checkmark_when_active` und `test_lidar_measurement_area_click_without_drag_clears_area`.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` and the test suite passed with `116 passed`.
- Verified syntax/bytecode with `PYTHONPATH=. python -m py_compile transceiver/mission_workflow_ui.py tests/test_mission_workflow_ui.py` which succeeded. 
- Static checks were run and the modified files are `transceiver/mission_workflow_ui.py` and `tests/test_mission_workflow_ui.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d89a49e948321b870daadf95057bc)