### PR TITLE
Remove LiDAR RMS values from mission workflow output

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -739,7 +739,7 @@ def test_draw_selected_measurement_position_markers_ignore_lidar_points_toggle()
 
 
 
-def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation_and_rms() -> None:
+def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation_without_rms() -> None:
     class FakeCanvas:
         def create_line(self, *_coords: float, **_kwargs: object) -> int:
             return 1
@@ -767,7 +767,8 @@ def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation_and_rm
     window._draw_lidar_wall_estimate(estimate)
 
     assert messages
-    assert "σ sichtbare rote Punkte=100.0cm, RMS sichtbare rote Punkte=100.0cm (2 Punkte)" in messages[0]
+    assert "σ sichtbare rote Punkte=100.0cm (2 Punkte)" in messages[0]
+    assert "RMS" not in messages[0]
 
 
 def test_draw_selected_echo_probability_overlay_tracks_visible_red_world_points() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3756,12 +3756,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         return world_points
 
     @staticmethod
-    def _line_residual_std_and_rms_m(
+    def _line_residual_std_m(
         points: list[tuple[float, float]],
         *,
         slope: float,
         intercept: float,
-    ) -> tuple[float, float] | None:
+    ) -> float | None:
         finite_points = [
             (float(x), float(y))
             for x, y in points
@@ -3775,9 +3775,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         finite_residuals = residuals[np.isfinite(residuals)]
         if finite_residuals.size == 0:
             return None
-        residual_std_m = float(np.std(finite_residuals))
-        residual_rms_m = float(math.sqrt(np.mean(finite_residuals * finite_residuals)))
-        return (residual_std_m, residual_rms_m)
+        return float(np.std(finite_residuals))
 
     def _draw_lidar_wall_estimate(self, estimate: LidarWallEstimate) -> None:
         original = self._map_image_original
@@ -3810,17 +3808,15 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             width=LIDAR_WALL_LINE_WIDTH_PX,
         )
         red_points = getattr(self, "_last_visible_red_echo_probability_world_points", [])
-        red_points_stats_m = self._line_residual_std_and_rms_m(
+        red_points_std_m = self._line_residual_std_m(
             red_points,
             slope=estimate.slope,
             intercept=estimate.intercept,
         )
         red_points_summary = ""
-        if red_points_stats_m is not None:
-            red_points_std_m, red_points_rms_m = red_points_stats_m
+        if red_points_std_m is not None:
             red_points_summary = (
-                f", σ sichtbare rote Punkte={red_points_std_m * 100.0:.1f}cm, "
-                f"RMS sichtbare rote Punkte={red_points_rms_m * 100.0:.1f}cm "
+                f", σ sichtbare rote Punkte={red_points_std_m * 100.0:.1f}cm "
                 f"({len(red_points)} Punkte)"
             )
         self._append_validation(
@@ -3828,8 +3824,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             f"{estimate.point_count} Punkte, "
             f"y={estimate.slope:.4f}x+{estimate.intercept:.3f}, "
             f"σ={estimate.residual_std_m * 100.0:.1f}cm, "
-            f"mittl. |Abweichung|={estimate.residual_mean_m * 100.0:.1f}cm, "
-            f"RMS={estimate.residual_rms_m * 100.0:.1f}cm"
+            f"mittl. |Abweichung|={estimate.residual_mean_m * 100.0:.1f}cm"
             f"{red_points_summary}"
         )
 


### PR DESCRIPTION
### Motivation
- The mission workflow terminal/UI emitted RMS values for LiDAR reference line residuals and visible red reference points which should be removed to simplify output while keeping standard deviation and mean absolute deviation.

### Description
- Replaced the helper ` _line_residual_std_and_rms_m` with ` _line_residual_std_m` to compute only the standard deviation and removed RMS computation.
- Updated `_draw_lidar_wall_estimate` to omit RMS information from the red points summary and the LiDAR wall summary while preserving σ and mean absolute deviation.
- Adjusted the UI test `test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation_*` in `tests/test_mission_workflow_ui.py` to assert the absence of `RMS` in emitted messages.
- Modified files: `transceiver/mission_workflow_ui.py` and `tests/test_mission_workflow_ui.py`.

### Testing
- Ran `python -m pytest tests/test_mission_workflow_ui.py -q` and the test file passed with `117 passed`.
- No other automated test failures were observed for the modified test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d8d71a4f88321a1d448cfed4fe0b3)