### PR TITLE
Add echo count selector for heatmap aggregation

### DIFF
--- a/tests/test_mission_workflow_ui.py
+++ b/tests/test_mission_workflow_ui.py
@@ -540,6 +540,55 @@ def test_draw_selected_echo_probability_overlay_aggregates_all_echo_distances() 
     assert len(window.map_preview_canvas.ovals) == 3
 
 
+def test_draw_selected_echo_probability_overlay_uses_configured_echo_count() -> None:
+    class FakeCanvas:
+        def __init__(self) -> None:
+            self.ovals: list[tuple[tuple[float, ...], dict[str, object]]] = []
+
+        def create_oval(self, *coords: float, **kwargs: object) -> int:
+            self.ovals.append((coords, kwargs))
+            return len(self.ovals)
+
+    window = MissionWorkflowWindow.__new__(MissionWorkflowWindow)
+    window._mission = SimpleNamespace(map_config=SimpleNamespace(resolution=1.0))
+    window._map_image_original = SimpleNamespace(height=lambda: 100)
+    window.map_preview_canvas = FakeCanvas()
+    window.echo_heatmap_min_visible_overlap_var = SimpleNamespace(get=lambda: "1")
+    window.echo_heatmap_imaginary_line_width_var = SimpleNamespace(get=lambda: "5")
+    window.echo_heatmap_aggregated_echo_count_var = SimpleNamespace(get=lambda: "2")
+    window._append_validation = lambda _message: None
+    records = [
+        {
+            "live_position_at_measurement": {"x": 0.0, "y": 0.0},
+            "measurement": {
+                "result": {
+                    "echo_delays": [
+                        {"distance_m": 1.0},
+                        {"distance_m": 2.0},
+                        {"distance_m": 3.0},
+                    ]
+                }
+            },
+        }
+    ]
+    used_distances: list[float] = []
+
+    def fake_preview_points(**kwargs: object) -> tuple[list[float] | None, int]:
+        echo_distance_m = float(kwargs["echo_distance_m"])
+        used_distances.append(echo_distance_m)
+        return ([10.0 * echo_distance_m, 10.0], 1)
+
+    window._build_echo_overlay_preview_points = fake_preview_points
+
+    drawn = window._draw_selected_echo_probability_overlay(
+        rx_position=(0.0, 0.0),
+        records=records,
+    )
+
+    assert drawn is True
+    assert used_distances == [1.0, 2.0]
+    assert len(window.map_preview_canvas.ovals) == 2
+
 def test_draw_selected_echo_probability_overlay_scales_overlapping_point_radius() -> None:
     class FakeCanvas:
         def __init__(self) -> None:
@@ -673,6 +722,7 @@ def test_workflow_state_payload_persists_echo_heatmap_settings() -> None:
     window.live_preview_enabled_var = SimpleNamespace(get=lambda: False)
     window.echo_heatmap_imaginary_line_width_var = SimpleNamespace(get=lambda: "6.5")
     window.echo_heatmap_min_visible_overlap_var = SimpleNamespace(get=lambda: "7")
+    window.echo_heatmap_aggregated_echo_count_var = SimpleNamespace(get=lambda: "3")
     window.echo_heatmap_evaluation_visible_var = SimpleNamespace(get=lambda: False)
     window.echo_heatmap_ellipses_visible_var = SimpleNamespace(get=lambda: True)
     window.echo_heatmap_lidar_points_visible_var = SimpleNamespace(get=lambda: False)
@@ -685,6 +735,7 @@ def test_workflow_state_payload_persists_echo_heatmap_settings() -> None:
 
     assert payload["echo_heatmap_imaginary_line_width_cm"] == 6.5
     assert payload["echo_heatmap_min_visible_overlap"] == 7
+    assert payload["echo_heatmap_aggregated_echo_count"] == 3
     assert payload["echo_heatmap_evaluation_visible"] is False
     assert payload["echo_heatmap_ellipses_visible"] is True
     assert payload["echo_heatmap_lidar_points_visible"] is False

