### PR TITLE
Rename residual RMS metric to RMSE

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -801,7 +801,7 @@ def test_draw_lidar_wall_estimate_reports_readable_reference_and_radar_residual_
         point_count=8,
         residual_mean_m=0.01,
         residual_std_m=0.02,
-        residual_rms_m=0.03,
+        residual_rmse_m=0.03,
     )
 
     window._draw_lidar_wall_estimate(estimate)
@@ -816,7 +816,7 @@ def test_draw_lidar_wall_estimate_reports_readable_reference_and_radar_residual_
         "  Punkte: 2\n"
         "  mittl. signed Abweichung: 0.0 cm\n"
         "  mittl. |Abweichung|: 100.0 cm\n"
-        "  RMS: 100.0 cm\n"
+        "  RMSE: 100.0 cm\n"
         "  σ: 100.0 cm"
     ]
 

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -192,7 +192,7 @@ class LineResidualMetrics:
     residual_signed_mean_m: float
     residual_abs_mean_m: float
     residual_std_m: float
-    residual_rms_m: float
+    residual_rmse_m: float
 
 
 @dataclass(frozen=True)
@@ -206,7 +206,7 @@ class LidarWallEstimate:
     point_count: int
     residual_mean_m: float
     residual_std_m: float
-    residual_rms_m: float
+    residual_rmse_m: float
 
 
 def _is_point_on_segment(
@@ -332,7 +332,7 @@ def _estimate_lidar_reference_wall(
         point_count=len(finite_points),
         residual_mean_m=float(np.mean(abs_residuals)),
         residual_std_m=float(np.std(finite_residuals)),
-        residual_rms_m=float(math.sqrt(np.mean(finite_residuals * finite_residuals))),
+        residual_rmse_m=float(math.sqrt(np.mean(finite_residuals * finite_residuals))),
     )
 
 
@@ -3990,7 +3990,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             residual_signed_mean_m=float(np.mean(finite_residuals)),
             residual_abs_mean_m=float(np.mean(np.abs(finite_residuals))),
             residual_std_m=float(np.std(finite_residuals)),
-            residual_rms_m=float(math.sqrt(np.mean(finite_residuals * finite_residuals))),
+            residual_rmse_m=float(math.sqrt(np.mean(finite_residuals * finite_residuals))),
         )
 
     def _draw_lidar_wall_estimate(self, estimate: LidarWallEstimate) -> None:
@@ -4036,7 +4036,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                 f"  Punkte: {red_points_metrics_m.point_count}\n"
                 f"  mittl. signed Abweichung: {red_points_metrics_m.residual_signed_mean_m * 100.0:.1f} cm\n"
                 f"  mittl. |Abweichung|: {red_points_metrics_m.residual_abs_mean_m * 100.0:.1f} cm\n"
-                f"  RMS: {red_points_metrics_m.residual_rms_m * 100.0:.1f} cm\n"
+                f"  RMSE: {red_points_metrics_m.residual_rmse_m * 100.0:.1f} cm\n"
                 f"  σ: {red_points_metrics_m.residual_std_m * 100.0:.1f} cm"
             )
         intercept_sign = "+" if estimate.intercept >= 0.0 else "-"


### PR DESCRIPTION
### Motivation
- Clarify the metric name by renaming the ambiguous `RMS` field to `RMSE` to indicate the root-mean-square error.

### Description
- Rename dataclass fields `residual_rms_m` to `residual_rmse_m` in `LineResidualMetrics` and `LidarWallEstimate`.
- Update computations to assign the RMSE value (`sqrt(mean(residuals**2))`) to `residual_rmse_m` where the RMS was previously computed.
- Change the LiDAR validation output label from `RMS` to `RMSE` in the UI message generation.
- Adjust the unit test `tests/test_mission_workflow_ui.py` to use `residual_rmse_m` and expect `RMSE` in the validation string.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` and it succeeded (`120 passed`).
- Ran `PYTHONPATH=. pytest -q` which failed during collection due to unrelated issues (`ImportError: cannot import name '_suppress_nearby_candidates'` and `TypeError: __mro_entries__ must return a tuple`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1db81cf4a083218bdf7332ca0eeb7c)