### PR TITLE
Rename mission map overlay label to "Radarmesspunkte"

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -699,7 +699,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         }
         tk.Checkbutton(
             frame,
-            text="Auswertung",
+            text="Radarmesspunkte",
             variable=self.echo_heatmap_evaluation_visible_var,
             command=self._on_echo_heatmap_settings_changed,
             **checkbutton_kwargs,


### PR DESCRIPTION
### Motivation
- Clarify the mission workflow map overlay checkbox by renaming the label from `Auswertung` to `Radarmesspunkte` for more accurate German wording.

### Description
- Change the overlay checkbox label in `transceiver/mission_workflow_ui.py` inside `_build_echo_heatmap_settings_overlay` from `text="Auswertung"` to `text="Radarmesspunkte"`.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py` and all tests passed (`119 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d9f87c7cc8321831be3e52fb57141)