--- a/transceiver/mission_workflow_ui.py
+++ b/transceiver/mission_workflow_ui.py
@@ -84,6 +84,7 @@ MULTI_SELECTION_ECHO_DOT_OUTLIER_COLOR = "#9E9E9E"
 RADAR_OUTLIER_BAND_WIDTH_CM = 20.0
 MULTI_SELECTION_ECHO_DOT_SAMPLE_LEVELS = (96, 160, 240)
 MULTI_SELECTION_ECHO_DOT_MIN_VISIBLE_OVERLAP = 5
+MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS = 5
 MULTI_SELECTION_ECHO_DOT_ANTENNA_OPENING_ANGLE_DEG = 360.0
 MULTI_SELECTION_PROBABILITY_DEBUG_LOG = True
 RESULTS_TABLE_EMPTY_ROW_IID = "__results_table_empty_row__"
@@ -632,6 +633,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.echo_heatmap_min_visible_overlap_var = tk.StringVar(
             value=str(MULTI_SELECTION_ECHO_DOT_MIN_VISIBLE_OVERLAP)
         )
+        self.echo_heatmap_aggregated_echo_count_var = tk.StringVar(
+            value=str(MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS)
+        )
         self.echo_heatmap_antenna_opening_angle_deg_var = tk.StringVar(
             value=f"{MULTI_SELECTION_ECHO_DOT_ANTENNA_OPENING_ANGLE_DEG:g}"
         )
@@ -680,6 +684,19 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             value,
             default=MULTI_SELECTION_ECHO_DOT_MIN_VISIBLE_OVERLAP,
         )
+
+    def _echo_heatmap_aggregated_echo_count(self) -> int:
+        variable = getattr(self, "echo_heatmap_aggregated_echo_count_var", None)
+        value = (
+            variable.get()
+            if variable is not None
+            else MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS
+        )
+        parsed = _parse_positive_int(
+            value,
+            default=MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS,
+        )
+        return min(MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS, max(1, parsed))
 
     def _on_echo_heatmap_settings_changed(self) -> None:
         if getattr(self, "_is_restoring_workflow_state", False):
@@ -977,6 +994,9 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
         self.echo_heatmap_min_visible_overlap_var.trace_add(
             "write", lambda *_args: self._on_echo_heatmap_settings_changed()
         )
+        self.echo_heatmap_aggregated_echo_count_var.trace_add(
+            "write", lambda *_args: self._on_echo_heatmap_settings_changed()
+        )
         self.echo_heatmap_antenna_opening_angle_deg_var.trace_add(
             "write", lambda *_args: self._on_echo_heatmap_settings_changed()
         )
@@ -1122,14 +1142,24 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             validate="key",
             validatecommand=(self.register(self._validate_positive_integer_input), "%P"),
         ).grid(row=1, column=7, padx=(0, 6), pady=(6, 0), sticky="w")
+        ctk.CTkLabel(rx_position_controls, text="Anzahl Echos").grid(
+            row=1, column=8, padx=(6, 4), pady=(6, 0), sticky="w"
+        )
+        ctk.CTkOptionMenu(
+            rx_position_controls,
+            values=[str(value) for value in range(1, MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS + 1)],
+            variable=self.echo_heatmap_aggregated_echo_count_var,
+            width=80,
+            command=lambda _value: self._on_echo_heatmap_settings_changed(),
+        ).grid(row=1, column=9, padx=(0, 6), pady=(6, 0), sticky="w")
         ctk.CTkCheckBox(
             rx_position_controls,
             text="Ausreißer entfernen",
             variable=self.radar_outlier_removal_enabled_var,
             command=self._on_echo_heatmap_settings_changed,
-        ).grid(row=1, column=8, padx=(6, 4), pady=(6, 0), sticky="w")
+        ).grid(row=1, column=10, padx=(6, 4), pady=(6, 0), sticky="w")
         ctk.CTkLabel(rx_position_controls, text="Breite cm").grid(
-            row=1, column=9, padx=(0, 4), pady=(6, 0), sticky="w"
+            row=1, column=11, padx=(0, 4), pady=(6, 0), sticky="w"
         )
         ctk.CTkEntry(
             rx_position_controls,
@@ -1137,7 +1167,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             width=80,
             validate="key",
             validatecommand=(self.register(self._validate_positive_float_input), "%P"),
-        ).grid(row=1, column=10, padx=(0, 6), pady=(6, 0), sticky="w")
+        ).grid(row=1, column=12, padx=(0, 6), pady=(6, 0), sticky="w")
 
         side_panel = ctk.CTkFrame(map_controls_row)
         side_panel.grid(row=0, column=1, sticky="nsew", padx=(6, 0))
