### PR TITLE
Report mean absolute deviation for LiDAR measurement points and rename label to Messpunkte

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -739,7 +739,7 @@ def test_draw_selected_measurement_position_markers_ignore_lidar_points_toggle()
 
 
 
-def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation_without_rms() -> None:
+def test_draw_lidar_wall_estimate_reports_measurement_point_residual_metrics_without_rms() -> None:
     class FakeCanvas:
         def create_line(self, *_coords: float, **_kwargs: object) -> int:
             return 1
@@ -767,7 +767,7 @@ def test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation_withou
     window._draw_lidar_wall_estimate(estimate)
 
     assert messages
-    assert "σ sichtbare rote Punkte=100.0cm (2 Punkte)" in messages[0]
+    assert "σ Messpunkte=100.0cm, mittl. |Abweichung| Messpunkte=100.0cm (2 Punkte)" in messages[0]
     assert "RMS" not in messages[0]
 
 

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3756,12 +3756,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         return world_points
 
     @staticmethod
-    def _line_residual_std_m(
+    def _line_residual_metrics_m(
         points: list[tuple[float, float]],
         *,
         slope: float,
         intercept: float,
-    ) -> float | None:
+    ) -> tuple[float, float] | None:
         finite_points = [
             (float(x), float(y))
             for x, y in points
@@ -3775,7 +3775,10 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         finite_residuals = residuals[np.isfinite(residuals)]
         if finite_residuals.size == 0:
             return None
-        return float(np.std(finite_residuals))
+        return (
+            float(np.std(finite_residuals)),
+            float(np.mean(np.abs(finite_residuals))),
+        )
 
     def _draw_lidar_wall_estimate(self, estimate: LidarWallEstimate) -> None:
         original = self._map_image_original
@@ -3808,15 +3811,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             width=LIDAR_WALL_LINE_WIDTH_PX,
         )
         red_points = getattr(self, "_last_visible_red_echo_probability_world_points", [])
-        red_points_std_m = self._line_residual_std_m(
+        red_points_metrics_m = self._line_residual_metrics_m(
             red_points,
             slope=estimate.slope,
             intercept=estimate.intercept,
         )
         red_points_summary = ""
-        if red_points_std_m is not None:
+        if red_points_metrics_m is not None:
+            red_points_std_m, red_points_mean_m = red_points_metrics_m
             red_points_summary = (
-                f", σ sichtbare rote Punkte={red_points_std_m * 100.0:.1f}cm "
+                f", σ Messpunkte={red_points_std_m * 100.0:.1f}cm, "
+                f"mittl. |Abweichung| Messpunkte={red_points_mean_m * 100.0:.1f}cm "
                 f"({len(red_points)} Punkte)"
             )
         self._append_validation(


### PR DESCRIPTION
### Motivation
- Replace the previous "sichtbare rote Punkte" label with a clearer `Messpunkte` label and report the mean absolute deviation for those measurement points in the LiDAR wall validation summary, matching the level of detail provided for the LiDAR fit itself.

### Description
- Replaced the old helper that returned only standard deviation with a new helper `def _line_residual_metrics_m(...) -> tuple[float, float] | None` that returns `(std_m, mean_abs_m)`.
- Updated `_draw_lidar_wall_estimate` to call `self._line_residual_metrics_m(...)` and to append a summary formatted as `σ Messpunkte=..., mittl. |Abweichung| Messpunkte=... (N Punkte)`.
- Updated the unit test by renaming `test_draw_lidar_wall_estimate_reports_visible_red_point_std_deviation_without_rms` to `test_draw_lidar_wall_estimate_reports_measurement_point_residual_metrics_without_rms` and adjusted the assertion to expect the new output string.

### Testing
- Running `pytest tests/test_mission_workflow_ui.py -q` without `PYTHONPATH` failed during import due to the test runner environment not finding the `transceiver` package.
- Running `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` succeeded and reported `117 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d92d3d2e08321a6f3b3ab98b2887d)