### PR TITLE
Rename mission workflow overlay labels

### DIFF
--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -792,7 +792,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         }
         tk.Checkbutton(
             frame,
-            text="Radarmesspunkte",
+            text="geschätzte Reflektorpositionen",
             variable=self.echo_heatmap_evaluation_visible_var,
             command=self._on_echo_heatmap_settings_changed,
             **checkbutton_kwargs,
@@ -806,7 +806,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         ).grid(row=2, column=0, columnspan=2, sticky="ew", padx=8, pady=(0, 0))
         tk.Checkbutton(
             frame,
-            text="LiDAR-Messpunkte",
+            text="LiDAR-Referenzpositionen",
             variable=self.echo_heatmap_lidar_points_visible_var,
             command=self._on_echo_heatmap_settings_changed,
             **checkbutton_kwargs,


### PR DESCRIPTION
### Motivation
- Update the overlay menu labels in the Mission Workflow map preview to clearer German terms for radar and LiDAR layers.

### Description
- Replace `text="Radarmesspunkte"` with `text="geschätzte Reflektorpositionen"` and `text="LiDAR-Messpunkte"` with `text="LiDAR-Referenzpositionen"` in `transceiver/mission_workflow_ui.py`.

### Testing
- Ran `python -m pytest tests/test_mission_workflow_ui.py` and all tests passed (`125 passed`).
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a560fd668648321a8902e440e1f38c2)