### PR TITLE
Make Messwand overlay label dark blue

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -2088,6 +2088,44 @@ def test_lidar_measurement_area_button_uses_checkmark_when_active() -> None:
     assert configured == ["✓"]
 
 
+def test_draw_lidar_measurement_area_overlay_uses_dark_blue_label() -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    text_calls: list[dict[str, object]] = []
+
+    class CanvasStub:
+        def create_polygon(self, *args, **kwargs):
+            return None
+
+        def create_text(self, *args, **kwargs):
+            text_calls.append(kwargs)
+            return None
+
+    window._lidar_measurement_area_edit_enabled = True
+    window._map_image_original = SimpleNamespace(height=lambda: 100)
+    window._map_preview_scale = (1.0, 1.0)
+    window._map_preview_offset = (0.0, 0.0)
+    window._lidar_measurement_area_draft_vertices = []
+    window._lidar_measurement_area = LidarMeasurementArea(
+        min_x=0.0,
+        min_y=0.0,
+        max_x=4.0,
+        max_y=3.0,
+    )
+    window._world_to_map_pixel = lambda *, x, y, image_height: (x, y)
+    window.map_preview_canvas = CanvasStub()
+
+    window._draw_lidar_measurement_area_overlay()
+
+    assert text_calls == [
+        {
+            "text": "Messwand",
+            "anchor": "nw",
+            "fill": "#0D47A1",
+            "font": ("TkDefaultFont", 10, "bold"),
+        }
+    ]
+
+
 def test_lidar_measurement_area_right_click_clears_area_and_draft() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window._lidar_measurement_area_edit_enabled = True

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -64,6 +64,7 @@ LIDAR_OVERLAY_SCANNER_YAW_OFFSET_RAD = math.pi / 2.0
 LIDAR_WALL_MIN_POINTS = 8
 LIDAR_WALL_LINE_COLOR = "#1E88E5"
 LIDAR_WALL_LINE_WIDTH_PX = 3
+LIDAR_MEASUREMENT_AREA_LABEL_COLOR = "#0D47A1"
 MEASUREMENT_START_LIVE_POSITION_WAIT_TIMEOUT_S = 1.6
 MEASUREMENT_START_LIVE_POSITION_WAIT_INTERVAL_S = 0.1
 LIVE_ECHO_CACHE_POSITION_DELTA_M = 0.015
@@ -1956,7 +1957,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             top + 6,
             text="Messwand",
             anchor="nw",
-            fill="#e3f2fd",
+            fill=LIDAR_MEASUREMENT_AREA_LABEL_COLOR,
             font=("TkDefaultFont", 10, "bold"),
         )
 


### PR DESCRIPTION
### Motivation
- Ensure the "Messwand" label drawn on the map overlay uses a dedicated dark-blue color for better contrast and consistency.

### Description
- Add a new color constant `LIDAR_MEASUREMENT_AREA_LABEL_COLOR = "#0D47A1"` to `transceiver/mission_workflow_ui.py`.
- Use `LIDAR_MEASUREMENT_AREA_LABEL_COLOR` for the `fill` argument when drawing the overlay text `"Messwand"` in `_draw_lidar_measurement_area_overlay`.
- Add a regression test `test_draw_lidar_measurement_area_overlay_uses_dark_blue_label` to `tests/test_mission_workflow_ui.py` that stubs the canvas and asserts the label is drawn with `"#0D47A1"`.

### Testing
- Running `pytest tests/test_mission_workflow_ui.py -q` without `PYTHONPATH` initially failed due to `ModuleNotFoundError` for the local package. 
- Running `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` succeeded and reported `121 passed in 1.89s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1dc13f73808321958dffdb4344e905)