### PR TITLE
Aggregate all echoes in reflection heatmap

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -489,6 +489,57 @@ def test_draw_selected_echo_probability_overlay_draws_dot_cloud_without_grid_rec
     assert len(window.map_preview_canvas.ovals) == 3
 
 
+def test_draw_selected_echo_probability_overlay_aggregates_all_echo_distances() -> None:
+    class FakeCanvas:
+        def __init__(self) -> None:
+            self.ovals: list[tuple[tuple[float, ...], dict[str, object]]] = []
+
+        def create_oval(self, *coords: float, **kwargs: object) -> int:
+            self.ovals.append((coords, kwargs))
+            return len(self.ovals)
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission = SimpleNamespace(map_config=SimpleNamespace(resolution=1.0))
+    window._map_image_original = SimpleNamespace(height=lambda: 100)
+    window._records = []
+    window._mission_points = []
+    window.map_preview_canvas = FakeCanvas()
+    window.echo_heatmap_min_visible_overlap_var = SimpleNamespace(get=lambda: "1")
+    window.echo_heatmap_imaginary_line_width_var = SimpleNamespace(get=lambda: "5")
+    window._append_validation = lambda _message: None
+    records = [
+        {
+            "live_position_at_measurement": {"x": 0.0, "y": 0.0},
+            "measurement": {
+                "result": {
+                    "echo_delays": [
+                        {"distance_m": 1.0},
+                        {"distance_m": 2.0},
+                        {"distance_m": 3.0},
+                    ]
+                }
+            },
+        }
+    ]
+    used_distances: list[float] = []
+
+    def fake_preview_points(**kwargs: object) -> tuple[list[float] | None, int]:
+        echo_distance_m = float(kwargs["echo_distance_m"])
+        used_distances.append(echo_distance_m)
+        return ([10.0 * echo_distance_m, 10.0], 1)
+
+    window._build_echo_overlay_preview_points = fake_preview_points
+
+    drawn = window._draw_selected_echo_probability_overlay(
+        rx_position=(0.0, 0.0),
+        records=records,
+    )
+
+    assert drawn is True
+    assert used_distances == [1.0, 2.0, 3.0]
+    assert len(window.map_preview_canvas.ovals) == 3
+
+
 def test_draw_selected_echo_probability_overlay_scales_overlapping_point_radius() -> None:
     class FakeCanvas:
         def __init__(self) -> None:

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -3449,59 +3449,64 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             result = measurement.get("result")
             if not isinstance(result, dict):
                 continue
-            echo_distances = self._extract_echo_distances(result.get("echo_delays"), limit=1)
+            echo_delay_entries = result.get("echo_delays")
+            echo_distances = self._extract_echo_distances(
+                echo_delay_entries,
+                limit=len(echo_delay_entries) if isinstance(echo_delay_entries, list) else 0,
+            )
             if not echo_distances:
                 continue
-            preview_points, _line_width = self._build_echo_overlay_preview_points(
-                rx_position=rx_position,
-                measurement_position=measurement_position,
-                echo_distance_m=echo_distances[0],
-                sample_levels=MULTI_SELECTION_ECHO_DOT_SAMPLE_LEVELS,
-            )
-            if preview_points is None:
-                continue
-            candidate_count += 1
-            seen_cells_for_ellipse: set[tuple[int, int]] = set()
-            point_pairs = zip(preview_points[0::2], preview_points[1::2])
-            for px, py in point_pairs:
-                if not math.isfinite(px) or not math.isfinite(py):
+            for echo_distance in echo_distances:
+                preview_points, _line_width = self._build_echo_overlay_preview_points(
+                    rx_position=rx_position,
+                    measurement_position=measurement_position,
+                    echo_distance_m=echo_distance,
+                    sample_levels=MULTI_SELECTION_ECHO_DOT_SAMPLE_LEVELS,
+                )
+                if preview_points is None:
                     continue
