### PR TITLE
Improve mission wall residual summary

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -70,8 +70,6 @@ def test_estimate_lidar_reference_wall_uses_measurement_area() -> None:
     assert estimate.intercept == pytest.approx(3.0, abs=0.03)
 
 
-
-
 def test_estimate_lidar_reference_wall_uses_polygon_measurement_area() -> None:
     inside_wall = [(x / 10.0, 2.0 + (0.01 if x % 2 else -0.01)) for x in range(0, 31)]
     outside_same_bbox = [(0.2, 0.2), (1.0, 0.4), (1.5, 0.7), (2.0, 0.6), (2.8, 0.2)]
@@ -360,8 +358,6 @@ def test_draw_selected_echo_overlay_renders_all_selected_results() -> None:
 
     assert len(calls) == 2
     assert {call["measurement_position"] for call in calls} == {(7.0, -2.0), (8.0, -1.0)}
-
-
 
 
 def test_draw_selected_echo_overlay_draws_evaluation_points_above_ellipses() -> None:
@@ -761,8 +757,7 @@ def test_draw_selected_measurement_position_markers_ignore_lidar_points_toggle()
     assert kwargs["fill"] == "#212121"
 
 
-
-def test_draw_lidar_wall_estimate_reports_measurement_point_residual_metrics_without_rms() -> None:
+def test_draw_lidar_wall_estimate_reports_readable_reference_and_radar_residual_metrics() -> None:
     class FakeCanvas:
         def create_line(self, *_coords: float, **_kwargs: object) -> int:
             return 1
@@ -789,11 +784,19 @@ def test_draw_lidar_wall_estimate_reports_measurement_point_residual_metrics_wit
 
     window._draw_lidar_wall_estimate(estimate)
 
-    assert messages
-    assert messages[0].startswith("ℹ️ Messwand: ")
-    assert "σ LiDAR Messpunkte=2.0cm, mittl. |Abweichung| LiDAR Messpunkte=1.0cm" in messages[0]
-    assert "σ Radarmesspunkte=100.0cm, mittl. |Abweichung| Radarmesspunkte=100.0cm (2 Punkte)" in messages[0]
-    assert "RMS" not in messages[0]
+    assert messages == [
+        "ℹ️ Messwand, LiDAR-Referenzmessung:\n"
+        "  Punkte: 8\n"
+        "  Linie: y = 0.0000x + 0.000\n"
+        "  σ: 2.0 cm\n"
+        "  mittl. |Abweichung| Referenz: 1.0 cm\n\n"
+        "Radar-Messpunkte zur LiDAR-Linie:\n"
+        "  Punkte: 2\n"
+        "  mittl. signed Abweichung: 0.0 cm\n"
+        "  mittl. |Abweichung|: 100.0 cm\n"
+        "  RMS: 100.0 cm\n"
+        "  σ: 100.0 cm"
+    ]
 
 
 def test_draw_selected_echo_probability_overlay_tracks_visible_red_world_points() -> None:
@@ -1662,7 +1665,6 @@ def test_build_waypoint_arrow_polygon_points_up_for_ninety_degree_yaw() -> None:
     assert round(right_y, 3) == 54.0
 
 
