### PR TITLE
Replace echo heading emojis with color legend

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from transceiver import mission_workflow_ui
 from transceiver.measurement_mission import MeasurementMission, MeasurementPoint
 from transceiver.navigation_adapter import NavigationPoint
 from transceiver.mission_workflow_ui import (
+    ECHO_HEADING_LABELS,
+    ECHO_OVERLAY_COLORS,
     RESULTS_TABLE_EMPTY_ROW_IID,
     LidarMeasurementArea,
     LidarWallEstimate,
@@ -104,6 +108,22 @@ def test_estimate_lidar_reference_wall_rejects_too_few_points() -> None:
     estimate = _estimate_lidar_reference_wall([(0.0, 1.0), (1.0, 1.0)])
 
     assert estimate is None
+
+
+def test_results_table_echo_headings_use_plain_labels_and_overlay_color_legend() -> None:
+    assert ECHO_HEADING_LABELS == ("E1", "E2", "E3", "E4", "E5")
+    assert len(ECHO_HEADING_LABELS) == len(ECHO_OVERLAY_COLORS)
+    assert all(label.isascii() for label in ECHO_HEADING_LABELS)
+
+    source = Path(mission_workflow_ui.__file__).read_text(encoding="utf-8")
+
+    assert "ECHO_HEADING_MARKERS" not in source
+    for echo_index, label_index in enumerate(range(len(ECHO_HEADING_LABELS)), start=1):
+        assert f'"echo_{echo_index}_m": ECHO_HEADING_LABELS[{label_index}]' in source
+    assert "zip(ECHO_HEADING_LABELS, ECHO_OVERLAY_COLORS)" in source
+    assert "text_color=color" in source
+    emoji_markers = ("\U0001F7E2", "\U0001F7E0", "\U0001F7E3", "\U0001F535", "\U0001F7E4")
+    assert not any(marker in source for marker in emoji_markers)
 
 
 def test_format_echo_distances_for_table_returns_only_meter_values_for_first_five_echoes() -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -53,7 +53,7 @@ LIVE_PREVIEW_FALLBACK_REDRAW_AFTER_S = 1.0
 AUTO_STOP_CONTINUOUS_BEFORE_RUN = True
 ECHO_OVERLAY_COLORS = ("#00796B", "#FFB300", "#8E24AA", "#00ACC1", "#F4511E")
 ECHO_OVERLAY_LINE_WIDTH_PX = 1
-ECHO_HEADING_MARKERS = ("🟢", "🟠", "🟣", "🔵", "🟤")
+ECHO_HEADING_LABELS = ("E1", "E2", "E3", "E4", "E5")
 LIDAR_OVERLAY_MAX_DRAWN_BEAMS = 450
 LIDAR_OVERLAY_CELL_SIZE_PX = 3.0
 LIDAR_OVERLAY_MAX_BEAMS_PER_CELL = 2
@@ -1168,7 +1168,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         table_frame = ctk.CTkFrame(self)
         table_frame.grid(row=5, column=0, sticky="nsew", padx=10, pady=(0, 10))
         table_frame.columnconfigure(0, weight=1)
-        table_frame.rowconfigure(0, weight=1)
+        table_frame.rowconfigure(1, weight=1)
 
         columns = (
             "measurement_idx",
@@ -1182,6 +1182,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "echo_5_m",
             "status",
         )
+        self._build_echo_results_legend(table_frame)
         self.results_table = ttk.Treeview(
             table_frame,
             columns=columns,
@@ -1189,17 +1190,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             height=14,
             selectmode="extended",
         )
-        self.results_table.grid(row=0, column=0, sticky="nsew")
+        self.results_table.grid(row=1, column=0, sticky="nsew")
         headings = {
             "measurement_idx": "Messung",
             "idx": "Punktindex",
             "live_position": "Position",
             "live_distance_to_rx_m": "Abstand",
-            "echo_1_m": f"{ECHO_HEADING_MARKERS[0]} E1",
-            "echo_2_m": f"{ECHO_HEADING_MARKERS[1]} E2",
-            "echo_3_m": f"{ECHO_HEADING_MARKERS[2]} E3",
-            "echo_4_m": f"{ECHO_HEADING_MARKERS[3]} E4",
-            "echo_5_m": f"{ECHO_HEADING_MARKERS[4]} E5",
+            "echo_1_m": ECHO_HEADING_LABELS[0],
+            "echo_2_m": ECHO_HEADING_LABELS[1],
+            "echo_3_m": ECHO_HEADING_LABELS[2],
+            "echo_4_m": ECHO_HEADING_LABELS[3],
+            "echo_5_m": ECHO_HEADING_LABELS[4],
             "status": "Status",
         }
         for key, title in headings.items():
@@ -1216,7 +1217,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.results_table.column("status", width=320)
 
         scroll = ttk.Scrollbar(table_frame, orient="vertical", command=self.results_table.yview)
-        scroll.grid(row=0, column=1, sticky="ns")
+        scroll.grid(row=1, column=1, sticky="ns")
         self.results_table.configure(yscrollcommand=scroll.set)
         self._ensure_results_table_empty_row()
         self.results_table.bind("<<TreeviewSelect>>", self._on_results_table_select)
@@ -1254,7 +1255,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         )
         self.results_selection_diagnostics_var = tk.StringVar(value="Auswahl: 0 Zeilen")
         results_footer = ctk.CTkFrame(table_frame, fg_color="transparent")
