### PR TITLE
Rename LiDAR wall validation labels

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -790,7 +790,9 @@ def test_draw_lidar_wall_estimate_reports_measurement_point_residual_metrics_wit
     window._draw_lidar_wall_estimate(estimate)
 
     assert messages
-    assert "σ Messpunkte=100.0cm, mittl. |Abweichung| Messpunkte=100.0cm (2 Punkte)" in messages[0]
+    assert messages[0].startswith("ℹ️ Messwand: ")
+    assert "σ LiDAR Messpunkte=2.0cm, mittl. |Abweichung| LiDAR Messpunkte=1.0cm" in messages[0]
+    assert "σ Radarmesspunkte=100.0cm, mittl. |Abweichung| Radarmesspunkte=100.0cm (2 Punkte)" in messages[0]
     assert "RMS" not in messages[0]
 
 

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -4020,16 +4020,16 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         if red_points_metrics_m is not None:
             red_points_std_m, red_points_mean_m = red_points_metrics_m
             red_points_summary = (
-                f", σ Messpunkte={red_points_std_m * 100.0:.1f}cm, "
-                f"mittl. |Abweichung| Messpunkte={red_points_mean_m * 100.0:.1f}cm "
+                f", σ Radarmesspunkte={red_points_std_m * 100.0:.1f}cm, "
+                f"mittl. |Abweichung| Radarmesspunkte={red_points_mean_m * 100.0:.1f}cm "
                 f"({len(red_points)} Punkte)"
             )
         self._append_validation(
-            "ℹ️ LiDAR-Wand: "
+            "ℹ️ Messwand: "
             f"{estimate.point_count} Punkte, "
             f"y={estimate.slope:.4f}x+{estimate.intercept:.3f}, "
-            f"σ={estimate.residual_std_m * 100.0:.1f}cm, "
-            f"mittl. |Abweichung|={estimate.residual_mean_m * 100.0:.1f}cm"
+            f"σ LiDAR Messpunkte={estimate.residual_std_m * 100.0:.1f}cm, "
+            f"mittl. |Abweichung| LiDAR Messpunkte={estimate.residual_mean_m * 100.0:.1f}cm"
             f"{red_points_summary}"
         )
 


### PR DESCRIPTION
### Motivation
- Improve clarity of the LiDAR wall validation message by renaming the heading and disambiguating which residual metrics refer to LiDAR measurement points and which refer to radar/red measurement points.

### Description
- Change the validation heading from `ℹ️ LiDAR-Wand:` to `ℹ️ Messwand:` in `_draw_lidar_wall_estimate`.
- Label the estimate residuals as `σ LiDAR Messpunkte` and `mittl. |Abweichung| LiDAR Messpunkte` and rename the per-point summary labels to `σ Radarmesspunkte` and `mittl. |Abweichung| Radarmesspunkte`.
- Update `tests/test_mission_workflow_ui.py::test_draw_lidar_wall_estimate_reports_measurement_point_residual_metrics_without_rms` to assert the new `Messwand`, `LiDAR Messpunkte`, and `Radarmesspunkte` wording.

### Testing
- Running `pytest -q tests/test_mission_workflow_ui.py::test_draw_lidar_wall_estimate_reports_measurement_point_residual_metrics_without_rms` without `PYTHONPATH` initially failed with `ModuleNotFoundError` due to the import path.
- Running `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py::test_draw_lidar_wall_estimate_reports_measurement_point_residual_metrics_without_rms` succeeded with `1 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d9726273083219d51acf330fe31dc)