-
 def test_build_echo_overlay_preview_points_clips_to_antenna_opening() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._mission = SimpleNamespace(
@@ -2313,8 +2315,6 @@ def test_open_review_for_result_row_derives_echo_delays_from_echo_lags() -> None
 
     result = window._records[0]["measurement"]["result"]
     assert result["echo_delays"] == [{"echo_index": 0, "delta_lag": 15.0, "distance_m": 22.5}]
-
-
 
 
 def test_open_review_for_result_row_scales_rereview_echo_delays_with_interpolation() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -83,7 +83,6 @@ MULTI_SELECTION_PROBABILITY_DEBUG_LOG = True
 RESULTS_TABLE_EMPTY_ROW_IID = "__results_table_empty_row__"
 
 
-
 def _load_json_dict(path: Path) -> dict[str, Any]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -183,6 +182,17 @@ class LidarMeasurementArea:
         if not vertices:
             return True
         return _is_point_in_polygon(point, vertices)
+
+
+@dataclass(frozen=True)
+class LineResidualMetrics:
+    """Residual metrics for points relative to a line in map/world coordinates."""
+
+    point_count: int
+    residual_signed_mean_m: float
+    residual_abs_mean_m: float
+    residual_std_m: float
+    residual_rms_m: float
 
 
 @dataclass(frozen=True)
@@ -3961,7 +3971,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         *,
         slope: float,
         intercept: float,
-    ) -> tuple[float, float] | None:
+    ) -> LineResidualMetrics | None:
         finite_points = [
             (float(x), float(y))
             for x, y in points
@@ -3975,9 +3985,12 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         finite_residuals = residuals[np.isfinite(residuals)]
         if finite_residuals.size == 0:
             return None
-        return (
-            float(np.std(finite_residuals)),
-            float(np.mean(np.abs(finite_residuals))),
+        return LineResidualMetrics(
+            point_count=int(finite_residuals.size),
+            residual_signed_mean_m=float(np.mean(finite_residuals)),
+            residual_abs_mean_m=float(np.mean(np.abs(finite_residuals))),
+            residual_std_m=float(np.std(finite_residuals)),
+            residual_rms_m=float(math.sqrt(np.mean(finite_residuals * finite_residuals))),
         )
 
     def _draw_lidar_wall_estimate(self, estimate: LidarWallEstimate) -> None:
@@ -4018,18 +4031,21 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         )
         red_points_summary = ""
         if red_points_metrics_m is not None:
-            red_points_std_m, red_points_mean_m = red_points_metrics_m
             red_points_summary = (
-                f", σ Radarmesspunkte={red_points_std_m * 100.0:.1f}cm, "
-                f"mittl. |Abweichung| Radarmesspunkte={red_points_mean_m * 100.0:.1f}cm "
-                f"({len(red_points)} Punkte)"
+                "\n\nRadar-Messpunkte zur LiDAR-Linie:\n"
+                f"  Punkte: {red_points_metrics_m.point_count}\n"
+                f"  mittl. signed Abweichung: {red_points_metrics_m.residual_signed_mean_m * 100.0:.1f} cm\n"
+                f"  mittl. |Abweichung|: {red_points_metrics_m.residual_abs_mean_m * 100.0:.1f} cm\n"
+                f"  RMS: {red_points_metrics_m.residual_rms_m * 100.0:.1f} cm\n"
+                f"  σ: {red_points_metrics_m.residual_std_m * 100.0:.1f} cm"
             )
+        intercept_sign = "+" if estimate.intercept >= 0.0 else "-"
         self._append_validation(
-            "ℹ️ Messwand: "
-            f"{estimate.point_count} Punkte, "
-            f"y={estimate.slope:.4f}x+{estimate.intercept:.3f}, "
-            f"σ LiDAR Messpunkte={estimate.residual_std_m * 100.0:.1f}cm, "
-            f"mittl. |Abweichung| LiDAR Messpunkte={estimate.residual_mean_m * 100.0:.1f}cm"
+            "ℹ️ Messwand, LiDAR-Referenzmessung:\n"
+            f"  Punkte: {estimate.point_count}\n"
+            f"  Linie: y = {estimate.slope:.4f}x {intercept_sign} {abs(estimate.intercept):.3f}\n"
+            f"  σ: {estimate.residual_std_m * 100.0:.1f} cm\n"
+            f"  mittl. |Abweichung| Referenz: {estimate.residual_mean_m * 100.0:.1f} cm"
             f"{red_points_summary}"
         )
 


### PR DESCRIPTION
### Motivation
- Make the mission workflow evaluation output more human-readable and include additional radar residual metrics (signed mean and RMS) for easier comparison with the LiDAR reference.

### Description
- Add `LineResidualMetrics` dataclass to hold point count, signed mean, mean absolute deviation, sigma, and RMS for residuals.
- Change `_line_residual_metrics_m` to return `LineResidualMetrics` and compute `residual_signed_mean_m`, `residual_abs_mean_m`, `residual_std_m`, `residual_rms_m`, and `point_count`.
- Reformat `_draw_lidar_wall_estimate` to emit a multi-line, readable block: first the "Messwand, LiDAR-Referenzmessung" summary and then an optional "Radar-Messpunkte zur LiDAR-Linie" block that includes signed mean and RMS alongside existing metrics; handle intercept sign for nicer formatting.
- Update `tests/test_mission_workflow_ui.py` to assert the new, more readable message format and the additional radar metrics.

### Testing
- Ran `python -m py_compile transceiver/mission_workflow_ui.py tests/test_mission_workflow_ui.py` which succeeded.
- Ran `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` which passed for the updated test file.
- Ran the repository tests with `PYTHONPATH=. pytest -q` and observed the full test run succeed (`119 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d9828cf608321a3cb46abb192fdb2)