-        results_footer.grid(row=1, column=0, sticky="ew", pady=(4, 0))
+        results_footer.grid(row=2, column=0, sticky="ew", pady=(4, 0))
         results_footer.columnconfigure(0, weight=1)
         ctk.CTkLabel(
             results_footer,
@@ -1275,6 +1276,22 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self._refresh_start_point_options()
         self._refresh_map_section()
         self._refresh_review_ready_indicator()
+
+    def _build_echo_results_legend(self, parent: tk.Widget) -> None:
+        legend = ctk.CTkFrame(parent, fg_color="transparent")
+        legend.grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 4))
+        ctk.CTkLabel(legend, text="Echo-Farben:", anchor="w").grid(row=0, column=0, padx=(0, 8), sticky="w")
+        for echo_index, (label, color) in enumerate(zip(ECHO_HEADING_LABELS, ECHO_OVERLAY_COLORS), start=1):
+            item = ctk.CTkFrame(legend, fg_color="transparent")
+            item.grid(row=0, column=echo_index, padx=(0, 10), sticky="w")
+            ctk.CTkLabel(
+                item,
+                text="●",
+                text_color=color,
+                width=14,
+                font=ctk.CTkFont(size=16, weight="bold"),
+            ).grid(row=0, column=0, sticky="w")
+            ctk.CTkLabel(item, text=label, width=24, anchor="w").grid(row=0, column=1, padx=(2, 0), sticky="w")
 
     def _stabilize_initial_geometry(self) -> None:
         """Ensure all control rows are visible right after opening the window."""


### PR DESCRIPTION
### Motivation
- The previous echo column headings used colored emoji characters which are fragile and inconsistent across platforms and fonts. 
- The UI needs an explicit, reliable mapping between echo labels (`E1`–`E5`) and the overlay colors defined in `ECHO_OVERLAY_COLORS` so the legend and overlays remain consistent.

### Description
- Replaced `ECHO_HEADING_MARKERS` emoji constant with `ECHO_HEADING_LABELS = ("E1","E2","E3","E4","E5")` and updated heading assignments for `"echo_1_m"` through `"echo_5_m"` to use these plain labels in `transceiver/mission_workflow_ui.py`.
- Added a `_build_echo_results_legend(self, parent: tk.Widget)` helper that renders a compact legend above the results table using `zip(ECHO_HEADING_LABELS, ECHO_OVERLAY_COLORS)` and `CTkLabel(text="●", text_color=color)` so colored dots are drawn explicitly.
- Adjusted results-table layout rows (`rowconfigure`, `grid` indices) to make space for the new legend and moved the results footer down accordingly.
- Added a static test `test_results_table_echo_headings_use_plain_labels_and_overlay_color_legend` to `tests/test_mission_workflow_ui.py` that asserts the new labels, verifies the legend mapping is present, and ensures the old emoji markers are absent.

### Testing
- Ran the new single test with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py::test_results_table_echo_headings_use_plain_labels_and_overlay_color_legend` and it passed (`1 passed`).
- Ran the full UI test module with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` and the suite passed (`125 passed`).
- Performed static verification with `rg` to confirm `ECHO_HEADING_MARKERS` and the emoji characters are no longer present in `transceiver/mission_workflow_ui.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f3aec5a0c8321a0a277c25ecaf2b3)