-                if overlay_point is not None:
-                    world_point = self._preview_pixel_to_world(preview_x=px, preview_y=py)
-                    if world_point is None:
+                candidate_count += 1
+                seen_cells_for_ellipse: set[tuple[int, int]] = set()
+                point_pairs = zip(preview_points[0::2], preview_points[1::2])
+                for px, py in point_pairs:
+                    if not math.isfinite(px) or not math.isfinite(py):
                         continue
-                    if not self._is_world_point_inside_antenna_opening(
-                        origin=(overlay_point.x, overlay_point.y),
-                        yaw=overlay_point.yaw,
-                        target=world_point,
-                        half_angle_rad=opening_half_angle_rad,
-                    ):
+                    if overlay_point is not None:
+                        world_point = self._preview_pixel_to_world(preview_x=px, preview_y=py)
+                        if world_point is None:
+                            continue
+                        if not self._is_world_point_inside_antenna_opening(
+                            origin=(overlay_point.x, overlay_point.y),
+                            yaw=overlay_point.yaw,
+                            target=world_point,
+                            half_angle_rad=opening_half_angle_rad,
+                        ):
+                            continue
+                    cell = (
+                        int(round(px / imaginary_line_width_px)),
+                        int(round(py / imaginary_line_width_px)),
+                    )
+                    if cell in seen_cells_for_ellipse:
                         continue
-                cell = (
-                    int(round(px / imaginary_line_width_px)),
-                    int(round(py / imaginary_line_width_px)),
-                )
-                if cell in seen_cells_for_ellipse:
-                    continue
-                seen_cells_for_ellipse.add(cell)
-                sampled_point_count += 1
-                bucket = ellipse_point_cells.setdefault(
-                    cell,
-                    {
-                        "x": 0.0,
-                        "y": 0.0,
-                        "samples": 0,
-                        "ellipses": set(),
-                        "positions": set(),
-                    },
-                )
-                bucket["x"] += float(px)
-                bucket["y"] += float(py)
-                bucket["samples"] += 1
-                bucket["ellipses"].add(candidate_count)
-                bucket["positions"].add(
-                    (float(measurement_position[0]), float(measurement_position[1]))
-                )
+                    seen_cells_for_ellipse.add(cell)
+                    sampled_point_count += 1
+                    bucket = ellipse_point_cells.setdefault(
+                        cell,
+                        {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "samples": 0,
+                            "ellipses": set(),
+                            "positions": set(),
+                        },
+                    )
+                    bucket["x"] += float(px)
+                    bucket["y"] += float(py)
+                    bucket["samples"] += 1
+                    bucket["ellipses"].add(candidate_count)
+                    bucket["positions"].add(
+                        (float(measurement_position[0]), float(measurement_position[1]))
+                    )
         if not ellipse_point_cells:
             return False
         drawn_points = 0


### PR DESCRIPTION
### Motivation
- Improve accuracy of the selected-record reflection/echo probability aggregation by sampling every valid echo delay from a measurement instead of only the first (`echo1`).

### Description
- In `MissionWorkflowWindow._draw_selected_echo_probability_overlay` replace single-echo sampling with iterating over all extracted echo distances and sample each echo arc independently while preserving per-ellipse de-duplication. 
- Compute `echo_delay_entries` and pass `limit=len(echo_delay_entries)` into `self._extract_echo_distances` to ensure all available echoes are considered. 
- Keep `candidate_count` and per-ellipse `seen_cells_for_ellipse` logic, but increment candidate counts for each sampled echo arc. 
- Add a regression test `test_draw_selected_echo_probability_overlay_aggregates_all_echo_distances` in `tests/test_mission_workflow_ui.py` that verifies multiple echo distances (`1.0`, `2.0`, `3.0`) are all sampled and drawn.

### Testing
- Ran the echo-probability focused subset with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py -k 'echo_probability_overlay'` which passed (`7 passed, 119 deselected`).
- Ran the full UI test module with `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` which passed (`126 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a564e2516d483219deb1fc3b4e83922)