### PR TITLE
Respect ellipse overlay visibility for single results

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -318,6 +318,7 @@ def test_draw_selected_echo_overlay_uses_live_measurement_position() -> None:
         }
     ]
     window._rx_antenna_global_position = (1.0, 1.0)
+    window.echo_heatmap_ellipses_visible_var = SimpleNamespace(get=lambda: True)
     window._mission_points = [MeasurementPoint(id="p0", name="P0", x=50.0, y=50.0, yaw=0.0)]
     calls: list[dict[str, object]] = []
     window._draw_echo_ellipse_for_overlay = lambda **kwargs: calls.append(kwargs)
@@ -326,6 +327,27 @@ def test_draw_selected_echo_overlay_uses_live_measurement_position() -> None:
 
     assert len(calls) == 1
     assert calls[0]["measurement_position"] == (7.0, -2.0)
+
+
+def test_draw_selected_echo_overlay_hides_single_selection_ellipse_when_disabled() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._selected_result_index = 0
+    window._records = [
+        {
+            "point_index": 0,
+            "live_position_at_measurement": {"x": 7.0, "y": -2.0},
+            "measurement": {"result": {"echo_delays": [{"distance_m": 3.0}]}},
+        }
+    ]
+    window._rx_antenna_global_position = (1.0, 1.0)
+    window.echo_heatmap_ellipses_visible_var = SimpleNamespace(get=lambda: False)
+    calls: list[dict[str, object]] = []
+    window._draw_echo_ellipse_for_overlay = lambda **kwargs: calls.append(kwargs)
+
+    overlay_visible = window._draw_selected_echo_overlay()
+
+    assert overlay_visible is False
+    assert calls == []
 
 
 def test_draw_selected_echo_overlay_renders_all_selected_results() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3233,7 +3233,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             return False
         selected_records = self._selected_record_payloads()
         multiple_records_selected = len(selected_records) > 1
-        ellipses_visible = not multiple_records_selected or self._echo_heatmap_ellipses_visible()
+        ellipses_visible = self._echo_heatmap_ellipses_visible()
         if ellipses_visible:
             for record in selected_records:
                 measurement_position = self._selected_record_measurement_position(record)


### PR DESCRIPTION
### Motivation
- Die Ellipsen-Overlay-Option sollte auch dann wirksam sein, wenn nur ein einzelner Ergebnis-Eintrag aktiv ist, damit deaktivierte Ellipsen nicht fälschlich angezeigt werden.

### Description
- In `transceiver/mission_workflow_ui.py` wird in `_draw_selected_echo_overlay` nun `ellipses_visible = self._echo_heatmap_ellipses_visible()` statt der bisherigen Logik verwendet, die bei Einzel-Auswahl Ellipsen immer erlaubt hat.
- In `tests/test_mission_workflow_ui.py` wurde ein vorhandener Test angepasst, damit Ellipsen explizit eingeschaltet sind, und ein neuer Test `test_draw_selected_echo_overlay_hides_single_selection_ellipse_when_disabled` hinzugefügt, der prüft, dass bei deaktiviertem Toggle keine Ellipse für eine einzelne Auswahl gezeichnet wird.
- Änderungen beschränken sich auf die Overlay-Rendering-Entscheidung und die zugehörigen Tests ohne weitere Verhaltensänderungen.

### Testing
- `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -q` wurde ausgeführt und die betroffenen Tests sind erfolgreich durchgelaufen.
- `PYTHONPATH=. pytest -q` (voller Testlauf) schlägt aufgrund bereits vorhandener, nicht mit dieser Änderung zusammenhängender Collection-Fehler in anderen Tests fehl, daher wurde hier nur die fokussierte Testdatei validiert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1da35e5c608321a971cc7821b5e97a)