### PR TITLE
Prompt to enable live position before mission run

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1000,6 +1000,17 @@ class _StringVarStub:
         self.value = value
 
 
+class _BooleanVarStub:
+    def __init__(self, value: bool = False) -> None:
+        self.value = value
+
+    def get(self) -> bool:
+        return self.value
+
+    def set(self, value: bool) -> None:
+        self.value = bool(value)
+
+
 def test_results_table_allows_extended_multiselect_mode() -> None:
     window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
     window.results_table = SimpleNamespace(cget=lambda key: "extended" if key == "selectmode" else None)
@@ -2548,6 +2559,70 @@ def test_check_run_prerequisites_skips_review_requirements_when_manual_review_di
 
     assert ok is True
     assert reasons == []
+
+
+def test_prompt_enable_live_position_before_run_activates_when_confirmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.live_pose_stream_enabled_var = _BooleanVarStub(False)
+    window.master = SimpleNamespace()
+    messages: list[str] = []
+    calls: list[str] = []
+    window._append_validation = messages.append
+    window._on_live_pose_stream_switch_changed = lambda: calls.append("switch")
+
+    ask_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "transceiver.mission_workflow_ui.messagebox.askyesno",
+        lambda title, message, parent=None: ask_calls.append((title, message)) or True,
+    )
+
+    assert window._prompt_enable_live_position_before_run() is True
+
+    assert window.live_pose_stream_enabled_var.get() is True
+    assert calls == ["switch"]
+    assert len(ask_calls) == 1
+    assert "Live-Position" in ask_calls[0][0]
+    assert any("aktiviert" in message for message in messages)
+
+
+def test_prompt_enable_live_position_before_run_continues_when_declined(monkeypatch: pytest.MonkeyPatch) -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.live_pose_stream_enabled_var = _BooleanVarStub(False)
+    window.master = SimpleNamespace()
+    messages: list[str] = []
+    calls: list[str] = []
+    window._append_validation = messages.append
+    window._on_live_pose_stream_switch_changed = lambda: calls.append("switch")
+
+    monkeypatch.setattr(
+        "transceiver.mission_workflow_ui.messagebox.askyesno",
+        lambda *_args, **_kwargs: False,
+    )
+
+    assert window._prompt_enable_live_position_before_run() is True
+
+    assert window.live_pose_stream_enabled_var.get() is False
+    assert calls == []
+    assert any("ohne aktive Live-Position" in message for message in messages)
+
+
+def test_prompt_enable_live_position_before_run_skips_prompt_when_already_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window.live_pose_stream_enabled_var = _BooleanVarStub(True)
+    calls: list[str] = []
+    window._on_live_pose_stream_switch_changed = lambda: calls.append("switch")
+
+    monkeypatch.setattr(
+        "transceiver.mission_workflow_ui.messagebox.askyesno",
+        lambda *_args, **_kwargs: pytest.fail("prompt should not be shown"),
+    )
+
+    assert window._prompt_enable_live_position_before_run() is True
+
+    assert window.live_pose_stream_enabled_var.get() is True
+    assert calls == []
 
 
 def test_on_live_pose_stream_switch_changed_persists_and_syncs() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -4969,6 +4969,8 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         test_run_enabled = self._is_test_run_enabled()
         if not test_run_enabled and not self._ensure_transmitter_before_run():
             return
+        if not self._prompt_enable_live_position_before_run():
+            return
         if test_run_enabled:
             self._append_validation("ℹ️ Testlauf aktiv: Wegpunkte werden ohne Messung angefahren.")
         start_point_index = self._selected_start_point_index()
@@ -5188,6 +5190,27 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             self._append_validation(f"❌ Run-Start blockiert: TX-Aktivierung fehlgeschlagen ({detail}).")
             return False
         self._append_validation("✅ Transmitter aktiv ('TX (Replay): playback started.'). Mission startet.")
+        return True
+
+    def _prompt_enable_live_position_before_run(self) -> bool:
+        if bool(self.live_pose_stream_enabled_var.get()):
+            return True
+
+        should_enable = messagebox.askyesno(
+            "Live-Position inaktiv",
+            "Die Live-Position ist aktuell nicht aktiv.\n\n"
+            "Soll die Live-Position vor dem Run-Start aktiviert werden?\n\n"
+            "Ja: Live-Position aktivieren und Run starten.\n"
+            "Nein: Run ohne aktive Live-Position starten.",
+            parent=self,
+        )
+        if not should_enable:
+            self._append_validation("⚠️ Mission startet ohne aktive Live-Position (Operator-Entscheidung).")
+            return True
+
+        self.live_pose_stream_enabled_var.set(True)
+        self._append_validation("ℹ️ Live-Position wird vor dem Run-Start aktiviert.")
+        self._on_live_pose_stream_switch_changed()
         return True
 
     def _start_live_label_ticker(self) -> None:


### PR DESCRIPTION
### Motivation
- Ensure the operator is informed when starting a mission run while the Live-Position stream is disabled and give an option to enable it before the run so live-map features and position checks are available.
- Provide an unobtrusive default to continue the run without live position if the operator explicitly declines.
- Add unit tests covering confirm, decline and no-prompt (already enabled) paths.

### Description
- Added a new helper method `MissionWorkflowWindow._prompt_enable_live_position_before_run` which asks the operator via `messagebox.askyesno` whether to enable the live pose stream when it is currently disabled, sets `live_pose_stream_enabled_var` and triggers the existing switch handler on confirmation, and appends an operator message on decline.
- Integrated the prompt into the run start sequence by calling `_prompt_enable_live_position_before_run()` in `_start_run` before starting the executor.
- Added `_BooleanVarStub` test helper and three unit tests in `tests/test_mission_workflow_ui.py` to validate the confirmed activation, declined continuation, and skip-when-already-enabled behaviors.
- Changes made to `transceiver/mission_workflow_ui.py` and `tests/test_mission_workflow_ui.py`.

### Testing
- Ran `PYTHONPATH=. pytest tests/test_mission_workflow_ui.py -q` which executed the test file and reported `124 passed` (success).
- Verified `transceiver/mission_workflow_ui.py` compiles with `python -m py_compile` (success).
- Ran project diff/checks to ensure no style/check errors (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1ec23fd5408321b686c9d431c8a053)