@@ -2382,6 +2412,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             getattr(self, "_lidar_measurement_area_drag_current_world", None),
             self._echo_heatmap_imaginary_line_width_cm(),
             self._echo_heatmap_min_visible_overlap(),
+            self._echo_heatmap_aggregated_echo_count(),
             self._echo_heatmap_evaluation_visible(),
             self._echo_heatmap_ellipses_visible(),
             self._echo_heatmap_lidar_points_visible(),
@@ -3452,7 +3483,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             echo_delay_entries = result.get("echo_delays")
             echo_distances = self._extract_echo_distances(
                 echo_delay_entries,
-                limit=len(echo_delay_entries) if isinstance(echo_delay_entries, list) else 0,
+                limit=self._echo_heatmap_aggregated_echo_count(),
             )
             if not echo_distances:
                 continue
@@ -4896,6 +4927,7 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
             "live_preview_enabled": bool(self.live_preview_enabled_var.get()),
             "echo_heatmap_imaginary_line_width_cm": self._echo_heatmap_imaginary_line_width_cm(),
             "echo_heatmap_min_visible_overlap": self._echo_heatmap_min_visible_overlap(),
+            "echo_heatmap_aggregated_echo_count": self._echo_heatmap_aggregated_echo_count(),
             "echo_heatmap_antenna_opening_angle_deg": self._echo_heatmap_antenna_opening_angle_deg(),
             "echo_heatmap_evaluation_visible": self._echo_heatmap_evaluation_visible(),
             "echo_heatmap_ellipses_visible": self._echo_heatmap_ellipses_visible(),
@@ -5011,6 +5043,17 @@ class MissionWorkflowWindow(ctk.CTkToplevel):
                     _parse_positive_int(
                         payload.get("echo_heatmap_min_visible_overlap"),
                         default=MULTI_SELECTION_ECHO_DOT_MIN_VISIBLE_OVERLAP,
+                    )
+                )
+            )
+            self.echo_heatmap_aggregated_echo_count_var.set(
+                str(
+                    min(
+                        MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS,
+                        _parse_positive_int(
+                            payload.get("echo_heatmap_aggregated_echo_count"),
+                            default=MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS,
+                        ),
                     )
                 )
             )


### PR DESCRIPTION
### Motivation
- Provide a UI control to choose how many echoes are considered for the aggregated echo heatmap instead of always using all available echoes. 
- Keep backward-compatible default behavior while allowing users to limit aggregation to 1–5 echoes. 
- Ensure the new setting is persisted and included in map redraw/signature so changes take effect immediately.

### Description
- Add `MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS = 5` and a `StringVar` `echo_heatmap_aggregated_echo_count_var` with a default of `5` in `mission_workflow_ui.py`. 
- Add `_echo_heatmap_aggregated_echo_count()` helper with clamping to `1..MULTI_SELECTION_ECHO_DOT_MAX_AGGREGATED_ECHOS` and hook its trace to `_on_echo_heatmap_settings_changed`. 
- Insert an `Anzahl Echos` dropdown (`CTkOptionMenu`) next to `Min. Überlappung` populated with values `1..5`, and wire it to trigger redraw/persistence. 
- Limit aggregation by passing `limit=self._echo_heatmap_aggregated_echo_count()` into `_extract_echo_distances()` so the probability-overlay only uses the configured number of echoes. 
- Persist and restore the new `echo_heatmap_aggregated_echo_count` field in the workflow state payload and include it in the static map layer signature. 
- Add unit tests to `tests/test_mission_workflow_ui.py` that verify the configured echo count is used and that the workflow payload persists the setting.

### Testing
- Ran `python -m py_compile transceiver/mission_workflow_ui.py` to validate syntax and the file compiled successfully. 
- Executed targeted tests `PYTHONPATH=. pytest -q tests/test_mission_workflow_ui.py` and then the full test suite; all tests passed (`127 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5654b0caec83219a4708d52311815a)